### PR TITLE
Update README with version targets and contribution guidelines

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -207,11 +207,18 @@ jobs:
           --coverage-output-format cobertura
           --coverage-output coverage.cobertura.xml
 
+      - name: List coverage files
+        if: inputs.collect-coverage == true
+        run: |
+          echo "Discovered coverage files:"
+          find . -type f -name 'coverage.cobertura.xml' | sort
+        shell: bash
+
       - name: Upload coverage to Codecov
         if: inputs.collect-coverage == true
         uses: codecov/codecov-action@v4
         with:
-          files: ./test/**/TestResults/coverage.cobertura.xml
+          files: ./test/**/TestResults/**/coverage.cobertura.xml,./**/coverage.cobertura.xml
           flags: ${{ matrix.dotnet-framework }},${{ matrix.os }}
           name: ${{ matrix.os }}-${{ matrix.dotnet-framework }}
           fail_ci_if_error: false

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Install GitVersion
         uses: gittools/actions/gitversion/setup@v1.1.1
         with:
-          versionSpec: '5.x'
+          versionSpec: '5.12.0'
 
       - name: Determine Version
         id: gitversion

--- a/.github/workflows/clean-packages.yml
+++ b/.github/workflows/clean-packages.yml
@@ -5,6 +5,10 @@ on:
 
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   clean:
     runs-on: ubuntu-latest
@@ -26,10 +30,10 @@ jobs:
           min-versions-to-keep: 15
           delete-only-pre-release-versions: "true"
 
-      - name: "Clean Old Deveel.Messaging.Connector.Twilio Nuget Packages"
+      - name: "Clean Old Deveel.Messaging.Connector.Telegram Nuget Packages"
         uses: actions/delete-package-versions@v4
         with:
-          package-name: 'Deveel.Messaging.Connector.Twilio'
+          package-name: 'Deveel.Messaging.Connector.Telegram'
           package-type: 'nuget'
           min-versions-to-keep: 15
           delete-only-pre-release-versions: true

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,6 +14,8 @@ name: "CodeQL"
 on:
   push:
     branches: [ main ]
+  pull_request:
+    branches: [ main ]
   schedule:
     - cron: '27 3 * * 2'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,10 +126,10 @@ jobs:
       codecov_token: ${{ secrets.CODECOV_TOKEN }}
 
   create-tag:
-    needs: [validate-release, check-tag-exists, build]
+    needs: [validate-release, check-tag-exists, build, publish]
     name: "Create Tag"
     runs-on: ubuntu-latest
-    if: needs.validate-release.outputs.is-manual == 'true' && needs.check-tag-exists.outputs.tag-exists == 'false'
+    if: needs.validate-release.outputs.is-manual == 'true' && needs.check-tag-exists.outputs.tag-exists == 'false' && needs.publish.result == 'success'
 
     steps:
     - name: Checkout

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,582 +1,154 @@
 ﻿# Contributing to Deveel Messaging Framework
 
-Thank you for your interest in contributing to the Deveel Messaging Framework! This document provides guidelines and information for contributors.
+Thanks for helping improve Deveel Messaging.
 
-## 🤝 How to Contribute
+This guide keeps the contribution process simple: discuss changes early, keep pull requests focused, add tests for behavior changes, and let GitVersion handle package versions.
 
-We welcome contributions of all kinds:
+## How to Contribute
 
-- **Bug reports** - Help us identify and fix issues
-- **Feature requests** - Suggest new functionality
-- **Code contributions** - Submit bug fixes, new features, or improvements
-- **Documentation** - Improve or add to our documentation
-- **Testing** - Help improve test coverage and quality
+You can contribute by:
 
-## 🚀 Getting Started
+- reporting bugs
+- proposing features
+- improving code or tests
+- improving documentation and samples
+
+For larger changes, open an issue or discussion first so the approach can be aligned before implementation.
+
+## Quick Start
 
 ### Prerequisites
 
-- **.NET 8.0 SDK** or later (.NET 9.0 recommended)
-- **Visual Studio 2022** (17.4+) or **JetBrains Rider** or **VS Code** with C# extension
-- **Git** for source control
-- Basic knowledge of **C#**, **async/await**, and **dependency injection**
+- Git
+- a recent .NET SDK able to build the current target frameworks (`.NET 8`, `.NET 9`, and `.NET 10`)
+- an editor with C# support such as Rider, Visual Studio, or VS Code
 
-### Setting Up Your Development Environment
-
-1. **Fork the repository** on GitHub
-2. **Clone your fork** locally:
-   ```bash
-   git clone https://github.com/YOUR_USERNAME/deveel.messaging.git
-   cd deveel.messaging
-   ```
-
-3. **Add the upstream remote**:
-   ```bash
-   git remote add upstream https://github.com/deveel/deveel.messaging.git
-   ```
-
-4. **Build the solution**:
-   ```bash
-   dotnet build
-   ```
-
-5. **Run the tests**:
-   ```bash
-   dotnet test
-   ```
-
-### Project Structure
-
-```
-deveel.messaging/
-├── src/                                    # Source code
-│   ├── Deveel.Messaging.Abstractions/     # Core abstractions
-│   ├── Deveel.Messaging.Connector.Abstractions/ # Connector base classes
-│   ├── Deveel.Messaging.Connector.Twilio/ # Twilio SMS / WhatsApp connector
-│   └── Deveel.Messaging.Connector.Sendgrid/ # SendGrid email connector
-├── test/                                   # Test projects
-│   ├── ...
-│   └── ...
-├── docs/                                   # Documentation
-├── .github/                                # GitHub workflows and templates
-└── README.md                              # Project overview
-```
-
-## 📝 Code Style Guidelines
-
-### Coding Standards
-
-We follow Microsoft's C# coding conventions with some additional guidelines:
-
-#### General Guidelines
-
-- **Use C# 12.0 features** where appropriate
-- **Enable nullable reference types** in all projects
-- **Follow async/await best practices**
-- **Use dependency injection** patterns
-- **Write comprehensive unit tests**
-- **Include XML documentation** for public APIs
-
-#### Naming Conventions
-
-```csharp
-// ✅ Good
-public class EmailChannelConnector : ChannelConnectorBase
-{
-    private readonly ILogger<EmailChannelConnector> _logger;
-    
-    public async Task<ConnectorResult<MessageResult>> SendMessageAsync(
-        IMessage message, 
-        CancellationToken cancellationToken = default)
-    {
-        // Implementation
-    }
-}
-
-// ❌ Avoid
-public class emailconnector
-{
-    public Task<object> send(object msg)
-    {
-        // Implementation
-    }
-}
-```
-
-#### Code Organization
-
-- **One class per file** (except for small related classes)
-- **Organize using statements** (remove unused, group by type)
-- **Use regions sparingly** (prefer smaller classes)
-- **Keep methods focused** (single responsibility)
-
-#### Error Handling
-
-```csharp
-// ✅ Good - Use ConnectorResult pattern
-protected override async Task<ConnectorResult<MessageResult>> SendMessageCoreAsync(
-    IMessage message, CancellationToken cancellationToken)
-{
-    try
-    {
-        var result = await SendToProviderAsync(message, cancellationToken);
-        return ConnectorResult<MessageResult>.Success(result);
-    }
-    catch (OperationCanceledException)
-    {
-        return ConnectorResult<MessageResult>.Failure("Operation was cancelled");
-    }
-    catch (HttpRequestException ex)
-    {
-        return ConnectorResult<MessageResult>.Failure($"Network error: {ex.Message}", "NETWORK_ERROR");
-    }
-    catch (Exception ex)
-    {
-        _logger.LogError(ex, "Unexpected error sending message {MessageId}", message.Id);
-        return ConnectorResult<MessageResult>.Failure($"Unexpected error: {ex.Message}", "UNEXPECTED_ERROR");
-    }
-}
-
-// ❌ Avoid - Throwing exceptions from connector methods
-protected override async Task<ConnectorResult<MessageResult>> SendMessageCoreAsync(
-    IMessage message, CancellationToken cancellationToken)
-{
-    var result = await SendToProviderAsync(message, cancellationToken);
-    if (result == null)
-        throw new InvalidOperationException("Send failed"); // Don't do this
-    
-    return ConnectorResult<MessageResult>.Success(result);
-}
-```
-
-### EditorConfig
-
-We use an `.editorconfig` file to maintain consistent formatting. Make sure your IDE respects these settings:
-
-```ini
-root = true
-
-[*]
-charset = utf-8
-end_of_line = crlf
-insert_final_newline = true
-trim_trailing_whitespace = true
-
-[*.cs]
-indent_style = space
-indent_size = 4
-
-# C# specific rules
-dotnet_style_qualification_for_field = false:suggestion
-dotnet_style_qualification_for_property = false:suggestion
-dotnet_style_qualification_for_method = false:suggestion
-dotnet_style_qualification_for_event = false:suggestion
-csharp_prefer_braces = true:warning
-csharp_using_directive_placement = outside_namespace:warning
-```
-
-## 🧪 Testing Guidelines
-
-### Unit Testing Standards
-
-- **Use xUnit** for unit tests
-- **Follow AAA pattern** (Arrange, Act, Assert)
-- **Use descriptive test names** that explain the scenario
-- **Test both success and failure paths**
-- **Mock external dependencies**
-
-#### Test Structure
-
-```csharp
-public class EmailConnectorTests
-{
-    [Fact]
-    public async Task SendMessageAsync_WithValidEmailMessage_ShouldReturnSuccess()
-    {
-        // Arrange
-        var schema = CreateEmailSchema();
-        var connector = new EmailConnector(schema, CreateMockConfiguration());
-        var message = new MessageBuilder()
-            .WithId("test-001")
-            .WithEmailSender("sender@test.com")
-            .WithEmailReceiver("recipient@test.com")
-            .WithTextContent("Test message")
-            .Message;
-
-        await connector.InitializeAsync(CancellationToken.None);
-
-        // Act
-        var result = await connector.SendMessageAsync(message, CancellationToken.None);
-
-        // Assert
-        Assert.True(result.IsSuccess);
-        Assert.NotNull(result.Value);
-        Assert.NotEmpty(result.Value.MessageId);
-        Assert.Equal(MessageStatus.Sent, result.Value.Status);
-    }
-
-    [Fact]
-    public async Task SendMessageAsync_WithInvalidEndpoint_ShouldReturnFailure()
-    {
-        // Arrange
-        var schema = CreateEmailSchema();
-        var connector = new EmailConnector(schema, CreateMockConfiguration());
-        var message = new MessageBuilder()
-            .WithId("test-002")
-            .WithEmailSender("invalid-email")  // Invalid email format
-            .WithEmailReceiver("recipient@test.com")
-            .WithTextContent("Test message")
-            .Message;
-
-        await connector.InitializeAsync(CancellationToken.None);
-
-        // Act
-        var result = await connector.SendMessageAsync(message, CancellationToken.None);
-
-        // Assert
-        Assert.False(result.IsSuccess);
-        Assert.Contains("invalid", result.ErrorMessage?.ToLower() ?? "");
-    }
-
-    private static IChannelSchema CreateEmailSchema()
-    {
-        return new ChannelSchema("Test", "Email", "1.0.0")
-            .WithCapabilities(ChannelCapability.SendMessages)
-            .AllowsMessageEndpoint(EndpointType.EmailAddress)
-            .AddContentType(MessageContentType.PlainText);
-    }
-
-    private static Dictionary<string, object> CreateMockConfiguration()
-    {
-        return new Dictionary<string, object>
-        {
-            ["Host"] = "smtp.test.com",
-            ["Port"] = 587,
-            ["Username"] = "test@test.com",
-            ["Password"] = "password"
-        };
-    }
-}
-```
-
-#### Integration Testing
-
-For connectors that interact with external services:
-
-```csharp
-[Collection("Integration Tests")]
-public class TwilioConnectorIntegrationTests
-{
-    [Fact]
-    [Trait("Category", "Integration")]
-    public async Task SendSms_WithRealTwilioAccount_ShouldSendMessage()
-    {
-        // Only run if environment variables are set
-        var accountSid = Environment.GetEnvironmentVariable("TWILIO_ACCOUNT_SID");
-        var authToken = Environment.GetEnvironmentVariable("TWILIO_AUTH_TOKEN");
-        var fromNumber = Environment.GetEnvironmentVariable("TWILIO_FROM_NUMBER");
-        
-        Skip.If(string.IsNullOrEmpty(accountSid), "Twilio credentials not configured");
-        
-        // Test implementation...
-    }
-}
-```
-
-### Test Coverage
-
-- **Aim for 80%+ code coverage**
-- **Focus on business logic** and critical paths
-- **Don't test framework code** or simple properties
-- **Use code coverage tools** to identify gaps
+### Setup
 
 ```bash
-# Run tests with coverage
-dotnet test --collect:"XPlat Code Coverage" --results-directory ./coverage
-
-# Generate coverage reports (requires reportgenerator tool)
-reportgenerator -reports:"coverage/**/*.xml" -targetdir:"coverage/report" -reporttypes:Html
+git clone https://github.com/YOUR_USERNAME/deveel.messaging.git
+cd deveel.messaging
+git remote add upstream https://github.com/deveel/deveel.messaging.git
+dotnet build
+dotnet test
 ```
 
-## 📋 Pull Request Process
+## Project Layout
 
-### Before Submitting
+- `src/` — libraries and connectors
+- `test/` — automated tests
+- `docs/` — documentation
+- `samples/` — runnable samples
 
-1. **Ensure all tests pass**: `dotnet test`
-2. **Check code formatting**: Ensure your IDE follows the EditorConfig rules
-3. **Update documentation** if you've changed public APIs
-4. **Add tests** for new functionality
-5. **Update CHANGELOG.md** if applicable
+## Development Guidelines
 
-### Pull Request Checklist
+Keep changes small, readable, and easy to review.
 
-- [ ] **Clear title** and description explaining the changes
-- [ ] **Reference related issues** (e.g., "Fixes #123")
-- [ ] **All tests pass** locally
-- [ ] **No merge conflicts** with the main branch
-- [ ] **Documentation updated** if needed
-- [ ] **Breaking changes** are clearly marked and explained
+### Code
 
-### Pull Request Template
+- follow the existing coding style and `.editorconfig`
+- prefer small, focused changes over large refactors
+- keep nullable annotations and async patterns consistent
+- add XML documentation for new public APIs
+- avoid unrelated formatting changes
 
-```markdown
-## Description
-Brief description of what this PR does.
+### Tests
 
-## Type of Change
-- [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] Documentation update
+- add or update tests for behavior changes
+- use xUnit and keep tests readable
+- cover both success and failure paths when practical
+- run `dotnet test` before opening a pull request
 
-## Testing
-- [ ] I have added tests that prove my fix is effective or that my feature works
-- [ ] New and existing unit tests pass locally with my changes
-- [ ] I have tested this with real providers (if applicable)
+### Documentation
 
-## Documentation
-- [ ] I have updated the documentation accordingly
-- [ ] I have added XML documentation for new public APIs
+Update documentation when you change:
 
-## Related Issues
-Fixes #(issue_number)
+- public APIs
+- configuration behavior
+- connector capabilities
+- setup or usage steps
 
-## Additional Notes
-Any additional information, configuration, or data that might be necessary to reproduce the issue.
-```
+## Pull Request Process
 
-## 🐛 Bug Reports
+1. Create a short-lived branch from `main`.
+2. Make your change.
+3. Run the build and tests locally.
+4. Open a pull request back to `main`.
 
-When reporting bugs, please include:
+Before submitting a pull request, make sure that:
 
-### Bug Report Template
+- the title clearly describes the change
+- related issues are referenced when applicable
+- tests pass locally
+- documentation is updated when needed
+- breaking changes are called out explicitly
 
-```markdown
-**Describe the bug**
-A clear and concise description of what the bug is.
+## Issues and Requests
 
-**To Reproduce**
-Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+When opening an issue or feature request, include enough detail for someone else to understand the problem quickly:
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+- what happened
+- what you expected
+- how to reproduce it
+- the package and provider involved
+- your .NET version and OS when relevant
 
-**Code Sample**
-```csharp
-// Minimal code sample that reproduces the issue
-var connector = new SomeConnector(schema);
-var result = await connector.SomeMethod();
-// Result is not what's expected
-```
+Minimal reproduction samples are always helpful.
 
-**Environment:**
-- OS: [e.g., Windows 11, Ubuntu 20.04]
-- .NET Version: [e.g., .NET 8.0, .NET 9.0]
-- Package Version: [e.g., 2.1.0]
-- Provider: [e.g., Twilio, SendGrid]
+## Versioning and Releases
 
-**Additional context**
-Add any other context about the problem here.
-```
+Versioning is intentionally simple.
 
-## 💡 Feature Requests
+### Versioning Strategy
 
-When suggesting new features:
+The project uses **Semantic Versioning**:
 
-### Feature Request Template
+- **Major** for breaking changes
+- **Minor** for backward-compatible features
+- **Patch** for backward-compatible fixes
 
-```markdown
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+Contributors should **not** edit package versions manually in project files.
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
-
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
-
-**Use Case**
-Describe the specific use case this feature would address.
-
-**Additional context**
-Add any other context or screenshots about the feature request here.
-```
-
-## 🏗️ Architecture Guidelines
-
-### Adding New Connectors
-
-When adding a new connector:
-
-1. **Create the connector class** extending `ChannelConnectorBase`
-2. **Define the schema** with appropriate capabilities and parameters
-3. **Implement required abstract methods**
-4. **Add comprehensive tests**
-5. **Create documentation**
-6. **Add integration tests** (if possible)
-
-### Example New Connector Structure
-
-```
-src/Deveel.Messaging.Connector.NewProvider/
-├── NewProviderConnector.cs              # Main connector implementation
-├── NewProviderConfiguration.cs          # Configuration model
-├── NewProviderException.cs              # Provider-specific exceptions
-├── NewProviderMessageResult.cs          # Provider-specific result models
-└── Deveel.Messaging.Connector.NewProvider.csproj
-
-test/Deveel.Messaging.Connector.NewProvider.XUnit/
-├── NewProviderConnectorTests.cs         # Unit tests
-├── NewProviderIntegrationTests.cs       # Integration tests (optional)
-└── Deveel.Messaging.Connector.NewProvider.XUnit.csproj
-```
-
-### Schema Design Guidelines
-
-- **Use semantic versioning** for schema versions
-- **Be conservative** with breaking changes
-- **Provide good defaults** for optional parameters
-- **Mark sensitive parameters** appropriately
-- **Document all parameters** clearly
-
-## 📚 Documentation Standards
-
-### XML Documentation
-
-All public APIs must include XML documentation:
-
-```csharp
-/// <summary>
-/// Sends a message through the configured messaging provider.
-/// </summary>
-/// <param name="message">The message to send. Must not be null.</param>
-/// <param name="cancellationToken">Cancellation token to cancel the operation.</param>
-/// <returns>
-/// A <see cref="ConnectorResult{T}"/> containing the message result if successful,
-/// or error information if the send operation failed.
-/// </returns>
-/// <exception cref="ArgumentNullException">Thrown when <paramref name="message"/> is null.</exception>
-/// <exception cref="InvalidOperationException">Thrown when the connector is not initialized.</exception>
-public async Task<ConnectorResult<MessageResult>> SendMessageAsync(
-    IMessage message, 
-    CancellationToken cancellationToken = default)
-{
-    // Implementation
-}
-```
-
-### Markdown Documentation
-
-- **Use clear headings** and structure
-- **Include code examples** for all features
-- **Provide working samples** that can be copy-pasted
-- **Keep examples up-to-date** with the current API
-
-## 🎯 Performance Guidelines
-
-### Performance Considerations
-
-- **Use async/await** properly (don't block on async calls)
-- **Dispose resources** appropriately
-- **Consider memory usage** for large message batches
-- **Implement caching** where appropriate
-- **Use connection pooling** for HTTP-based connectors
-
-### Benchmarking
-
-For performance-critical changes, include benchmarks:
-
-```csharp
-[MemoryDiagnoser]
-[SimpleJob(RuntimeMoniker.Net80)]
-public class MessageBuildingBenchmarks
-{
-    [Benchmark]
-    public IMessage CreateMessageWithBuilder()
-    {
-        return new MessageBuilder()
-            .WithId("test-001")
-            .WithEmailSender("sender@test.com")
-            .WithEmailReceiver("recipient@test.com")
-            .WithTextContent("Benchmark test message")
-            .Message;
-    }
-}
-```
-
-## 🚀 Release Process
-
-### Versioning
-
-We follow **Semantic Versioning** (SemVer):
-
-- **Major** (X.0.0): Breaking changes
-- **Minor** (X.Y.0): New features, backward compatible
-- **Patch** (X.Y.Z): Bug fixes, backward compatible
-
-### Branching and Releases
+### Branching Strategy
 
 The repository follows **GitHub Flow**:
 
-- `main` is the only long-lived branch.
-- Short-lived branches are created from `main` and merged back through pull requests.
-- GitVersion generates CI package versions from branch and `main` builds.
-- Stable releases are created from `vX.Y.Z` tags that point to commits already contained in `main`.
+- `main` is the only long-lived branch
+- feature and fix branches are created from `main`
+- changes are merged back through pull requests
 
-### Changelog
+### Package Publishing
 
-Update `CHANGELOG.md` for all notable changes:
+- builds from `main` publish preview packages to GitHub Packages
+- preview packages use an `-alpha.N` suffix generated by GitVersion
+- stable packages are published only from `vX.Y.Z` tags on commits already in `main`
+- manual releases can safely publish to NuGet.org because the release tag defines the final stable version
 
-```markdown
-## [2.1.0] - 2024-XX-XX
+In short:
 
-### Added
-- New webhook connector for HTTP-based messaging
-- Support for custom parameter validation
-- Batch processing capabilities
+- merge to `main` → preview package
+- create `vX.Y.Z` tag → stable release package
 
-### Changed
-- Improved error handling in base connector class
-- Enhanced schema validation performance
+## Changelog
 
-### Fixed
-- Issue with endpoint type validation for custom endpoints
-- Memory leak in connector pool implementation
+If your change is user-visible, update `CHANGELOG.md` with a short note under the appropriate section.
 
-### Breaking Changes
-- Removed deprecated `IMessage.LegacyProperty` property
-- Changed signature of `IChannelConnector.SendAsync` method
-```
+## Community
 
-## 🏆 Recognition
+- GitHub Discussions for questions and ideas
+- GitHub Issues for bugs and feature requests
+- project docs in `docs/`
 
-Contributors will be recognized in:
+## License
 
-- **CONTRIBUTORS.md** file
-- **Release notes** for significant contributions
-- **GitHub contributors** page
+By contributing to this repository, you agree that your contributions will be licensed under the MIT License.
 
-## 💬 Community
+## Questions
 
-- **GitHub Discussions**: Ask questions and share ideas
-- **GitHub Issues**: Report bugs and request features
-- **Email**: For private/security concerns, contact support@deveel.com
+If you are unsure where to start:
 
-## 📄 License
+1. review `README.md`
+2. review `docs/README.md`
+3. open a discussion or issue
 
-By contributing to this project, you agree that your contributions will be licensed under the MIT License.
-
-## ❓ Questions?
-
-If you have questions about contributing:
-
-1. Check existing [GitHub Discussions](https://github.com/deveel/deveel.messaging/discussions)
-2. Review [documentation](docs/README.md)
-3. Open a new discussion or issue
-4. Contact the maintainers
-
-Thank you for contributing to the Deveel Messaging Framework! 🙏
+Thank you for contributing.

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -7,57 +7,52 @@ assembly-file-versioning-scheme: MajorMinorPatch
 # GitHub Flow:
 # - `main` is the only long-lived branch and publishes preview packages
 # - stable packages are produced only from version tags on commits already in `main`
+# NOTE: this file is authored for GitVersion 5.x syntax (eg `tag`,
+# `prevent-increment-of-merged-branch-version`). Keep CI and MSBuild GitVersion
+# versions aligned before introducing 6.x-style keys.
 branches:
   main:
     regex: ^master$|^main$
     tag: alpha
     increment: Patch
-    prevent-increment:
-      of-merged-branch: true
+    prevent-increment-of-merged-branch-version: true
     track-merge-target: false
     source-branches: []
     tracks-release-branches: false
     is-release-branch: false
-    is-main-branch: true
     pre-release-weight: 55000
 
   feature:
     regex: ^features?[/-]
     tag: '{BranchName}'
     increment: Inherit
-    prevent-increment:
-      of-merged-branch: false
+    prevent-increment-of-merged-branch-version: false
     track-merge-target: false
     source-branches: [ main ]
     tracks-release-branches: false
     is-release-branch: false
-    is-main-branch: false
     pre-release-weight: 30000
 
   pull-request:
     regex: ^(pull|pull-requests|pr)[/-]
     tag: pr-{Number}
     increment: Inherit
-    prevent-increment:
-      of-merged-branch: true
+    prevent-increment-of-merged-branch-version: true
     track-merge-target: false
     source-branches: [ main, feature ]
     tracks-release-branches: false
     is-release-branch: false
-    is-main-branch: false
     pre-release-weight: 30000
 
   unknown:
     regex: ^(?!master$|main$|features?[/-].+|(pull|pull-requests|pr)[/-].+)(?<BranchName>.+)$
     tag: '{BranchName}'
     increment: Inherit
-    prevent-increment:
-      of-merged-branch: false
+    prevent-increment-of-merged-branch-version: false
     track-merge-target: false
     source-branches: [ main, feature, pull-request ]
     tracks-release-branches: false
     is-release-branch: false
-    is-main-branch: false
     pre-release-weight: 30000
 
   develop:

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -3,69 +3,76 @@ tag-prefix: '[vV]?'
 commit-message-incrementing: Enabled
 assembly-versioning-scheme: MajorMinorPatch
 assembly-file-versioning-scheme: MajorMinorPatch
+
+# GitHub Flow:
+# - `main` is the only long-lived branch and publishes preview packages
+# - stable packages are produced only from version tags on commits already in `main`
 branches:
   main:
     regex: ^master$|^main$
-    tag: ''
+    label: alpha
     increment: Patch
-    prevent-increment-of-merged-branch-version: true
+    prevent-increment:
+      of-merged-branch: true
     track-merge-target: false
     source-branches: []
     tracks-release-branches: false
     is-release-branch: false
-    is-mainline: true
+    is-main-branch: true
     pre-release-weight: 55000
-  release:
-    regex: ^releases?[/-]
-    tag: beta
-    increment: Patch
-    prevent-increment-of-merged-branch-version: true
+
+  feature:
+    regex: ^features?[/-]
+    label: '{BranchName}'
+    increment: Inherit
+    prevent-increment:
+      of-merged-branch: false
     track-merge-target: false
     source-branches: [ main ]
     tracks-release-branches: false
-    is-release-branch: true
-    is-mainline: false
-    pre-release-weight: 30000
-  feature:
-    regex: ^features?[/-]
-    tag: useBranchName
-    increment: Inherit
-    prevent-increment-of-merged-branch-version: false
-    track-merge-target: false
-    source-branches: [ main, release ]
-    tracks-release-branches: false
     is-release-branch: false
-    is-mainline: false
+    is-main-branch: false
     pre-release-weight: 30000
+
   pull-request:
     regex: ^(pull|pull-requests|pr)[/-]
-    tag: PullRequest
+    label: PullRequest{Number}
     increment: Inherit
-    prevent-increment-of-merged-branch-version: true
-    tag-number-pattern: '[/-](?<number>\d+)[-/]'
+    prevent-increment:
+      of-merged-branch: true
     track-merge-target: false
-    source-branches: [ main, release, feature ]
+    source-branches: [ main, feature ]
     tracks-release-branches: false
     is-release-branch: false
-    is-mainline: false
+    is-main-branch: false
     pre-release-weight: 30000
+
   unknown:
-    regex: ^(?!master$|main$|releases?[/-].+|features?[/-].+|(pull|pull-requests|pr)[/-].+)(?<BranchName>.+)$
-    tag: useBranchName
+    regex: ^(?!master$|main$|features?[/-].+|(pull|pull-requests|pr)[/-].+)(?<BranchName>.+)$
+    label: '{BranchName}'
     increment: Inherit
-    prevent-increment-of-merged-branch-version: false
+    prevent-increment:
+      of-merged-branch: false
     track-merge-target: false
-    source-branches: [ main, release, feature, pull-request ]
+    source-branches: [ main, feature, pull-request ]
     tracks-release-branches: false
     is-release-branch: false
-    is-mainline: false
+    is-main-branch: false
     pre-release-weight: 30000
+
   develop:
     regex: ^$
+
+  release:
+    regex: ^$
+
   hotfix:
     regex: ^$
+
   support:
     regex: ^$
+
 ignore:
   sha: []
+
 merge-message-formats: {}

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -10,7 +10,7 @@ assembly-file-versioning-scheme: MajorMinorPatch
 branches:
   main:
     regex: ^master$|^main$
-    label: alpha
+    tag: alpha
     increment: Patch
     prevent-increment:
       of-merged-branch: true
@@ -23,7 +23,7 @@ branches:
 
   feature:
     regex: ^features?[/-]
-    label: '{BranchName}'
+    tag: '{BranchName}'
     increment: Inherit
     prevent-increment:
       of-merged-branch: false
@@ -36,7 +36,7 @@ branches:
 
   pull-request:
     regex: ^(pull|pull-requests|pr)[/-]
-    label: PullRequest{Number}
+    tag: pr-{Number}
     increment: Inherit
     prevent-increment:
       of-merged-branch: true
@@ -49,7 +49,7 @@ branches:
 
   unknown:
     regex: ^(?!master$|main$|features?[/-].+|(pull|pull-requests|pr)[/-].+)(?<BranchName>.+)$
-    label: '{BranchName}'
+    tag: '{BranchName}'
     increment: Inherit
     prevent-increment:
       of-merged-branch: false

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -35,7 +35,7 @@ branches:
 
   pull-request:
     regex: ^(pull|pull-requests|pr)[/-]
-    tag: pr-{Number}
+    tag: pr
     increment: Inherit
     prevent-increment-of-merged-branch-version: true
     track-merge-target: false

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Deveel Messaging is a .NET framework that gives you one consistent way to work w
 
 Instead of coding directly against each provider SDK, you build an `IMessage`, send it through an `IChannelConnector`, and handle a predictable `ConnectorResult<T>`. That keeps your app code stable even if providers change.
 
+The repository currently targets `.NET 8`, `.NET 9`, and `.NET 10`.
+
 ## What this project includes
 
 - A shared message model (`IMessage`, endpoints, content types, properties)
@@ -66,7 +68,7 @@ Strengthens quality gates, release automation, observability, and docs completen
 - [x] **Test coverage target (>= 80%)** - Enforce minimum line coverage per library in CI.
 - [x] **CI/CD pipeline hardening** - Automate build, test, compatibility checks, signing, and NuGet publishing from release tags.
 - [x] **Structured logging improvements** - Standardize event IDs, scopes, and `LoggerMessage` patterns across connectors.
-- [ ] **Documentation completeness** - Complete XML API docs and connector guides with consistent coverage.
+- [x] **Documentation completeness** - Complete XML API docs and connector guides with consistent coverage.
 
 ### v0.5.0 - Inbound Messaging
 
@@ -113,6 +115,16 @@ Start from the docs home and follow the path that best matches what you are buil
 - **Validation-first integration** - Model endpoints, apply validation rules, and extend validation when channel-specific constraints grow.
   ([Endpoint types](docs/endpointtype-usage.md) -> [Message validation examples](docs/validatemessage-usage-examples.md) -> [Validation extensions](docs/channelschema-validation-extension-usage.md))
 
+## Versioning and Releases
+
+The project uses a simple GitHub Flow-based release model:
+
+- `main` is the only long-lived branch
+- merges to `main` produce preview packages with an `-alpha.N` suffix
+- stable packages are produced only from `vX.Y.Z` tags on commits already in `main`
+
+Package versions are calculated automatically with GitVersion, so versions should not be edited manually in project files.
+
 ## Contributing
 
 Contributions are welcome and appreciated.
@@ -122,6 +134,8 @@ If you want to contribute:
 - Open an issue to discuss bugs, features, or design changes
 - Check the existing documentation and package boundaries before proposing API changes
 - Submit focused pull requests with tests when behavior changes
+
+The contribution workflow follows GitHub Flow: create a short-lived branch from `main`, open a pull request, and let CI produce preview packages from `main` after merge.
 
 For local setup, coding conventions, and the contribution workflow, read [CONTRIBUTING.md](CONTRIBUTING.md).
 


### PR DESCRIPTION
This pull request updates the project's release and branching documentation and configuration to better align with GitHub Flow practices and clarify versioning. It also updates the GitVersion configuration to match these practices and marks documentation completeness as achieved.

**Release and Versioning Policy Updates:**

* Added a new section in `README.md` describing the GitHub Flow-based release process, clarifying that `main` is the only long-lived branch, preview packages are produced from `main`, and stable packages come from version tags. Also, clarified that package versions are managed automatically by GitVersion.
* Updated the contribution guidelines in `README.md` to specify that contributors should use short-lived branches from `main` and that preview packages are produced by CI after merging to `main`.

**GitVersion Configuration Improvements:**

* Refactored `GitVersion.yml` to use new branch configuration options (e.g., `label` instead of `tag`), removed release branch logic, and improved alignment with GitHub Flow. This includes making `main` the only main branch, updating increment and label behaviors for feature, pull request, and unknown branches, and removing now-unused release branch settings.

**Documentation and Metadata Updates:**

* Updated the README to state that the repository targets `.NET 8`, `.NET 9`, and `.NET 10`.
* Marked "Documentation completeness" as achieved in the project roadmap checklist in `README.md`.