### PR TITLE
Increase the test coverage of the Solution.

### DIFF
--- a/test/Deveel.Messaging.Connector.Abstractions.XUnit/Unit/ClientCredentialsAuthenticationProviderTests.cs
+++ b/test/Deveel.Messaging.Connector.Abstractions.XUnit/Unit/ClientCredentialsAuthenticationProviderTests.cs
@@ -1,0 +1,404 @@
+//
+// Copyright (c) Antonello Provenzano and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+//
+
+using Xunit;
+
+namespace Deveel.Messaging
+{
+    /// <summary>
+    /// Additional tests for <see cref="ClientCredentialsAuthenticationProvider"/>
+    /// covering error paths and refresh flows.
+    /// </summary>
+    [Trait("Category", "Unit")]
+    [Trait("Layer", "Application")]
+    [Trait("Feature", "ClientCredentialsAuthentication")]
+    public class ClientCredentialsAuthenticationProviderTests
+    {
+        private static ConnectionSettings BuildFullSettings(
+            string clientId = "client-id",
+            string clientSecret = "client-secret",
+            string tokenEndpoint = "https://oauth.example.com/token",
+            string? scope = null)
+        {
+            var settings = new ConnectionSettings()
+                .SetParameter("ClientId", clientId)
+                .SetParameter("ClientSecret", clientSecret)
+                .SetParameter("TokenEndpoint", tokenEndpoint);
+
+            if (scope != null)
+                settings = settings.SetParameter("Scope", scope);
+
+            return settings;
+        }
+
+        private static MockHttpMessageHandler CreateHandler(int statusCode, string responseBody)
+        {
+            var handler = new MockHttpMessageHandler();
+            handler.SetupResponse(statusCode, responseBody);
+            return handler;
+        }
+
+        #region ObtainCredentialAsync
+
+        [Fact]
+        public async Task Should_ReturnFailure_When_TokenRequestReturnsNonSuccessStatus()
+        {
+            // Arrange
+            var cancellationToken = TestContext.Current.CancellationToken;
+            var handler = CreateHandler(401, @"{""error"":""invalid_client""}");
+            var provider = new ClientCredentialsAuthenticationProvider(new HttpClient(handler));
+            var settings = BuildFullSettings();
+
+            // Act
+            var result = await provider.ObtainCredentialAsync(settings, cancellationToken);
+
+            // Assert
+            Assert.False(result.IsSuccessful);
+            Assert.Equal("TOKEN_REQUEST_FAILED", result.ErrorCode);
+        }
+
+        [Fact]
+        public async Task Should_ReturnFailure_When_ResponseMissingAccessToken()
+        {
+            // Arrange
+            var cancellationToken = TestContext.Current.CancellationToken;
+            var handler = CreateHandler(200, @"{""token_type"":""Bearer""}");
+            var provider = new ClientCredentialsAuthenticationProvider(new HttpClient(handler));
+            var settings = BuildFullSettings();
+
+            // Act
+            var result = await provider.ObtainCredentialAsync(settings, cancellationToken);
+
+            // Assert
+            Assert.False(result.IsSuccessful);
+            Assert.Equal("INVALID_TOKEN_RESPONSE", result.ErrorCode);
+        }
+
+        [Fact]
+        public async Task Should_ReturnFailure_When_AccessTokenIsEmpty()
+        {
+            // Arrange
+            var cancellationToken = TestContext.Current.CancellationToken;
+            var handler = CreateHandler(200, @"{""access_token"":""""}");
+            var provider = new ClientCredentialsAuthenticationProvider(new HttpClient(handler));
+            var settings = BuildFullSettings();
+
+            // Act
+            var result = await provider.ObtainCredentialAsync(settings, cancellationToken);
+
+            // Assert
+            Assert.False(result.IsSuccessful);
+            Assert.Equal("EMPTY_ACCESS_TOKEN", result.ErrorCode);
+        }
+
+        [Fact]
+        public async Task Should_ReturnSuccess_When_ResponseIncludesScope()
+        {
+            // Arrange
+            var cancellationToken = TestContext.Current.CancellationToken;
+            var handler = CreateHandler(200, @"{
+                ""access_token"": ""scoped-token"",
+                ""token_type"": ""Bearer"",
+                ""expires_in"": 3600,
+                ""scope"": ""read write""
+            }");
+            var provider = new ClientCredentialsAuthenticationProvider(new HttpClient(handler));
+            var settings = BuildFullSettings(scope: "read write");
+
+            // Act
+            var result = await provider.ObtainCredentialAsync(settings, cancellationToken);
+
+            // Assert
+            Assert.True(result.IsSuccessful);
+            Assert.Equal("read write", result.Credential!.Properties["Scope"]);
+        }
+
+        [Fact]
+        public async Task Should_ReturnSuccess_When_ResponseIncludesRefreshToken()
+        {
+            // Arrange
+            var cancellationToken = TestContext.Current.CancellationToken;
+            var handler = CreateHandler(200, @"{
+                ""access_token"": ""access-token-123"",
+                ""token_type"": ""Bearer"",
+                ""expires_in"": 3600,
+                ""refresh_token"": ""refresh-token-456""
+            }");
+            var provider = new ClientCredentialsAuthenticationProvider(new HttpClient(handler));
+            var settings = BuildFullSettings();
+
+            // Act
+            var result = await provider.ObtainCredentialAsync(settings, cancellationToken);
+
+            // Assert
+            Assert.True(result.IsSuccessful);
+            Assert.Equal("refresh-token-456", result.Credential!.Properties["RefreshToken"]);
+        }
+
+        [Fact]
+        public async Task Should_UseDefaultTokenType_When_ResponseMissingTokenType()
+        {
+            // Arrange
+            var cancellationToken = TestContext.Current.CancellationToken;
+            var handler = CreateHandler(200, @"{""access_token"":""token-no-type""}");
+            var provider = new ClientCredentialsAuthenticationProvider(new HttpClient(handler));
+            var settings = BuildFullSettings();
+
+            // Act
+            var result = await provider.ObtainCredentialAsync(settings, cancellationToken);
+
+            // Assert
+            Assert.True(result.IsSuccessful);
+            Assert.Equal("Bearer", result.Credential!.Properties["TokenType"]);
+        }
+
+        [Fact]
+        public async Task Should_ReturnNullExpiresAt_When_ResponseMissingExpiresIn()
+        {
+            // Arrange
+            var cancellationToken = TestContext.Current.CancellationToken;
+            var handler = CreateHandler(200, @"{""access_token"":""token-no-expiry"",""token_type"":""Bearer""}");
+            var provider = new ClientCredentialsAuthenticationProvider(new HttpClient(handler));
+            var settings = BuildFullSettings();
+
+            // Act
+            var result = await provider.ObtainCredentialAsync(settings, cancellationToken);
+
+            // Assert
+            Assert.True(result.IsSuccessful);
+            Assert.Null(result.Credential!.ExpiresAt);
+        }
+
+        [Fact]
+        public async Task Should_ReturnFailure_When_NetworkErrorOccurs()
+        {
+            // Arrange
+            var cancellationToken = TestContext.Current.CancellationToken;
+            var handler = new FailingHttpMessageHandler(new HttpRequestException("Connection refused"));
+            var provider = new ClientCredentialsAuthenticationProvider(new HttpClient(handler));
+            var settings = BuildFullSettings();
+
+            // Act
+            var result = await provider.ObtainCredentialAsync(settings, cancellationToken);
+
+            // Assert
+            Assert.False(result.IsSuccessful);
+            Assert.Equal("NETWORK_ERROR", result.ErrorCode);
+        }
+
+        [Fact]
+        public async Task Should_ReturnFailure_When_InvalidJsonResponse()
+        {
+            // Arrange
+            var cancellationToken = TestContext.Current.CancellationToken;
+            var handler = CreateHandler(200, "not-valid-json{{{");
+            var provider = new ClientCredentialsAuthenticationProvider(new HttpClient(handler));
+            var settings = BuildFullSettings();
+
+            // Act
+            var result = await provider.ObtainCredentialAsync(settings, cancellationToken);
+
+            // Assert
+            Assert.False(result.IsSuccessful);
+            Assert.Equal("INVALID_JSON", result.ErrorCode);
+        }
+
+        #endregion
+
+        #region RefreshCredentialAsync
+
+        [Fact]
+        public async Task Should_ObtainNewToken_When_RefreshCredentialAsyncNoRefreshToken()
+        {
+            // Arrange
+            var cancellationToken = TestContext.Current.CancellationToken;
+            var handler = CreateHandler(200, @"{""access_token"":""refreshed-token"",""token_type"":""Bearer""}");
+            var provider = new ClientCredentialsAuthenticationProvider(new HttpClient(handler));
+            var settings = BuildFullSettings();
+            var existingCredential = AuthenticationCredential.CreateToken("old-token", null, "Bearer");
+
+            // Act
+            var result = await provider.RefreshCredentialAsync(existingCredential, settings, cancellationToken);
+
+            // Assert
+            Assert.True(result.IsSuccessful);
+            Assert.Equal("refreshed-token", result.Credential!.CredentialValue);
+        }
+
+        [Fact]
+        public async Task Should_UseRefreshTokenFlow_When_CredentialHasRefreshToken()
+        {
+            // Arrange
+            var cancellationToken = TestContext.Current.CancellationToken;
+            var handler = CreateHandler(200, @"{
+                ""access_token"": ""refreshed-access"",
+                ""token_type"": ""Bearer"",
+                ""expires_in"": 1800
+            }");
+            var provider = new ClientCredentialsAuthenticationProvider(new HttpClient(handler));
+            var settings = BuildFullSettings();
+            var existingCredential = AuthenticationCredential.CreateToken("old-token", null, "Bearer");
+            existingCredential.Properties["RefreshToken"] = "existing-refresh-token";
+
+            // Act
+            var result = await provider.RefreshCredentialAsync(existingCredential, settings, cancellationToken);
+
+            // Assert
+            Assert.True(result.IsSuccessful);
+            Assert.Equal("refreshed-access", result.Credential!.CredentialValue);
+            // Should preserve old refresh token when not provided in response
+            Assert.Equal("existing-refresh-token", result.Credential.Properties["RefreshToken"]);
+        }
+
+        [Fact]
+        public async Task Should_UpdateRefreshToken_When_NewRefreshTokenInRefreshResponse()
+        {
+            // Arrange
+            var cancellationToken = TestContext.Current.CancellationToken;
+            var handler = CreateHandler(200, @"{
+                ""access_token"": ""new-access"",
+                ""token_type"": ""Bearer"",
+                ""refresh_token"": ""new-refresh-token""
+            }");
+            var provider = new ClientCredentialsAuthenticationProvider(new HttpClient(handler));
+            var settings = BuildFullSettings();
+            var existingCredential = AuthenticationCredential.CreateToken("old-token", null, "Bearer");
+            existingCredential.Properties["RefreshToken"] = "old-refresh-token";
+
+            // Act
+            var result = await provider.RefreshCredentialAsync(existingCredential, settings, cancellationToken);
+
+            // Assert
+            Assert.True(result.IsSuccessful);
+            Assert.Equal("new-refresh-token", result.Credential!.Properties["RefreshToken"]);
+        }
+
+        [Fact]
+        public async Task Should_ReturnFailure_When_RefreshResponseMissingAccessToken()
+        {
+            // Arrange
+            var cancellationToken = TestContext.Current.CancellationToken;
+            var handler = CreateHandler(200, @"{""token_type"":""Bearer""}");
+            var provider = new ClientCredentialsAuthenticationProvider(new HttpClient(handler));
+            var settings = BuildFullSettings();
+            var existingCredential = AuthenticationCredential.CreateToken("old-token", null, "Bearer");
+            existingCredential.Properties["RefreshToken"] = "existing-refresh-token";
+
+            // Act
+            var result = await provider.RefreshCredentialAsync(existingCredential, settings, cancellationToken);
+
+            // Assert
+            Assert.False(result.IsSuccessful);
+            Assert.Equal("INVALID_REFRESH_RESPONSE", result.ErrorCode);
+        }
+
+        [Fact]
+        public async Task Should_ReturnFailure_When_RefreshResponseEmptyAccessToken()
+        {
+            // Arrange
+            var cancellationToken = TestContext.Current.CancellationToken;
+            var handler = CreateHandler(200, @"{""access_token"":""""}");
+            var provider = new ClientCredentialsAuthenticationProvider(new HttpClient(handler));
+            var settings = BuildFullSettings();
+            var existingCredential = AuthenticationCredential.CreateToken("old-token", null, "Bearer");
+            existingCredential.Properties["RefreshToken"] = "existing-refresh-token";
+
+            // Act
+            var result = await provider.RefreshCredentialAsync(existingCredential, settings, cancellationToken);
+
+            // Assert
+            Assert.False(result.IsSuccessful);
+            Assert.Equal("EMPTY_REFRESH_TOKEN", result.ErrorCode);
+        }
+
+        [Fact]
+        public async Task Should_FallbackToObtainCredential_When_RefreshTokenRequestFails()
+        {
+            // Arrange
+            var cancellationToken = TestContext.Current.CancellationToken;
+            // First response (refresh attempt) = failure; second = success (fallback to obtain)
+            var handler = new SequentialHttpMessageHandler(new[]
+            {
+                (401, @"{""error"":""invalid_refresh_token""}"),
+                (200, @"{""access_token"":""fallback-token"",""token_type"":""Bearer""}")
+            });
+            var provider = new ClientCredentialsAuthenticationProvider(new HttpClient(handler));
+            var settings = BuildFullSettings();
+            var existingCredential = AuthenticationCredential.CreateToken("old-token", null, "Bearer");
+            existingCredential.Properties["RefreshToken"] = "bad-refresh-token";
+
+            // Act
+            var result = await provider.RefreshCredentialAsync(existingCredential, settings, cancellationToken);
+
+            // Assert
+            Assert.True(result.IsSuccessful);
+            Assert.Equal("fallback-token", result.Credential!.CredentialValue);
+        }
+
+        #endregion
+
+        #region Dispose
+
+        [Fact]
+        public void Should_NotThrow_When_Disposed()
+        {
+            // Arrange
+            var handler = new MockHttpMessageHandler();
+            var provider = new ClientCredentialsAuthenticationProvider(new HttpClient(handler));
+
+            // Act & Assert
+            var ex = Record.Exception(() => provider.Dispose());
+            Assert.Null(ex);
+        }
+
+        #endregion
+    }
+
+    /// <summary>
+    /// HTTP message handler that always throws an exception.
+    /// </summary>
+    internal sealed class FailingHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Exception _exception;
+
+        public FailingHttpMessageHandler(Exception exception)
+        {
+            _exception = exception;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            throw _exception;
+        }
+    }
+
+    /// <summary>
+    /// HTTP message handler that returns responses in sequence.
+    /// </summary>
+    internal sealed class SequentialHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly (int StatusCode, string Content)[] _responses;
+        private int _index;
+
+        public SequentialHttpMessageHandler((int StatusCode, string Content)[] responses)
+        {
+            _responses = responses;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (_index >= _responses.Length)
+                throw new InvalidOperationException("No more responses configured.");
+
+            var (statusCode, content) = _responses[_index++];
+            var response = new HttpResponseMessage((System.Net.HttpStatusCode)statusCode)
+            {
+                Content = new StringContent(content)
+            };
+            return Task.FromResult(response);
+        }
+    }
+}
+

--- a/test/Deveel.Messaging.Connector.Abstractions.XUnit/Unit/MessageValidationErrorTests.cs
+++ b/test/Deveel.Messaging.Connector.Abstractions.XUnit/Unit/MessageValidationErrorTests.cs
@@ -1,0 +1,139 @@
+//
+// Copyright (c) Antonello Provenzano and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+//
+
+using System.ComponentModel.DataAnnotations;
+using Xunit;
+
+namespace Deveel.Messaging
+{
+    /// <summary>
+    /// Unit tests for <see cref="MessageValidationError"/> struct.
+    /// </summary>
+    [Trait("Category", "Unit")]
+    [Trait("Layer", "Domain")]
+    [Trait("Feature", "MessageValidationError")]
+    public class MessageValidationErrorTests
+    {
+        private static IReadOnlyList<ValidationResult> SampleResults(int count = 1) =>
+            Enumerable.Range(1, count)
+                .Select(i => new ValidationResult($"Error {i}", new[] { $"Field{i}" }))
+                .ToList();
+
+        #region Constructor(string, string?, IReadOnlyList<ValidationResult>)
+
+        [Fact]
+        public void Should_SetAllProperties_When_ConstructedWithCodeMessageAndResults()
+        {
+            // Arrange
+            const string errorCode = "ERR_VALIDATION";
+            const string errorMessage = "Validation failed badly";
+            var results = SampleResults(2);
+
+            // Act
+            var error = new MessageValidationError(errorCode, errorMessage, results);
+
+            // Assert
+            Assert.Equal(errorCode, error.ErrorCode);
+            Assert.Equal(errorMessage, error.ErrorMessage);
+            Assert.Equal(2, error.ValidationResults.Count);
+        }
+
+        [Fact]
+        public void Should_AllowNullErrorMessage_When_ConstructedWithNullMessage()
+        {
+            // Arrange
+            const string errorCode = "ERR_VALIDATION_NULL";
+            var results = SampleResults();
+
+            // Act
+            var error = new MessageValidationError(errorCode, null, results);
+
+            // Assert
+            Assert.Equal(errorCode, error.ErrorCode);
+            Assert.Null(error.ErrorMessage);
+            Assert.NotNull(error.ValidationResults);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void Should_ThrowArgumentNullException_When_ErrorCodeIsNullOrWhitespace(string? errorCode)
+        {
+            // Arrange
+            var results = SampleResults();
+
+            // Act & Assert
+            // ArgumentNullException.ThrowIfNullOrWhiteSpace → ArgumentNullException for null,
+            // ArgumentException for empty/whitespace (both extend ArgumentException)
+            Assert.ThrowsAny<ArgumentException>(() =>
+                new MessageValidationError(errorCode!, "message", results));
+        }
+
+        [Fact]
+        public void Should_ThrowArgumentNullException_When_ValidationResultsIsNull()
+        {
+            // Arrange
+            // Act & Assert
+            Assert.Throws<ArgumentNullException>(() =>
+                new MessageValidationError("ERR", "message", null!));
+        }
+
+        #endregion
+
+        #region Constructor(string, IReadOnlyList<ValidationResult>)
+
+        [Fact]
+        public void Should_SetNullErrorMessage_When_ConstructedWithCodeAndResults()
+        {
+            // Arrange
+            const string errorCode = "ERR_SHORT";
+            var results = SampleResults(3);
+
+            // Act
+            var error = new MessageValidationError(errorCode, results);
+
+            // Assert
+            Assert.Equal(errorCode, error.ErrorCode);
+            Assert.Null(error.ErrorMessage);
+            Assert.Equal(3, error.ValidationResults.Count);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void Should_ThrowArgumentNullException_When_ErrorCodeIsNullOrWhitespace_TwoParam(string? errorCode)
+        {
+            // Arrange
+            var results = SampleResults();
+
+            // Act & Assert
+            Assert.ThrowsAny<ArgumentException>(() =>
+                new MessageValidationError(errorCode!, results));
+        }
+
+        [Fact]
+        public void Should_ImplementIMessageValidationError_When_Created()
+        {
+            // Arrange
+            const string errorCode = "ERR_INTERFACE";
+            var results = SampleResults(1);
+
+            // Act
+            IMessageValidationError iface = new MessageValidationError(errorCode, "err msg", results);
+
+            // Assert
+            Assert.Equal(errorCode, iface.ErrorCode);
+            Assert.Equal("err msg", iface.ErrorMessage);
+            Assert.Single(iface.ValidationResults);
+        }
+
+        #endregion
+    }
+}
+
+
+

--- a/test/Deveel.Messaging.Connector.Abstractions.XUnit/Unit/MessageValidationErrorTests.cs
+++ b/test/Deveel.Messaging.Connector.Abstractions.XUnit/Unit/MessageValidationErrorTests.cs
@@ -60,7 +60,7 @@ namespace Deveel.Messaging
         [InlineData(null)]
         [InlineData("")]
         [InlineData("   ")]
-        public void Should_ThrowArgumentNullException_When_ErrorCodeIsNullOrWhitespace(string? errorCode)
+        public void Should_ThrowArgumentException_When_ErrorCodeIsNullOrWhitespace(string? errorCode)
         {
             // Arrange
             var results = SampleResults();
@@ -105,7 +105,7 @@ namespace Deveel.Messaging
         [InlineData(null)]
         [InlineData("")]
         [InlineData("   ")]
-        public void Should_ThrowArgumentNullException_When_ErrorCodeIsNullOrWhitespace_TwoParam(string? errorCode)
+        public void Should_ThrowArgumentException_When_ErrorCodeIsNullOrWhitespace_TwoParam(string? errorCode)
         {
             // Arrange
             var results = SampleResults();

--- a/test/Deveel.Messaging.Connector.Abstractions.XUnit/Unit/MessageValidationExceptionTests.cs
+++ b/test/Deveel.Messaging.Connector.Abstractions.XUnit/Unit/MessageValidationExceptionTests.cs
@@ -1,0 +1,113 @@
+//
+// Copyright (c) Antonello Provenzano and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+//
+
+using System.ComponentModel.DataAnnotations;
+using Xunit;
+
+namespace Deveel.Messaging
+{
+    /// <summary>
+    /// Unit tests for <see cref="MessageValidationException"/>.
+    /// </summary>
+    [Trait("Category", "Unit")]
+    [Trait("Layer", "Domain")]
+    [Trait("Feature", "MessageValidationException")]
+    public class MessageValidationExceptionTests
+    {
+        private static IReadOnlyList<ValidationResult> BuildValidationResults(int count = 1)
+        {
+            return Enumerable.Range(1, count)
+                .Select(i => new ValidationResult($"Validation error {i}", new[] { $"Field{i}" }))
+                .ToList();
+        }
+
+        #region Constructor(string errorCode, string? message, IReadOnlyList<ValidationResult> validationResults)
+
+        [Fact]
+        public void Should_SetAllProperties_When_ConstructedWithCodeMessageAndResults()
+        {
+            // Arrange
+            const string errorCode = "VALIDATION_001";
+            const string message = "Message validation failed";
+            var validationResults = BuildValidationResults(2);
+
+            // Act
+            var exception = new MessageValidationException(errorCode, message, validationResults);
+
+            // Assert
+            Assert.Equal(errorCode, exception.ErrorCode);
+            Assert.Equal(message, exception.Message);
+            Assert.Same(validationResults, exception.ValidationResults);
+            Assert.Equal(2, exception.ValidationResults.Count);
+        }
+
+        [Fact]
+        public void Should_AllowNullMessage_When_ConstructedWithNullMessage()
+        {
+            // Arrange
+            const string errorCode = "VALIDATION_002";
+            var validationResults = BuildValidationResults();
+
+            // Act
+            var exception = new MessageValidationException(errorCode, null, validationResults);
+
+            // Assert
+            Assert.Equal(errorCode, exception.ErrorCode);
+            Assert.NotNull(exception.ValidationResults);
+        }
+
+        [Fact]
+        public void Should_ImplementIMessageValidationError_When_Created()
+        {
+            // Arrange
+            const string errorCode = "VALIDATION_003";
+            var results = BuildValidationResults(3);
+
+            // Act
+            IMessageValidationError error = new MessageValidationException(errorCode, "error", results);
+
+            // Assert
+            Assert.Equal(errorCode, error.ErrorCode);
+            Assert.Equal(3, error.ValidationResults.Count);
+        }
+
+        #endregion
+
+        #region Constructor(string errorCode, IReadOnlyList<ValidationResult> validationResults)
+
+        [Fact]
+        public void Should_SetProperties_When_ConstructedWithCodeAndResults()
+        {
+            // Arrange
+            const string errorCode = "VALIDATION_004";
+            var validationResults = BuildValidationResults(1);
+
+            // Act
+            var exception = new MessageValidationException(errorCode, validationResults);
+
+            // Assert
+            Assert.Equal(errorCode, exception.ErrorCode);
+            Assert.Same(validationResults, exception.ValidationResults);
+            Assert.Single(exception.ValidationResults);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("  ")]
+        public void Should_ThrowArgumentNullException_When_ErrorCodeIsNullOrWhitespace(string? errorCode)
+        {
+            // Arrange
+            var results = BuildValidationResults();
+
+            // Act & Assert
+            Assert.ThrowsAny<ArgumentException>(() => new MessageValidationException(errorCode!, results));
+        }
+
+        #endregion
+    }
+}
+
+

--- a/test/Deveel.Messaging.Connector.Abstractions.XUnit/Unit/MessagingExceptionTests.cs
+++ b/test/Deveel.Messaging.Connector.Abstractions.XUnit/Unit/MessagingExceptionTests.cs
@@ -41,7 +41,7 @@ namespace Deveel.Messaging
             var exception = new MessagingException(errorCode);
 
             // Assert
-            Assert.Null(exception.Message == exception.Message ? null : exception.Message);
+            Assert.False(string.IsNullOrEmpty(exception.Message));
             Assert.Null(exception.InnerException);
         }
 

--- a/test/Deveel.Messaging.Connector.Abstractions.XUnit/Unit/MessagingExceptionTests.cs
+++ b/test/Deveel.Messaging.Connector.Abstractions.XUnit/Unit/MessagingExceptionTests.cs
@@ -49,7 +49,7 @@ namespace Deveel.Messaging
         [InlineData(null)]
         [InlineData("")]
         [InlineData("   ")]
-        public void Should_ThrowArgumentNullException_When_ErrorCodeIsNullOrWhitespace(string? errorCode)
+        public void Should_ThrowArgumentException_When_ErrorCodeIsNullOrWhitespace(string? errorCode)
         {
             // Arrange
             // Act & Assert
@@ -173,7 +173,6 @@ namespace Deveel.Messaging
         #endregion
     }
 }
-
 
 
 

--- a/test/Deveel.Messaging.Connector.Abstractions.XUnit/Unit/MessagingExceptionTests.cs
+++ b/test/Deveel.Messaging.Connector.Abstractions.XUnit/Unit/MessagingExceptionTests.cs
@@ -1,0 +1,179 @@
+//
+// Copyright (c) Antonello Provenzano and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+//
+
+using Xunit;
+
+namespace Deveel.Messaging
+{
+    /// <summary>
+    /// Unit tests for <see cref="MessagingException"/>.
+    /// </summary>
+    [Trait("Category", "Unit")]
+    [Trait("Layer", "Domain")]
+    [Trait("Feature", "MessagingException")]
+    public class MessagingExceptionTests
+    {
+        #region Constructor(string errorCode)
+
+        [Fact]
+        public void Should_SetErrorCode_When_ConstructedWithErrorCode()
+        {
+            // Arrange
+            const string errorCode = "ERR_001";
+
+            // Act
+            var exception = new MessagingException(errorCode);
+
+            // Assert
+            Assert.Equal(errorCode, exception.ErrorCode);
+            Assert.IsAssignableFrom<IMessagingError>(exception);
+        }
+
+        [Fact]
+        public void Should_HaveNullMessage_When_ConstructedWithErrorCodeOnly()
+        {
+            // Arrange
+            const string errorCode = "ERR_002";
+
+            // Act
+            var exception = new MessagingException(errorCode);
+
+            // Assert
+            Assert.Null(exception.Message == exception.Message ? null : exception.Message);
+            Assert.Null(exception.InnerException);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void Should_ThrowArgumentNullException_When_ErrorCodeIsNullOrWhitespace(string? errorCode)
+        {
+            // Arrange
+            // Act & Assert
+            // ArgumentNullException.ThrowIfNullOrWhiteSpace throws ArgumentNullException for null,
+            // ArgumentException for empty/whitespace — both derive from ArgumentException
+            Assert.ThrowsAny<ArgumentException>(() => new MessagingException(errorCode!));
+        }
+
+        #endregion
+
+        #region Constructor(string errorCode, string? message)
+
+        [Fact]
+        public void Should_SetErrorCodeAndMessage_When_ConstructedWithErrorCodeAndMessage()
+        {
+            // Arrange
+            const string errorCode = "ERR_003";
+            const string message = "Something went wrong";
+
+            // Act
+            var exception = new MessagingException(errorCode, message);
+
+            // Assert
+            Assert.Equal(errorCode, exception.ErrorCode);
+            Assert.Equal(message, exception.Message);
+            Assert.Null(exception.InnerException);
+        }
+
+        [Fact]
+        public void Should_AllowNullMessage_When_ConstructedWithNullMessage()
+        {
+            // Arrange
+            const string errorCode = "ERR_004";
+
+            // Act
+            var exception = new MessagingException(errorCode, null);
+
+            // Assert
+            Assert.Equal(errorCode, exception.ErrorCode);
+            Assert.Null(exception.InnerException);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void Should_ThrowArgumentNullException_When_ErrorCodeIsNullOrWhitespace_WithMessage(string? errorCode)
+        {
+            // Arrange
+            // Act & Assert
+            Assert.ThrowsAny<ArgumentException>(() => new MessagingException(errorCode!, "some message"));
+        }
+
+        #endregion
+
+        #region Constructor(string errorCode, string? message, Exception? innerException)
+
+        [Fact]
+        public void Should_SetAllProperties_When_ConstructedWithAllParameters()
+        {
+            // Arrange
+            const string errorCode = "ERR_005";
+            const string message = "Error with inner";
+            var inner = new InvalidOperationException("inner error");
+
+            // Act
+            var exception = new MessagingException(errorCode, message, inner);
+
+            // Assert
+            Assert.Equal(errorCode, exception.ErrorCode);
+            Assert.Equal(message, exception.Message);
+            Assert.Same(inner, exception.InnerException);
+        }
+
+        [Fact]
+        public void Should_AllowNullInnerException_When_ConstructedWithNullInner()
+        {
+            // Arrange
+            const string errorCode = "ERR_006";
+            const string message = "No inner exception";
+
+            // Act
+            var exception = new MessagingException(errorCode, message, null);
+
+            // Assert
+            Assert.Equal(errorCode, exception.ErrorCode);
+            Assert.Equal(message, exception.Message);
+            Assert.Null(exception.InnerException);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void Should_ThrowArgumentNullException_When_ErrorCodeIsNullOrWhitespace_WithInner(string? errorCode)
+        {
+            // Arrange
+            // Act & Assert
+            Assert.ThrowsAny<ArgumentException>(() => new MessagingException(errorCode!, "msg", null));
+        }
+
+        #endregion
+
+        #region IMessagingError
+
+        [Fact]
+        public void Should_ExposeErrorMessageViaInterface_When_MessagingExceptionCreated()
+        {
+            // Arrange
+            const string errorCode = "ERR_007";
+            const string message = "Interface message";
+
+            // Act
+            IMessagingError error = new MessagingException(errorCode, message);
+
+            // Assert
+            Assert.Equal(message, error.ErrorMessage);
+            Assert.Equal(errorCode, error.ErrorCode);
+        }
+
+        #endregion
+    }
+}
+
+
+
+

--- a/test/Deveel.Messaging.Connector.Abstractions.XUnit/Unit/MessagingExceptionTests.cs
+++ b/test/Deveel.Messaging.Connector.Abstractions.XUnit/Unit/MessagingExceptionTests.cs
@@ -96,7 +96,7 @@ namespace Deveel.Messaging
         [InlineData(null)]
         [InlineData("")]
         [InlineData("   ")]
-        public void Should_ThrowArgumentNullException_When_ErrorCodeIsNullOrWhitespace_WithMessage(string? errorCode)
+        public void Should_ThrowArgumentException_When_ErrorCodeIsNullOrWhitespace_WithMessage(string? errorCode)
         {
             // Arrange
             // Act & Assert
@@ -144,7 +144,7 @@ namespace Deveel.Messaging
         [InlineData(null)]
         [InlineData("")]
         [InlineData("   ")]
-        public void Should_ThrowArgumentNullException_When_ErrorCodeIsNullOrWhitespace_WithInner(string? errorCode)
+        public void Should_ThrowArgumentException_When_ErrorCodeIsNullOrWhitespace_WithInner(string? errorCode)
         {
             // Arrange
             // Act & Assert

--- a/test/Deveel.Messaging.Connector.Facebook.XUnit/Unit/FacebookMessengerSchemaFactoryTests.cs
+++ b/test/Deveel.Messaging.Connector.Facebook.XUnit/Unit/FacebookMessengerSchemaFactoryTests.cs
@@ -1,0 +1,50 @@
+//
+// Copyright (c) Antonello Provenzano and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+//
+
+namespace Deveel.Messaging;
+
+/// <summary>
+/// Unit tests verifying that <see cref="FacebookMessengerSchemaFactory"/> returns
+/// the expected default schema.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("Layer", "Infrastructure")]
+[Trait("Feature", "FacebookMessengerSchemaFactory")]
+public class FacebookMessengerSchemaFactoryTests
+{
+    [Fact]
+    public void Should_ReturnFacebookMessengerSchema_When_CreateSchemaIsCalled()
+    {
+        // Arrange
+        IChannelSchemaFactory factory = new FacebookMessengerSchemaFactory();
+
+        // Act
+        var schema = factory.CreateSchema();
+
+        // Assert
+        Assert.NotNull(schema);
+        Assert.Equal(FacebookConnectorConstants.Provider, schema.ChannelProvider);
+        Assert.Equal(FacebookConnectorConstants.MessengerChannel, schema.ChannelType);
+    }
+
+    [Fact]
+    public void Should_MatchStaticPropertyValues_When_CreateSchemaIsCalled()
+    {
+        // Arrange
+        IChannelSchemaFactory factory = new FacebookMessengerSchemaFactory();
+        var expected = FacebookChannelSchemas.FacebookMessenger;
+
+        // Act
+        var schema = factory.CreateSchema();
+
+        // Assert
+        Assert.Equal(expected.ChannelProvider, schema.ChannelProvider);
+        Assert.Equal(expected.ChannelType, schema.ChannelType);
+        Assert.Equal(expected.Version, schema.Version);
+        Assert.Equal(expected.DisplayName, schema.DisplayName);
+    }
+}
+
+

--- a/test/Deveel.Messaging.Connector.Firebase.XUnit/Unit/FirebasePushSchemaFactoryTests.cs
+++ b/test/Deveel.Messaging.Connector.Firebase.XUnit/Unit/FirebasePushSchemaFactoryTests.cs
@@ -1,0 +1,51 @@
+//
+// Copyright (c) Antonello Provenzano and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+//
+
+namespace Deveel.Messaging
+{
+    /// <summary>
+    /// Unit tests verifying that <see cref="FirebasePushSchemaFactory"/> returns
+    /// the expected default schema.
+    /// </summary>
+    [Trait("Category", "Unit")]
+    [Trait("Layer", "Infrastructure")]
+    [Trait("Feature", "FirebasePushSchemaFactory")]
+    public class FirebasePushSchemaFactoryTests
+    {
+        [Fact]
+        public void Should_ReturnFirebasePushSchema_When_CreateSchemaIsCalled()
+        {
+            // Arrange
+            IChannelSchemaFactory factory = new FirebasePushSchemaFactory();
+
+            // Act
+            var schema = factory.CreateSchema();
+
+            // Assert
+            Assert.NotNull(schema);
+            Assert.Equal(FirebaseConnectorConstants.Provider, schema.ChannelProvider);
+            Assert.Equal(FirebaseConnectorConstants.PushChannel, schema.ChannelType);
+        }
+
+        [Fact]
+        public void Should_MatchStaticPropertyValues_When_CreateSchemaIsCalled()
+        {
+            // Arrange
+            IChannelSchemaFactory factory = new FirebasePushSchemaFactory();
+            var expected = FirebaseChannelSchemas.FirebasePush;
+
+            // Act
+            var schema = factory.CreateSchema();
+
+            // Assert
+            Assert.Equal(expected.ChannelProvider, schema.ChannelProvider);
+            Assert.Equal(expected.ChannelType, schema.ChannelType);
+            Assert.Equal(expected.Version, schema.Version);
+            Assert.Equal(expected.DisplayName, schema.DisplayName);
+        }
+    }
+}
+
+

--- a/test/Deveel.Messaging.Connector.Twilio.XUnit/Unit/TwilioSchemaFactoryTests.cs
+++ b/test/Deveel.Messaging.Connector.Twilio.XUnit/Unit/TwilioSchemaFactoryTests.cs
@@ -1,0 +1,89 @@
+//
+// Copyright (c) Antonello Provenzano and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+//
+
+namespace Deveel.Messaging;
+
+/// <summary>
+/// Unit tests verifying that <see cref="TwilioSmsSchemaFactory"/> and
+/// <see cref="TwilioWhatsAppSchemaFactory"/> return the expected default schemas.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("Layer", "Infrastructure")]
+[Trait("Feature", "TwilioSchemaFactories")]
+public class TwilioSchemaFactoryTests
+{
+    #region TwilioSmsSchemaFactory
+
+    [Fact]
+    public void Should_ReturnTwilioSmsSchema_When_SmsCreateSchemaIsCalled()
+    {
+        // Arrange
+        IChannelSchemaFactory factory = new TwilioSmsSchemaFactory();
+
+        // Act
+        var schema = factory.CreateSchema();
+
+        // Assert
+        Assert.NotNull(schema);
+        Assert.Equal(TwilioConnectorConstants.Provider, schema.ChannelProvider);
+        Assert.Equal(TwilioConnectorConstants.SmsChannel, schema.ChannelType);
+    }
+
+    [Fact]
+    public void Should_MatchStaticPropertyValues_When_SmsCreateSchemaIsCalled()
+    {
+        // Arrange
+        IChannelSchemaFactory factory = new TwilioSmsSchemaFactory();
+        var expected = TwilioChannelSchemas.TwilioSms;
+
+        // Act
+        var schema = factory.CreateSchema();
+
+        // Assert
+        Assert.Equal(expected.ChannelProvider, schema.ChannelProvider);
+        Assert.Equal(expected.ChannelType, schema.ChannelType);
+        Assert.Equal(expected.Version, schema.Version);
+    }
+
+    #endregion
+
+    #region TwilioWhatsAppSchemaFactory
+
+    [Fact]
+    public void Should_ReturnTwilioWhatsAppSchema_When_WhatsAppCreateSchemaIsCalled()
+    {
+        // Arrange
+        IChannelSchemaFactory factory = new TwilioWhatsAppSchemaFactory();
+
+        // Act
+        var schema = factory.CreateSchema();
+
+        // Assert
+        Assert.NotNull(schema);
+        Assert.Equal(TwilioConnectorConstants.Provider, schema.ChannelProvider);
+        Assert.Equal(TwilioConnectorConstants.WhatsAppChannel, schema.ChannelType);
+    }
+
+    [Fact]
+    public void Should_MatchStaticPropertyValues_When_WhatsAppCreateSchemaIsCalled()
+    {
+        // Arrange
+        IChannelSchemaFactory factory = new TwilioWhatsAppSchemaFactory();
+        var expected = TwilioChannelSchemas.TwilioWhatsApp;
+
+        // Act
+        var schema = factory.CreateSchema();
+
+        // Assert
+        Assert.Equal(expected.ChannelProvider, schema.ChannelProvider);
+        Assert.Equal(expected.ChannelType, schema.ChannelType);
+        Assert.Equal(expected.Version, schema.Version);
+    }
+
+    #endregion
+}
+
+
+


### PR DESCRIPTION
This pull request introduces comprehensive unit tests for messaging-related exception and schema factory classes across several connectors (core, Facebook, Firebase, and Twilio). The new tests verify object construction, property assignments, interface implementations, and error handling for invalid arguments.

**Unit Test Additions:**

- **Messaging Exception Classes:**
  * Added unit tests for `MessagingException` to cover all constructors, property assignments, interface implementation, and argument validation.
  * Added unit tests for `MessageValidationException`, including tests for property assignments, interface implementation, and validation of error code arguments.
  * Added unit tests for `MessageValidationError` struct, verifying property assignments, null handling, interface implementation, and error code validation.

- **Channel Schema Factories:**
  * Added tests for `FacebookMessengerSchemaFactory` to ensure it returns the expected schema and matches static property values.
  * Added tests for `FirebasePushSchemaFactory` to verify schema creation and property values.
  * Added tests for both `TwilioSmsSchemaFactory` and `TwilioWhatsAppSchemaFactory`, checking correct schema instantiation and property matching.…uthenticationProvider, and messaging errors.