### PR TITLE
Add support for interactive content types including buttons and carousels

### DIFF
--- a/Deveel.Messaging.Model.sln
+++ b/Deveel.Messaging.Model.sln
@@ -51,6 +51,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Deveel.Messaging", "src\Dev
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Deveel.Messaging.XUnit", "test\Deveel.Messaging.XUnit\Deveel.Messaging.XUnit.csproj", "{8838304E-3F66-41D0-95C2-CEAE20859BDF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Deveel.Messaging.Testing", "test\Deveel.Messaging.Testing\Deveel.Messaging.Testing.csproj", "{6F694C65-9580-422A-ADC4-85C5566599D4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -289,6 +291,18 @@ Global
 		{8838304E-3F66-41D0-95C2-CEAE20859BDF}.Release|x64.Build.0 = Release|Any CPU
 		{8838304E-3F66-41D0-95C2-CEAE20859BDF}.Release|x86.ActiveCfg = Release|Any CPU
 		{8838304E-3F66-41D0-95C2-CEAE20859BDF}.Release|x86.Build.0 = Release|Any CPU
+		{6F694C65-9580-422A-ADC4-85C5566599D4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6F694C65-9580-422A-ADC4-85C5566599D4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6F694C65-9580-422A-ADC4-85C5566599D4}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6F694C65-9580-422A-ADC4-85C5566599D4}.Debug|x64.Build.0 = Debug|Any CPU
+		{6F694C65-9580-422A-ADC4-85C5566599D4}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6F694C65-9580-422A-ADC4-85C5566599D4}.Debug|x86.Build.0 = Debug|Any CPU
+		{6F694C65-9580-422A-ADC4-85C5566599D4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6F694C65-9580-422A-ADC4-85C5566599D4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6F694C65-9580-422A-ADC4-85C5566599D4}.Release|x64.ActiveCfg = Release|Any CPU
+		{6F694C65-9580-422A-ADC4-85C5566599D4}.Release|x64.Build.0 = Release|Any CPU
+		{6F694C65-9580-422A-ADC4-85C5566599D4}.Release|x86.ActiveCfg = Release|Any CPU
+		{6F694C65-9580-422A-ADC4-85C5566599D4}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -313,6 +327,7 @@ Global
 		{AFD255F4-767A-409A-9435-0059530D83A2} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{E89DB6F7-29B2-455D-B0AE-FB9E41F90B46} = {0F91077D-AC47-4319-96FF-09CA6EE50CC6}
 		{8838304E-3F66-41D0-95C2-CEAE20859BDF} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{6F694C65-9580-422A-ADC4-85C5566599D4} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {64BF9420-C7A8-4D2B-804F-41EB2E83437F}

--- a/docs/connectors/facebook-messenger.md
+++ b/docs/connectors/facebook-messenger.md
@@ -31,8 +31,8 @@ The `PageAccessToken` must be a long-lived token (valid ~60 days). Generate it f
 | Provider | `Facebook` |
 | Type | `Messenger` |
 | Version | `1.0.0` |
-| Capabilities | `SendMessages`, `ReceiveMessages`, `MediaAttachments` |
-| Content types | `PlainText`, `Media`, `Json` |
+| Capabilities | `SendMessages`, `ReceiveMessages`, `MediaAttachments`, `InteractiveContent` |
+| Content types | `PlainText`, `Media`, `Json`, `Button`, `QuickReply`, `Carousel`, `ListPicker` |
 | Endpoints | `UserId` (PSID), `Id` (page-scoped ID) |
 | Authentication | API Key (`PageAccessToken`) |
 
@@ -75,6 +75,55 @@ new MessageBuilder()
     .To(Endpoint.User("psid-123"))
     .WithText("Choose an option:")
     .WithQuickReplies("[{\"content_type\":\"text\",\"title\":\"Yes\",\"payload\":\"YES\"},{\"content_type\":\"text\",\"title\":\"No\",\"payload\":\"NO\"}]")
+    .Build();
+```
+
+### Message with buttons
+
+```csharp
+// Using the convenience method
+new MessageBuilder()
+    .To(Endpoint.User("psid-123"))
+    .WithButton("Open Website", ButtonType.Url, "https://example.com")
+    .Build();
+```
+
+### Message with quick reply options
+
+```csharp
+// Single quick reply option
+new MessageBuilder()
+    .To(Endpoint.User("psid-123"))
+    .WithQuickReply("Yes", "YES_PAYLOAD")
+    .Build();
+```
+
+### Message with carousel (horizontal cards)
+
+```csharp
+// Using the sub-builder API
+new MessageBuilder()
+    .To(Endpoint.User("psid-123"))
+    .WithCarousel(carousel => carousel
+        .AddCard("https://example.com/img1.jpg", "Product A", "Amazing", card =>
+            card.WithButton("Buy", ButtonType.Postback, "BUY_A")
+                .WithButton("Details", ButtonType.Url, "https://example.com/a"))
+        .AddCard("https://example.com/img2.jpg", "Product B", "Even better", card =>
+            card.WithButton("Buy", ButtonType.Postback, "BUY_B")
+                .WithButton("Details", ButtonType.Url, "https://example.com/b")))
+    .Build();
+```
+
+### Message with list picker
+
+```csharp
+// Using the sub-builder API
+new MessageBuilder()
+    .To(Endpoint.User("psid-123"))
+    .WithListPicker(list => list
+        .WithStyle(ListPickerStyle.Compact)
+        .AddItem("Pizza", "Delicious cheese pizza")
+        .AddItem("Burger", "Juicy beef burger"))
     .Build();
 ```
 

--- a/docs/connectors/telegram-bot.md
+++ b/docs/connectors/telegram-bot.md
@@ -31,8 +31,8 @@ The Bot token is obtained from [@BotFather](https://t.me/BotFather) on Telegram.
 | Provider | `Telegram` |
 | Type | `Bot` |
 | Version | `1.0.0` |
-| Capabilities | `SendMessages`, `ReceiveMessages`, `MediaAttachments` |
-| Content types | `PlainText`, `Media` |
+| Capabilities | `SendMessages`, `ReceiveMessages`, `MediaAttachments`, `InteractiveContent` |
+| Content types | `PlainText`, `Media`, `Button`, `QuickReply` |
 | Endpoints | `Id` (chat ID) |
 | Authentication | Token (bot token) |
 
@@ -114,6 +114,27 @@ new MessageBuilder()
     .To(Endpoint.Id("123456789"))
     .WithContent(new LocationContent(41.9028, 12.4964)
         .WithHorizontalAccuracy(10))
+    .Build();
+```
+
+### Message with inline buttons
+
+```csharp
+// Using the convenience method
+new MessageBuilder()
+    .To(Endpoint.Id("123456789"))
+    .WithText("What would you like to do?")
+    .WithButton("Open Website", ButtonType.Url, "https://example.com")
+    .Build();
+```
+
+### Message with quick reply keyboard
+
+```csharp
+// Single quick reply option
+new MessageBuilder()
+    .To(Endpoint.Id("123456789"))
+    .WithQuickReply("Yes", "YES_PAYLOAD")
     .Build();
 ```
 

--- a/docs/connectors/telegram-bot.md
+++ b/docs/connectors/telegram-bot.md
@@ -120,11 +120,10 @@ new MessageBuilder()
 ### Message with inline buttons
 
 ```csharp
-// Using the convenience method
+// The button text is used as the message body
 new MessageBuilder()
     .To(Endpoint.Id("123456789"))
-    .WithText("What would you like to do?")
-    .WithButton("Open Website", ButtonType.Url, "https://example.com")
+    .WithButton("What would you like to do?", ButtonType.Url, "https://example.com")
     .Build();
 ```
 

--- a/docs/messaging-model.md
+++ b/docs/messaging-model.md
@@ -128,7 +128,7 @@ new Message
 
 Different channels support different kinds of content. SMS carries plain text, email supports HTML and attachments, chat apps handle media and locations, and push notifications can carry structured JSON payloads. The framework models this with separate content classes, each implementing `IMessageContent`. When you build a message, you choose the content type that matches your channel — and the schema validator confirms the connector supports it.
 
-Eight content classes implement `IMessageContent`. The base class `MessageContent` provides a static factory `MessageContent.Create(IMessageContent?)` that auto-selects the correct subclass.
+Twelve content classes implement `IMessageContent`. The base class `MessageContent` provides a static factory `MessageContent.Create(IMessageContent?)` that auto-selects the correct subclass.
 
 ### TextContent
 
@@ -256,6 +256,110 @@ new Message { Content = multipart };
 ```
 
 Each part can be any `IMessageContentPart` implementation: `TextContentPart`, `HtmlContentPart`.
+
+### ButtonContent
+
+For sending interactive buttons in chat channels. Each button has a `Text`, `ButtonType` (`Url`, `Postback`, or `PhoneNumber`), and an optional `Value` (URL, callback data, or phone number):
+
+```csharp
+// Using the convenience method on MessageBuilder
+new MessageBuilder()
+    .WithButton("Open Website", ButtonType.Url, "https://example.com")
+    .Build();
+
+// Using explicit constructor
+new Message { Content = new ButtonContent("Open Website", ButtonType.Url, "https://example.com") };
+```
+
+Properties: `Text`, `ButtonType`, `Value`.
+
+### QuickReplyContent
+
+For offering a single quick, one-tap reply option that appears above the keyboard in chat apps:
+
+```csharp
+// Using the convenience method on MessageBuilder
+new MessageBuilder()
+    .WithQuickReply("Yes", "YES_PAYLOAD")
+    .Build();
+
+// With sub-builder configuration
+new MessageBuilder()
+    .WithQuickReply(qr => qr
+        .WithTitle("Maybe")
+        .WithPayload("MAYBE_PAYLOAD"))
+    .Build();
+
+// Using explicit constructor
+new Message { Content = new QuickReplyContent("No", "NO_PAYLOAD") };
+```
+
+Properties: `Title`, `Payload`, `ImageUrl`.
+
+### CarouselContent
+
+For sending a horizontal scrollable set of cards, each with an image, title, subtitle, and optional buttons (Facebook Messenger). Use the sub-builder API for a fluent construction:
+
+```csharp
+// Using the sub-builder API
+new MessageBuilder()
+    .WithCarousel(carousel => carousel
+        .AddCard("https://example.com/img1.jpg", "Product A", "Amazing", card =>
+            card.WithButton("Buy", ButtonType.Postback, "BUY_A")
+                .WithButton("Details", ButtonType.Url, "https://example.com/a"))
+        .AddCard("https://example.com/img2.jpg", "Product B", "Even better", card =>
+            card.WithButton("Buy", ButtonType.Postback, "BUY_B")
+                .WithButton("Details", ButtonType.Url, "https://example.com/b")))
+    .Build();
+
+// Using explicit construction
+var carousel = new CarouselContent();
+carousel.AddCard(new CarouselCard("Product A", "Amazing", "https://example.com/img1.jpg")
+{
+    Buttons = { new ButtonContent("Buy", ButtonType.Postback, "BUY_A") }
+});
+new Message { Content = carousel };
+```
+
+`CarouselCard` properties: `ImageUrl`, `Title`, `Subtitle`, `Buttons`.
+`CarouselContent` properties: `Cards` (read-only), `AddCard()`/`RemoveCard()`/`ClearCards()` for mutation.
+
+### ListPickerContent
+
+For sending a vertically-scrollable list of items the user can pick from (Facebook Messenger). Use the sub-builder API for a fluent construction:
+
+```csharp
+// Using the sub-builder API
+new MessageBuilder()
+    .WithListPicker(list => list
+        .WithStyle(ListPickerStyle.Compact)
+        .AddItem("Pizza", "Delicious cheese pizza")
+        .AddItem("Burger", "Juicy beef burger", payload: "ORDER_BURGER")
+        .AddItem(item => item
+            .WithTitle("Salad")
+            .WithDescription("Fresh garden salad")))
+    .Build();
+
+// Using explicit construction
+var list = new ListPickerContent("Our Menu", style: ListPickerStyle.Compact);
+list.AddItem(new ListPickerItem("Pizza", "Delicious cheese pizza"));
+new Message { Content = list };
+```
+
+`ListPickerStyle` values: `Inlined` (default), `Compact`, `Large`.
+`ListPickerItem` properties: `Title`, `Description`, `ImageUrl`, `Payload`.
+`ListPickerContent` properties: `Title`, `Subtitle`, `Style`, `Items`.
+
+### Channel support
+
+| Content type | Facebook Messenger | Telegram Bot |
+|---|---|---|
+| `ButtonContent` | Button template | InlineKeyboardMarkup |
+| `QuickReplyContent` | Quick Replies | ReplyKeyboardMarkup (one-time) |
+| `CarouselContent` | Generic template | — |
+| `ListPickerContent` | List template | — |
+
+Carousel and List picker content throw `NotSupportedException` on Telegram.
 
 ## Message properties
 

--- a/samples/facebook-messenger/src/Facebook/Support/FacebookSampleSupport.cs
+++ b/samples/facebook-messenger/src/Facebook/Support/FacebookSampleSupport.cs
@@ -68,8 +68,13 @@ public sealed class FacebookSampleSupport(ILoggerFactory loggerFactory, IMessagi
                     "facebook validate media",
                     FacebookChannelSchemas.MediaMessenger.ValidateMessage(CreateMediaMessage("USER-PSID", "https://example.com/welcome.png")));
                 break;
+            case "button":
+                SampleOutputHelper.PrintValidationResult(
+                    "facebook validate button",
+                    FacebookChannelSchemas.FacebookMessenger.ValidateMessage(CreateButtonMessage("USER-PSID")));
+                break;
             default:
-                Console.WriteLine($"Unsupported validation kind '{kind}'. Use text or media.");
+                Console.WriteLine($"Unsupported validation kind '{kind}'. Use text, media, or button.");
                 break;
         }
     }
@@ -110,12 +115,18 @@ public sealed class FacebookSampleSupport(ILoggerFactory loggerFactory, IMessagi
         }
         var kind = SampleConsolePrompts.Select(
             "Select the Facebook message type",
-            ["Text", "Media"],
+            ["Text", "Media", "Button", "Quick Reply", "Carousel", "List Picker"],
             GetValue("MediaUrl", "FACEBOOK_MEDIA_URL") is null ? "Text" : "Media");
 
-        var message = kind == "Text"
-            ? BuildTextMessage(recipient)
-            : BuildMediaMessage(recipient);
+        var message = kind switch
+        {
+            "Text" => BuildTextMessage(recipient),
+            "Media" => BuildMediaMessage(recipient),
+            "Button" => BuildButtonMessage(recipient),
+            "Quick Reply" => BuildQuickReplyMessage(recipient),
+            "Carousel" => BuildCarouselMessage(recipient),
+            _ => BuildListPickerMessage(recipient)
+        };
 
         SampleOutputHelper.PrintSendResult($"facebook send {kind.ToLowerInvariant()}", await client.SendAsync("facebook", message, CancellationToken.None));
     }
@@ -193,6 +204,99 @@ public sealed class FacebookSampleSupport(ILoggerFactory loggerFactory, IMessagi
             SampleConsolePrompts.RequiredText("Media file name", "welcome.png"),
             SampleConsolePrompts.RequiredText("Media URL", defaultMediaUrl),
             SampleConsolePrompts.Select("Messaging type", ["UPDATE", "RESPONSE", "MESSAGE_TAG"], "UPDATE"));
+    }
+
+    private Message BuildButtonMessage(string recipientId)
+    {
+        var text = SampleConsolePrompts.RequiredText("Button text", "Click here");
+        var buttonType = SampleConsolePrompts.Select("Button type", ["Url", "Postback", "PhoneNumber"], "Url");
+        var value = buttonType == "Url"
+            ? SampleConsolePrompts.RequiredText("URL", "https://example.com")
+            : SampleConsolePrompts.OptionalText("Payload", "BTN_PAYLOAD");
+
+        return CreateButtonMessage(
+            recipientId,
+            SampleConsolePrompts.RequiredText("Message ID", "facebook-button-sample"),
+            text,
+            buttonType switch
+            {
+                "Url" => ButtonType.Url,
+                "Postback" => ButtonType.Postback,
+                _ => ButtonType.PhoneNumber
+            },
+            value);
+    }
+
+    private Message BuildQuickReplyMessage(string recipientId)
+    {
+        var title = SampleConsolePrompts.RequiredText("Quick reply title", "Start");
+        var payload = SampleConsolePrompts.OptionalText("Payload", "QR_PAYLOAD");
+        var imageUrl = SampleConsolePrompts.OptionalText("Image URL (optional)");
+
+        return CreateQuickReplyMessage(
+            recipientId,
+            SampleConsolePrompts.RequiredText("Message ID", "facebook-quickreply-sample"),
+            title,
+            payload,
+            imageUrl);
+    }
+
+    private Message BuildCarouselMessage(string recipientId)
+    {
+        var cardCount = SampleConsolePrompts.RequiredInt("Number of cards", 3);
+
+        var carousel = new CarouselContent();
+        for (int i = 1; i <= cardCount; i++)
+        {
+            Console.WriteLine($"--- Card {i} ---");
+            var card = new CarouselCard(
+                SampleConsolePrompts.RequiredText($"Card {i} title", $"Card {i}"),
+                SampleConsolePrompts.OptionalText($"Card {i} subtitle"),
+                SampleConsolePrompts.OptionalText($"Card {i} image URL"));
+            carousel.AddCard(card);
+        }
+
+        return new Message
+        {
+            Id = SampleConsolePrompts.RequiredText("Message ID", "facebook-carousel-sample"),
+            Receiver = Endpoint.User(recipientId),
+            Content = carousel,
+            Properties = new Dictionary<string, MessageProperty>
+            {
+                ["MessagingType"] = new("MessagingType", "RESPONSE")
+            }
+        };
+    }
+
+    private Message BuildListPickerMessage(string recipientId)
+    {
+        var title = SampleConsolePrompts.RequiredText("List title", "Options");
+        var style = SampleConsolePrompts.Select("List style", ["Compact", "Large"], "Compact");
+        var itemCount = SampleConsolePrompts.RequiredInt("Number of items", 3);
+
+        var picker = new ListPickerContent(title,
+            SampleConsolePrompts.OptionalText("Subtitle (optional)"),
+            style: style == "Compact" ? ListPickerStyle.Compact : ListPickerStyle.Large);
+
+        for (int i = 1; i <= itemCount; i++)
+        {
+            Console.WriteLine($"--- Item {i} ---");
+            picker.AddItem(new ListPickerItem(
+                SampleConsolePrompts.RequiredText($"Item {i} title", $"Option {i}"),
+                SampleConsolePrompts.OptionalText($"Item {i} description"),
+                SampleConsolePrompts.OptionalText($"Item {i} image URL")));
+        }
+
+        return new Message
+        {
+            Id = SampleConsolePrompts.RequiredText("Message ID", "facebook-list-sample"),
+            Receiver = Endpoint.User(recipientId),
+            Content = picker,
+            Properties = new Dictionary<string, MessageProperty>
+            {
+                ["MessagingType"] = new("MessagingType", "RESPONSE")
+            }
+        };
     }
 
     private static Message CreateTextMessage(string recipientId)
@@ -280,6 +384,50 @@ public sealed class FacebookSampleSupport(ILoggerFactory loggerFactory, IMessagi
         {
             Console.WriteLine($"  - id={message.Id}, from={message.Sender?.Address}, to={message.Receiver?.Address}, content={message.Content?.GetType().Name}");
         }
+    }
+
+    private static Message CreateButtonMessage(string recipientId)
+        => CreateButtonMessage(recipientId, "facebook-button-sample", "Click here", ButtonType.Url, "https://example.com");
+
+    private static Message CreateButtonMessage(
+        string recipientId,
+        string id,
+        string text,
+        ButtonType buttonType,
+        string? value)
+    {
+        return new Message
+        {
+            Id = id,
+            Receiver = Endpoint.User(recipientId),
+            Content = new ButtonContent(text, buttonType, value),
+            Properties = new Dictionary<string, MessageProperty>
+            {
+                ["MessagingType"] = new("MessagingType", "RESPONSE")
+            }
+        };
+    }
+
+    private static Message CreateQuickReplyMessage(string recipientId)
+        => CreateQuickReplyMessage(recipientId, "facebook-quickreply-sample", "Start", "QR_PAYLOAD", null);
+
+    private static Message CreateQuickReplyMessage(
+        string recipientId,
+        string id,
+        string title,
+        string? payload,
+        string? imageUrl)
+    {
+        return new Message
+        {
+            Id = id,
+            Receiver = Endpoint.User(recipientId),
+            Content = new QuickReplyContent(title, payload, imageUrl),
+            Properties = new Dictionary<string, MessageProperty>
+            {
+                ["MessagingType"] = new("MessagingType", "RESPONSE")
+            }
+        };
     }
 
     private const string DefaultReceivePayload = """

--- a/samples/multi-connector/src/MultiConnector/Dtos/MessageContentDto.cs
+++ b/samples/multi-connector/src/MultiConnector/Dtos/MessageContentDto.cs
@@ -19,4 +19,33 @@ public class MessageContentDto
     public double? Latitude { get; set; }
     public double? Longitude { get; set; }
     public int? LivePeriod { get; set; }
+
+    public string? ButtonText { get; set; }
+    public string? ButtonType { get; set; }
+    public string? ButtonValue { get; set; }
+
+    public string? QuickReplyTitle { get; set; }
+    public string? QuickReplyPayload { get; set; }
+    public string? QuickReplyImageUrl { get; set; }
+
+    public List<CarouselCardDto>? CarouselCards { get; set; }
+
+    public string? ListTitle { get; set; }
+    public string? ListSubtitle { get; set; }
+    public string? ListStyle { get; set; }
+    public List<ListPickerItemDto>? ListItems { get; set; }
+}
+
+public class CarouselCardDto
+{
+    public string? Title { get; set; }
+    public string? Subtitle { get; set; }
+    public string? ImageUrl { get; set; }
+}
+
+public class ListPickerItemDto
+{
+    public string? Title { get; set; }
+    public string? Description { get; set; }
+    public string? ImageUrl { get; set; }
 }

--- a/samples/multi-connector/src/MultiConnector/Mappers/MessageMapper.cs
+++ b/samples/multi-connector/src/MultiConnector/Mappers/MessageMapper.cs
@@ -97,6 +97,51 @@ public static class MessageMapper
 
                 return location;
 
+            case "button":
+                var buttonType = (dto.ButtonType ?? "url").ToLowerInvariant() switch
+                {
+                    "postback" => ButtonType.Postback,
+                    "phonenumber" => ButtonType.PhoneNumber,
+                    _ => ButtonType.Url
+                };
+
+                return new ButtonContent(dto.ButtonText ?? "Click", buttonType, dto.ButtonValue);
+
+            case "quickreply":
+                return new QuickReplyContent(
+                    dto.QuickReplyTitle ?? "Yes",
+                    dto.QuickReplyPayload,
+                    dto.QuickReplyImageUrl);
+
+            case "carousel":
+                var carousel = new CarouselContent();
+                if (dto.CarouselCards != null)
+                {
+                    foreach (var card in dto.CarouselCards)
+                    {
+                        carousel.AddCard(new CarouselCard(card.Title ?? "Card", card.Subtitle, card.ImageUrl));
+                    }
+                }
+                return carousel;
+
+            case "listpicker":
+                var style = (dto.ListStyle ?? "compact").ToLowerInvariant() switch
+                {
+                    "large" => ListPickerStyle.Large,
+                    "inlined" => ListPickerStyle.Inlined,
+                    _ => ListPickerStyle.Compact
+                };
+
+                var picker = new ListPickerContent(dto.ListTitle ?? "Options", dto.ListSubtitle, style: style);
+                if (dto.ListItems != null)
+                {
+                    foreach (var item in dto.ListItems)
+                    {
+                        picker.AddItem(new ListPickerItem(item.Title ?? "Item", item.Description, item.ImageUrl));
+                    }
+                }
+                return picker;
+
             case "text":
             default:
                 return new TextContent(dto.Text ?? string.Empty, dto.Encoding);

--- a/samples/telegram-bot/src/Telegram/Support/TelegramSampleSupport.cs
+++ b/samples/telegram-bot/src/Telegram/Support/TelegramSampleSupport.cs
@@ -69,8 +69,13 @@ public sealed class TelegramSampleSupport(ILoggerFactory loggerFactory, IMessagi
                     "telegram validate location",
                     TelegramChannelSchemas.TelegramBot.ValidateMessage(CreateLocationMessage("123456789", 45.4642, 9.1900)));
                 break;
+            case "button":
+                SampleOutputHelper.PrintValidationResult(
+                    "telegram validate button",
+                    TelegramChannelSchemas.TelegramBot.ValidateMessage(CreateButtonMessage("123456789")));
+                break;
             default:
-                Console.WriteLine($"Unsupported validation kind '{kind}'. Use text or location.");
+                Console.WriteLine($"Unsupported validation kind '{kind}'. Use text, location, or button.");
                 break;
         }
     }
@@ -109,12 +114,14 @@ public sealed class TelegramSampleSupport(ILoggerFactory loggerFactory, IMessagi
             return;
         }
 
-        var kind = SampleConsolePrompts.Select("Select the Telegram message type", ["Text", "Media", "Location"], "Text");
+        var kind = SampleConsolePrompts.Select("Select the Telegram message type", ["Text", "Media", "Location", "Button", "Quick Reply"], "Text");
         var message = kind switch
         {
             "Text" => BuildTextMessage(chatId),
             "Media" => BuildMediaMessage(chatId),
-            _ => BuildLocationMessage(chatId)
+            "Location" => BuildLocationMessage(chatId),
+            "Button" => BuildButtonMessage(chatId),
+            _ => BuildQuickReplyMessage(chatId)
         };
 
         SampleOutputHelper.PrintSendResult($"telegram send {kind.ToLowerInvariant()}", await client.SendAsync("telegram", message, CancellationToken.None));
@@ -239,6 +246,61 @@ public sealed class TelegramSampleSupport(ILoggerFactory loggerFactory, IMessagi
             Id = id,
             Receiver = Endpoint.Id(chatId),
             Content = new LocationContent(latitude, longitude).WithLivePeriod(livePeriod)
+        };
+    }
+
+    private Message BuildButtonMessage(string chatId)
+    {
+        var text = SampleConsolePrompts.RequiredText("Button text", "Click here");
+        var buttonType = SampleConsolePrompts.Select("Button type", ["Url", "Postback"], "Url");
+        var value = buttonType == "Url"
+            ? SampleConsolePrompts.RequiredText("URL", "https://example.com")
+            : SampleConsolePrompts.RequiredText("Callback data", "BTN_PAYLOAD");
+
+        return CreateButtonMessage(
+            SampleConsolePrompts.RequiredText("Message ID", "telegram-button-sample"),
+            chatId,
+            text,
+            buttonType == "Url" ? ButtonType.Url : ButtonType.Postback,
+            value);
+    }
+
+    private Message BuildQuickReplyMessage(string chatId)
+    {
+        var title = SampleConsolePrompts.RequiredText("Quick reply title", "Yes");
+
+        return new Message
+        {
+            Id = SampleConsolePrompts.RequiredText("Message ID", "telegram-quickreply-sample"),
+            Receiver = Endpoint.Id(chatId),
+            Content = new QuickReplyContent(title, title),
+            Properties = new Dictionary<string, MessageProperty>
+            {
+                ["ParseMode"] = new("ParseMode", "Html")
+            }
+        };
+    }
+
+    private static Message CreateButtonMessage(string chatId)
+        => CreateButtonMessage("telegram-button-sample", chatId, "Click here", ButtonType.Url, "https://example.com");
+
+    private static Message CreateButtonMessage(
+        string id,
+        string chatId,
+        string text,
+        ButtonType buttonType,
+        string? value)
+    {
+        return new Message
+        {
+            Id = id,
+            Receiver = Endpoint.Id(chatId),
+            Content = new ButtonContent(text, buttonType, value),
+            Properties = new Dictionary<string, MessageProperty>
+            {
+                ["ParseMode"] = new("ParseMode", "Html"),
+                ["DisableWebPagePreview"] = new("DisableWebPagePreview", true)
+            }
         };
     }
 

--- a/src/Deveel.Messaging.Abstractions/Messaging/ButtonContent.cs
+++ b/src/Deveel.Messaging.Abstractions/Messaging/ButtonContent.cs
@@ -1,0 +1,51 @@
+namespace Deveel.Messaging {
+	/// <summary>
+	/// Represents a clickable button that can be attached to a message.
+	/// </summary>
+	public class ButtonContent : MessageContent, IButtonContent {
+		/// <summary>
+		/// Constructs the content with the given text, type, and optional value.
+		/// </summary>
+		/// <param name="text">The text displayed on the button.</param>
+		/// <param name="buttonType">The type of the button.</param>
+		/// <param name="value">An optional value such as a URL or callback payload.</param>
+		public ButtonContent(string text, ButtonType buttonType, string? value = null) {
+			Text = text;
+			ButtonType = buttonType;
+			Value = value;
+		}
+
+		/// <summary>
+		/// Constructs the content by copying from the given interface instance.
+		/// </summary>
+		/// <param name="content">The source instance of <see cref="IButtonContent"/>.</param>
+		public ButtonContent(IButtonContent content)
+			: this(content?.Text!, content?.ButtonType ?? default, content?.Value) {
+		}
+
+		/// <summary>
+		/// Initializes a new instance with default values.
+		/// </summary>
+		public ButtonContent() {
+		}
+
+		/// <inheritdoc/>
+		public override MessageContentType ContentType => MessageContentType.Button;
+
+		/// <summary>
+		/// Gets or sets the text displayed on the button.
+		/// </summary>
+		public string Text { get; set; } = string.Empty;
+
+		/// <summary>
+		/// Gets or sets the type of the button.
+		/// </summary>
+		public ButtonType ButtonType { get; set; }
+
+		/// <summary>
+		/// Gets or sets the value associated with the button,
+		/// such as a URL or callback payload.
+		/// </summary>
+		public string? Value { get; set; }
+	}
+}

--- a/src/Deveel.Messaging.Abstractions/Messaging/ButtonType.cs
+++ b/src/Deveel.Messaging.Abstractions/Messaging/ButtonType.cs
@@ -1,0 +1,13 @@
+namespace Deveel.Messaging {
+	/// <summary>
+	/// Defines the types of buttons that can be used in interactive content.
+	/// </summary>
+	public enum ButtonType {
+		/// <summary>Opens a URL when clicked.</summary>
+		Url = 0,
+		/// <summary>Sends a callback payload to the bot.</summary>
+		Postback = 1,
+		/// <summary>Prompts the user to make a phone call.</summary>
+		PhoneNumber = 2
+	}
+}

--- a/src/Deveel.Messaging.Abstractions/Messaging/CarouselBuilder.cs
+++ b/src/Deveel.Messaging.Abstractions/Messaging/CarouselBuilder.cs
@@ -1,0 +1,54 @@
+namespace Deveel.Messaging {
+	/// <summary>
+	/// A builder for constructing <see cref="CarouselContent"/> instances
+	/// using a fluent API with sub-builders for individual cards.
+	/// </summary>
+	public class CarouselBuilder {
+		private readonly List<CarouselCard> _cards = new();
+
+		/// <summary>
+		/// Adds a card to the carousel, configured by a sub-builder.
+		/// </summary>
+		/// <param name="configure">An action to configure the card.</param>
+		/// <returns>This instance for chaining.</returns>
+		/// <exception cref="ArgumentNullException">
+		/// Thrown if <paramref name="configure"/> is <c>null</c>.
+		/// </exception>
+		public CarouselBuilder AddCard(Action<CarouselCardBuilder> configure) {
+			ArgumentNullException.ThrowIfNull(configure, nameof(configure));
+
+			var cardBuilder = new CarouselCardBuilder();
+			configure(cardBuilder);
+			_cards.Add(cardBuilder.Build());
+			return this;
+		}
+
+		/// <summary>
+		/// Adds a card to the carousel with the given properties
+		/// and an optional sub-builder for buttons.
+		/// </summary>
+		/// <param name="imageUrl">The URL of an image to display on the card.</param>
+		/// <param name="title">The title of the card.</param>
+		/// <param name="subtitle">An optional subtitle.</param>
+		/// <param name="configure">
+		/// An optional action to configure the card (e.g., add buttons).
+		/// </param>
+		/// <returns>This instance for chaining.</returns>
+		public CarouselBuilder AddCard(string? imageUrl, string? title, string? subtitle = null, Action<CarouselCardBuilder>? configure = null) {
+			var cardBuilder = new CarouselCardBuilder {
+				ImageUrl = imageUrl,
+				Title = title,
+				Subtitle = subtitle
+			};
+			configure?.Invoke(cardBuilder);
+			_cards.Add(cardBuilder.Build());
+			return this;
+		}
+
+		/// <summary>
+		/// Builds a <see cref="CarouselContent"/> instance from the configured cards.
+		/// </summary>
+		/// <returns>A new <see cref="CarouselContent"/>.</returns>
+		public CarouselContent Build() => new(_cards);
+	}
+}

--- a/src/Deveel.Messaging.Abstractions/Messaging/CarouselCard.cs
+++ b/src/Deveel.Messaging.Abstractions/Messaging/CarouselCard.cs
@@ -1,0 +1,56 @@
+namespace Deveel.Messaging {
+	/// <summary>
+	/// Represents a single card within a carousel content.
+	/// </summary>
+	public class CarouselCard : ICarouselCard {
+		/// <summary>
+		/// Constructs the card with the given title, subtitle, and image URL.
+		/// </summary>
+		/// <param name="title">The title of the card.</param>
+		/// <param name="subtitle">An optional subtitle.</param>
+		/// <param name="imageUrl">An optional URL of an image.</param>
+		public CarouselCard(string? title = null, string? subtitle = null, string? imageUrl = null) {
+			Title = title;
+			Subtitle = subtitle;
+			ImageUrl = imageUrl;
+		}
+
+		/// <summary>
+		/// Constructs the card by copying from the given interface instance.
+		/// </summary>
+		/// <param name="card">The source instance of <see cref="ICarouselCard"/>.</param>
+		public CarouselCard(ICarouselCard card) {
+			Title = card.Title;
+			Subtitle = card.Subtitle;
+			ImageUrl = card.ImageUrl;
+			foreach (var button in card.Buttons)
+				Buttons.Add(new ButtonContent(button));
+		}
+
+		/// <summary>
+		/// Initializes a new instance with default values.
+		/// </summary>
+		public CarouselCard() {
+		}
+
+		/// <summary>
+		/// Gets or sets the title of the card.
+		/// </summary>
+		public string? Title { get; set; }
+
+		/// <summary>
+		/// Gets or sets the subtitle of the card.
+		/// </summary>
+		public string? Subtitle { get; set; }
+
+		/// <summary>
+		/// Gets or sets the URL of an image displayed on the card.
+		/// </summary>
+		public string? ImageUrl { get; set; }
+
+		/// <summary>
+		/// Gets or sets the list of buttons attached to the card.
+		/// </summary>
+		public IList<IButtonContent> Buttons { get; set; } = new List<IButtonContent>();
+	}
+}

--- a/src/Deveel.Messaging.Abstractions/Messaging/CarouselCardBuilder.cs
+++ b/src/Deveel.Messaging.Abstractions/Messaging/CarouselCardBuilder.cs
@@ -1,0 +1,46 @@
+namespace Deveel.Messaging {
+	/// <summary>
+	/// A builder for constructing <see cref="CarouselCard"/> instances
+	/// using a fluent API.
+	/// </summary>
+	public class CarouselCardBuilder {
+		private readonly List<IButtonContent> _buttons = new();
+
+		/// <summary>
+		/// Gets or sets the URL of an image displayed on the card.
+		/// </summary>
+		public string? ImageUrl { get; set; }
+
+		/// <summary>
+		/// Gets or sets the title of the card.
+		/// </summary>
+		public string? Title { get; set; }
+
+		/// <summary>
+		/// Gets or sets the subtitle of the card.
+		/// </summary>
+		public string? Subtitle { get; set; }
+
+		/// <summary>
+		/// Adds a button to the card.
+		/// </summary>
+		/// <param name="text">The text displayed on the button.</param>
+		/// <param name="buttonType">The type of the button.</param>
+		/// <param name="value">An optional value (URL, callback data, etc.).</param>
+		/// <returns>This instance for chaining.</returns>
+		public CarouselCardBuilder WithButton(string text, ButtonType buttonType, string? value = null) {
+			_buttons.Add(new ButtonContent(text, buttonType, value));
+			return this;
+		}
+
+		/// <summary>
+		/// Builds a <see cref="CarouselCard"/> instance from the configured values.
+		/// </summary>
+		/// <returns>A new <see cref="CarouselCard"/>.</returns>
+		public CarouselCard Build() {
+			return new CarouselCard(Title, Subtitle, ImageUrl) {
+				Buttons = _buttons
+			};
+		}
+	}
+}

--- a/src/Deveel.Messaging.Abstractions/Messaging/CarouselContent.cs
+++ b/src/Deveel.Messaging.Abstractions/Messaging/CarouselContent.cs
@@ -1,0 +1,73 @@
+namespace Deveel.Messaging {
+	/// <summary>
+	/// Represents a carousel of interactive cards that can
+	/// be scrolled through by the user.
+	/// </summary>
+	public class CarouselContent : MessageContent, ICarouselContent {
+		/// <summary>
+		/// Constructs the content with a collection of cards.
+		/// </summary>
+		/// <param name="cards">The collection of cards to include.</param>
+		/// <exception cref="ArgumentNullException">
+		/// Thrown if <paramref name="cards"/> is <c>null</c>.
+		/// </exception>
+		public CarouselContent(IEnumerable<ICarouselCard> cards) {
+			ArgumentNullException.ThrowIfNull(cards, nameof(cards));
+			_cards = new List<ICarouselCard>(cards);
+		}
+
+		/// <summary>
+		/// Constructs the content by copying from the given interface instance.
+		/// </summary>
+		/// <param name="content">The source instance of <see cref="ICarouselContent"/>.</param>
+		public CarouselContent(ICarouselContent content)
+			: this(content?.Cards ?? Enumerable.Empty<ICarouselCard>()) {
+		}
+
+		/// <summary>
+		/// Initializes a new empty instance.
+		/// </summary>
+		public CarouselContent() {
+		}
+
+		/// <inheritdoc/>
+		public override MessageContentType ContentType => MessageContentType.Carousel;
+
+		private readonly List<ICarouselCard> _cards = new();
+
+		/// <summary>
+		/// Gets a read-only list of cards in the carousel.
+		/// </summary>
+		public IReadOnlyList<ICarouselCard> Cards => _cards.AsReadOnly();
+
+		/// <summary>
+		/// Adds a card to the carousel.
+		/// </summary>
+		/// <param name="card">The card to add.</param>
+		/// <exception cref="ArgumentNullException">
+		/// Thrown if <paramref name="card"/> is <c>null</c>.
+		/// </exception>
+		public void AddCard(ICarouselCard card) {
+			ArgumentNullException.ThrowIfNull(card, nameof(card));
+			_cards.Add(card);
+		}
+
+		/// <summary>
+		/// Removes a card from the carousel.
+		/// </summary>
+		/// <param name="card">The card to remove.</param>
+		/// <returns>
+		/// <c>true</c> if the card was removed; otherwise <c>false</c>.
+		/// </returns>
+		public bool RemoveCard(ICarouselCard card) {
+			return _cards.Remove(card);
+		}
+
+		/// <summary>
+		/// Removes all cards from the carousel.
+		/// </summary>
+		public void ClearCards() {
+			_cards.Clear();
+		}
+	}
+}

--- a/src/Deveel.Messaging.Abstractions/Messaging/IButtonContent.cs
+++ b/src/Deveel.Messaging.Abstractions/Messaging/IButtonContent.cs
@@ -1,0 +1,23 @@
+namespace Deveel.Messaging {
+	/// <summary>
+	/// Represents a content that provides a clickable button
+	/// in a message.
+	/// </summary>
+	public interface IButtonContent : IInteractiveContent {
+		/// <summary>
+		/// Gets the text displayed on the button.
+		/// </summary>
+		string Text { get; }
+
+		/// <summary>
+		/// Gets the type of the button that defines its behavior.
+		/// </summary>
+		ButtonType ButtonType { get; }
+
+		/// <summary>
+		/// Gets the value associated with the button,
+		/// such as a URL or callback payload.
+		/// </summary>
+		string? Value { get; }
+	}
+}

--- a/src/Deveel.Messaging.Abstractions/Messaging/ICarouselCard.cs
+++ b/src/Deveel.Messaging.Abstractions/Messaging/ICarouselCard.cs
@@ -1,0 +1,26 @@
+namespace Deveel.Messaging {
+	/// <summary>
+	/// Represents a single card in a carousel of interactive elements.
+	/// </summary>
+	public interface ICarouselCard {
+		/// <summary>
+		/// Gets the title of the card.
+		/// </summary>
+		string? Title { get; }
+
+		/// <summary>
+		/// Gets an optional subtitle displayed below the title.
+		/// </summary>
+		string? Subtitle { get; }
+
+		/// <summary>
+		/// Gets an optional URL of an image to display on the card.
+		/// </summary>
+		string? ImageUrl { get; }
+
+		/// <summary>
+		/// Gets a list of buttons attached to the card.
+		/// </summary>
+		IList<IButtonContent> Buttons { get; }
+	}
+}

--- a/src/Deveel.Messaging.Abstractions/Messaging/ICarouselContent.cs
+++ b/src/Deveel.Messaging.Abstractions/Messaging/ICarouselContent.cs
@@ -1,0 +1,12 @@
+namespace Deveel.Messaging {
+	/// <summary>
+	/// Represents a carousel of interactive cards that can
+	/// be scrolled through by the user.
+	/// </summary>
+	public interface ICarouselContent : IInteractiveContent {
+		/// <summary>
+		/// Gets a read-only list of cards in the carousel.
+		/// </summary>
+		IReadOnlyList<ICarouselCard> Cards { get; }
+	}
+}

--- a/src/Deveel.Messaging.Abstractions/Messaging/IInteractiveContent.cs
+++ b/src/Deveel.Messaging.Abstractions/Messaging/IInteractiveContent.cs
@@ -1,0 +1,8 @@
+namespace Deveel.Messaging {
+	/// <summary>
+	/// A marker interface for content types that support interactive
+	/// elements such as buttons, quick replies, carousels, and list pickers.
+	/// </summary>
+	public interface IInteractiveContent : IMessageContent {
+	}
+}

--- a/src/Deveel.Messaging.Abstractions/Messaging/IListPickerContent.cs
+++ b/src/Deveel.Messaging.Abstractions/Messaging/IListPickerContent.cs
@@ -1,0 +1,27 @@
+namespace Deveel.Messaging {
+	/// <summary>
+	/// Represents a list picker content that allows the user
+	/// to select from a vertical list of items.
+	/// </summary>
+	public interface IListPickerContent : IInteractiveContent {
+		/// <summary>
+		/// Gets the title of the list picker.
+		/// </summary>
+		string? Title { get; }
+
+		/// <summary>
+		/// Gets an optional subtitle displayed above the list.
+		/// </summary>
+		string? Subtitle { get; }
+
+		/// <summary>
+		/// Gets a read-only list of selectable items.
+		/// </summary>
+		IReadOnlyList<IListPickerItem> Items { get; }
+
+		/// <summary>
+		/// Gets the display style of the list picker.
+		/// </summary>
+		ListPickerStyle Style { get; }
+	}
+}

--- a/src/Deveel.Messaging.Abstractions/Messaging/IListPickerItem.cs
+++ b/src/Deveel.Messaging.Abstractions/Messaging/IListPickerItem.cs
@@ -1,0 +1,26 @@
+namespace Deveel.Messaging {
+	/// <summary>
+	/// Represents a single item in a list picker selection.
+	/// </summary>
+	public interface IListPickerItem {
+		/// <summary>
+		/// Gets the title of the list item.
+		/// </summary>
+		string Title { get; }
+
+		/// <summary>
+		/// Gets an optional description of the item.
+		/// </summary>
+		string? Description { get; }
+
+		/// <summary>
+		/// Gets an optional URL of an image for the item.
+		/// </summary>
+		string? ImageUrl { get; }
+
+		/// <summary>
+		/// Gets an optional payload returned when the item is selected.
+		/// </summary>
+		string? Payload { get; }
+	}
+}

--- a/src/Deveel.Messaging.Abstractions/Messaging/IQuickReplyContent.cs
+++ b/src/Deveel.Messaging.Abstractions/Messaging/IQuickReplyContent.cs
@@ -1,0 +1,24 @@
+namespace Deveel.Messaging {
+	/// <summary>
+	/// Represents a quick reply option that can be presented
+	/// to the user as a selectable response.
+	/// </summary>
+	public interface IQuickReplyContent : IInteractiveContent {
+		/// <summary>
+		/// Gets the title of the quick reply option.
+		/// </summary>
+		string Title { get; }
+
+		/// <summary>
+		/// Gets an optional payload sent back when the quick
+		/// reply is selected.
+		/// </summary>
+		string? Payload { get; }
+
+		/// <summary>
+		/// Gets an optional URL of an image to display alongside
+		/// the quick reply option.
+		/// </summary>
+		string? ImageUrl { get; }
+	}
+}

--- a/src/Deveel.Messaging.Abstractions/Messaging/ListPickerBuilder.cs
+++ b/src/Deveel.Messaging.Abstractions/Messaging/ListPickerBuilder.cs
@@ -1,0 +1,75 @@
+namespace Deveel.Messaging {
+	/// <summary>
+	/// A builder for constructing <see cref="ListPickerContent"/> instances
+	/// using a fluent API with sub-builders for individual items.
+	/// </summary>
+	public class ListPickerBuilder {
+		private readonly List<ListPickerItem> _items = new();
+		private ListPickerStyle _style = ListPickerStyle.Inlined;
+
+		/// <summary>
+		/// Gets or sets the title of the list picker.
+		/// </summary>
+		public string? Title { get; set; }
+
+		/// <summary>
+		/// Gets or sets the subtitle displayed above the list.
+		/// </summary>
+		public string? Subtitle { get; set; }
+
+		/// <summary>
+		/// Gets or sets the display style of the list picker.
+		/// </summary>
+		public ListPickerStyle Style {
+			get => _style;
+			set => _style = value;
+		}
+
+		/// <summary>
+		/// Sets the display style of the list picker.
+		/// </summary>
+		/// <param name="style">The style value.</param>
+		/// <returns>This instance for chaining.</returns>
+		public ListPickerBuilder WithStyle(ListPickerStyle style) {
+			_style = style;
+			return this;
+		}
+
+		/// <summary>
+		/// Adds an item to the list picker with the given properties.
+		/// </summary>
+		/// <param name="title">The title of the item.</param>
+		/// <param name="description">An optional description.</param>
+		/// <param name="imageUrl">An optional image URL.</param>
+		/// <param name="payload">An optional payload returned when selected.</param>
+		/// <returns>This instance for chaining.</returns>
+		public ListPickerBuilder AddItem(string title, string? description = null, string? imageUrl = null, string? payload = null) {
+			_items.Add(new ListPickerItem(title, description, imageUrl, payload));
+			return this;
+		}
+
+		/// <summary>
+		/// Adds an item to the list picker, configured by a sub-builder.
+		/// </summary>
+		/// <param name="configure">An action to configure the item.</param>
+		/// <returns>This instance for chaining.</returns>
+		/// <exception cref="ArgumentNullException">
+		/// Thrown if <paramref name="configure"/> is <c>null</c>.
+		/// </exception>
+		public ListPickerBuilder AddItem(Action<ListPickerItemBuilder> configure) {
+			ArgumentNullException.ThrowIfNull(configure, nameof(configure));
+
+			var itemBuilder = new ListPickerItemBuilder();
+			configure(itemBuilder);
+			_items.Add(itemBuilder.Build());
+			return this;
+		}
+
+		/// <summary>
+		/// Builds a <see cref="ListPickerContent"/> instance from the configured values.
+		/// </summary>
+		/// <returns>A new <see cref="ListPickerContent"/>.</returns>
+		public ListPickerContent Build()
+			=> new ListPickerContent(Title, Subtitle, _items, _style);
+	}
+}

--- a/src/Deveel.Messaging.Abstractions/Messaging/ListPickerContent.cs
+++ b/src/Deveel.Messaging.Abstractions/Messaging/ListPickerContent.cs
@@ -1,0 +1,92 @@
+namespace Deveel.Messaging {
+	/// <summary>
+	/// Represents a list picker content that allows the user
+	/// to select from a vertical list of items.
+	/// </summary>
+	public class ListPickerContent : MessageContent, IListPickerContent {
+		/// <summary>
+		/// Constructs the content with the given title, subtitle, items, and style.
+		/// </summary>
+		/// <param name="title">The title of the list picker.</param>
+		/// <param name="subtitle">An optional subtitle.</param>
+		/// <param name="items">An optional collection of items.</param>
+		/// <param name="style">The display style of the list.</param>
+		public ListPickerContent(string? title = null, string? subtitle = null, IEnumerable<IListPickerItem>? items = null, ListPickerStyle style = ListPickerStyle.Inlined) {
+			Title = title;
+			Subtitle = subtitle;
+			Style = style;
+			if (items != null) {
+				_items = new List<IListPickerItem>(items);
+			}
+		}
+
+		/// <summary>
+		/// Constructs the content by copying from the given interface instance.
+		/// </summary>
+		/// <param name="content">The source instance of <see cref="IListPickerContent"/>.</param>
+		public ListPickerContent(IListPickerContent content)
+			: this(content?.Title, content?.Subtitle, content?.Items, content?.Style ?? ListPickerStyle.Inlined) {
+		}
+
+		/// <summary>
+		/// Initializes a new empty instance.
+		/// </summary>
+		public ListPickerContent() {
+		}
+
+		/// <inheritdoc/>
+		public override MessageContentType ContentType => MessageContentType.ListPicker;
+
+		private readonly List<IListPickerItem> _items = new();
+
+		/// <summary>
+		/// Gets or sets the title of the list picker.
+		/// </summary>
+		public string? Title { get; set; }
+
+		/// <summary>
+		/// Gets or sets the subtitle displayed above the list.
+		/// </summary>
+		public string? Subtitle { get; set; }
+
+		/// <summary>
+		/// Gets a read-only list of selectable items.
+		/// </summary>
+		public IReadOnlyList<IListPickerItem> Items => _items.AsReadOnly();
+
+		/// <summary>
+		/// Gets or sets the display style of the list.
+		/// </summary>
+		public ListPickerStyle Style { get; set; }
+
+		/// <summary>
+		/// Adds an item to the list picker.
+		/// </summary>
+		/// <param name="item">The item to add.</param>
+		/// <exception cref="ArgumentNullException">
+		/// Thrown if <paramref name="item"/> is <c>null</c>.
+		/// </exception>
+		public void AddItem(IListPickerItem item) {
+			ArgumentNullException.ThrowIfNull(item, nameof(item));
+			_items.Add(item);
+		}
+
+		/// <summary>
+		/// Removes an item from the list picker.
+		/// </summary>
+		/// <param name="item">The item to remove.</param>
+		/// <returns>
+		/// <c>true</c> if the item was removed; otherwise <c>false</c>.
+		/// </returns>
+		public bool RemoveItem(IListPickerItem item) {
+			return _items.Remove(item);
+		}
+
+		/// <summary>
+		/// Removes all items from the list picker.
+		/// </summary>
+		public void ClearItems() {
+			_items.Clear();
+		}
+	}
+}

--- a/src/Deveel.Messaging.Abstractions/Messaging/ListPickerItem.cs
+++ b/src/Deveel.Messaging.Abstractions/Messaging/ListPickerItem.cs
@@ -1,0 +1,54 @@
+namespace Deveel.Messaging {
+	/// <summary>
+	/// Represents a single item in a list picker selection.
+	/// </summary>
+	public class ListPickerItem : IListPickerItem {
+		/// <summary>
+		/// Constructs the item with the given title and optional details.
+		/// </summary>
+		/// <param name="title">The title of the item.</param>
+		/// <param name="description">An optional description.</param>
+		/// <param name="imageUrl">An optional URL of an image.</param>
+		/// <param name="payload">An optional payload returned when selected.</param>
+		public ListPickerItem(string title, string? description = null, string? imageUrl = null, string? payload = null) {
+			Title = title;
+			Description = description;
+			ImageUrl = imageUrl;
+			Payload = payload;
+		}
+
+		/// <summary>
+		/// Constructs the item by copying from the given interface instance.
+		/// </summary>
+		/// <param name="item">The source instance of <see cref="IListPickerItem"/>.</param>
+		public ListPickerItem(IListPickerItem item)
+			: this(item?.Title!, item?.Description, item?.ImageUrl, item?.Payload) {
+		}
+
+		/// <summary>
+		/// Initializes a new instance with default values.
+		/// </summary>
+		public ListPickerItem() {
+		}
+
+		/// <summary>
+		/// Gets or sets the title of the list item.
+		/// </summary>
+		public string Title { get; set; } = string.Empty;
+
+		/// <summary>
+		/// Gets or sets the optional description of the item.
+		/// </summary>
+		public string? Description { get; set; }
+
+		/// <summary>
+		/// Gets or sets the optional URL of an image for the item.
+		/// </summary>
+		public string? ImageUrl { get; set; }
+
+		/// <summary>
+		/// Gets or sets the optional payload returned when the item is selected.
+		/// </summary>
+		public string? Payload { get; set; }
+	}
+}

--- a/src/Deveel.Messaging.Abstractions/Messaging/ListPickerItemBuilder.cs
+++ b/src/Deveel.Messaging.Abstractions/Messaging/ListPickerItemBuilder.cs
@@ -1,0 +1,73 @@
+namespace Deveel.Messaging {
+	/// <summary>
+	/// A builder for constructing <see cref="ListPickerItem"/> instances
+	/// using a fluent API.
+	/// </summary>
+	public class ListPickerItemBuilder {
+		/// <summary>
+		/// Gets or sets the title of the list item.
+		/// </summary>
+		public string Title { get; set; } = string.Empty;
+
+		/// <summary>
+		/// Gets or sets the optional description of the item.
+		/// </summary>
+		public string? Description { get; set; }
+
+		/// <summary>
+		/// Gets or sets the optional URL of an image for the item.
+		/// </summary>
+		public string? ImageUrl { get; set; }
+
+		/// <summary>
+		/// Gets or sets the optional payload returned when the item is selected.
+		/// </summary>
+		public string? Payload { get; set; }
+
+		/// <summary>
+		/// Sets the title of the list item.
+		/// </summary>
+		/// <param name="title">The title text.</param>
+		/// <returns>This instance for chaining.</returns>
+		public ListPickerItemBuilder WithTitle(string title) {
+			Title = title;
+			return this;
+		}
+
+		/// <summary>
+		/// Sets the description of the list item.
+		/// </summary>
+		/// <param name="description">The description text.</param>
+		/// <returns>This instance for chaining.</returns>
+		public ListPickerItemBuilder WithDescription(string? description) {
+			Description = description;
+			return this;
+		}
+
+		/// <summary>
+		/// Sets the URL of an image for the list item.
+		/// </summary>
+		/// <param name="imageUrl">The image URL.</param>
+		/// <returns>This instance for chaining.</returns>
+		public ListPickerItemBuilder WithImageUrl(string? imageUrl) {
+			ImageUrl = imageUrl;
+			return this;
+		}
+
+		/// <summary>
+		/// Sets the payload returned when the item is selected.
+		/// </summary>
+		/// <param name="payload">The payload string.</param>
+		/// <returns>This instance for chaining.</returns>
+		public ListPickerItemBuilder WithPayload(string? payload) {
+			Payload = payload;
+			return this;
+		}
+
+		/// <summary>
+		/// Builds a <see cref="ListPickerItem"/> instance from the configured values.
+		/// </summary>
+		/// <returns>A new <see cref="ListPickerItem"/>.</returns>
+		public ListPickerItem Build() => new(Title, Description, ImageUrl, Payload);
+	}
+}

--- a/src/Deveel.Messaging.Abstractions/Messaging/ListPickerStyle.cs
+++ b/src/Deveel.Messaging.Abstractions/Messaging/ListPickerStyle.cs
@@ -1,0 +1,13 @@
+namespace Deveel.Messaging {
+	/// <summary>
+	/// Defines the visual style of a list picker component.
+	/// </summary>
+	public enum ListPickerStyle {
+		/// <summary>Items are displayed inline within the message.</summary>
+		Inlined = 0,
+		/// <summary>Items are displayed in a compact list.</summary>
+		Compact = 1,
+		/// <summary>Items are displayed in a large, expanded list.</summary>
+		Large = 2
+	}
+}

--- a/src/Deveel.Messaging.Abstractions/Messaging/MessageBuilder.cs
+++ b/src/Deveel.Messaging.Abstractions/Messaging/MessageBuilder.cs
@@ -194,6 +194,70 @@ namespace Deveel.Messaging
             => WithProperty(KnownMessageProperties.ReplyTo, messageId);
 
         /// <summary>
+        /// Sets the content as a single button.
+        /// </summary>
+        /// <param name="text">The text displayed on the button.</param>
+        /// <param name="buttonType">The type of the button.</param>
+        /// <param name="value">An optional value (URL, callback data, etc.).</param>
+        /// <returns>This instance for chaining.</returns>
+        public MessageBuilder WithButton(string text, ButtonType buttonType, string? value = null)
+            => WithContent(new ButtonContent(text, buttonType, value));
+
+        /// <summary>
+        /// Sets the content as a single quick reply option.
+        /// </summary>
+        /// <param name="title">The title of the quick reply.</param>
+        /// <param name="payload">An optional payload returned when selected.</param>
+        /// <param name="imageUrl">An optional image URL.</param>
+        /// <returns>This instance for chaining.</returns>
+        public MessageBuilder WithQuickReply(string title, string? payload = null, string? imageUrl = null)
+            => WithContent(new QuickReplyContent(title, payload, imageUrl));
+
+        /// <summary>
+        /// Sets the content as a quick reply and configures it with the given action.
+        /// </summary>
+        /// <param name="configure">An action to configure the quick reply.</param>
+        /// <returns>This instance for chaining.</returns>
+        public MessageBuilder WithQuickReply(Action<QuickReplyBuilder> configure)
+        {
+            var builder = new QuickReplyBuilder();
+            configure(builder);
+            return WithContent(builder.Build());
+        }
+
+        /// <summary>
+        /// Sets the content as a carousel of cards, configured with a sub-builder.
+        /// </summary>
+        /// <param name="configure">An action to configure the carousel.</param>
+        /// <returns>This instance for chaining.</returns>
+        public MessageBuilder WithCarousel(Action<CarouselBuilder> configure)
+        {
+            var builder = new CarouselBuilder();
+            configure(builder);
+            return WithContent(builder.Build());
+        }
+
+        /// <summary>
+        /// Sets the content as a carousel from a collection of cards.
+        /// </summary>
+        /// <param name="cards">The cards to include in the carousel.</param>
+        /// <returns>This instance for chaining.</returns>
+        public MessageBuilder WithCarousel(IEnumerable<CarouselCard> cards)
+            => WithContent(new CarouselContent(cards));
+
+        /// <summary>
+        /// Sets the content as a list picker, configured with a sub-builder.
+        /// </summary>
+        /// <param name="configure">An action to configure the list picker.</param>
+        /// <returns>This instance for chaining.</returns>
+        public MessageBuilder WithListPicker(Action<ListPickerBuilder> configure)
+        {
+            var builder = new ListPickerBuilder();
+            configure(builder);
+            return WithContent(builder.Build());
+        }
+
+        /// <summary>
         /// Builds the <see cref="Message"/> instance with the configured values.
         /// </summary>
         /// <returns>The constructed <see cref="Message"/>.</returns>

--- a/src/Deveel.Messaging.Abstractions/Messaging/MessageBuilder.cs
+++ b/src/Deveel.Messaging.Abstractions/Messaging/MessageBuilder.cs
@@ -220,6 +220,7 @@ namespace Deveel.Messaging
         /// <returns>This instance for chaining.</returns>
         public MessageBuilder WithQuickReply(Action<QuickReplyBuilder> configure)
         {
+            ArgumentNullException.ThrowIfNull(configure);
             var builder = new QuickReplyBuilder();
             configure(builder);
             return WithContent(builder.Build());
@@ -232,6 +233,7 @@ namespace Deveel.Messaging
         /// <returns>This instance for chaining.</returns>
         public MessageBuilder WithCarousel(Action<CarouselBuilder> configure)
         {
+            ArgumentNullException.ThrowIfNull(configure);
             var builder = new CarouselBuilder();
             configure(builder);
             return WithContent(builder.Build());
@@ -252,6 +254,7 @@ namespace Deveel.Messaging
         /// <returns>This instance for chaining.</returns>
         public MessageBuilder WithListPicker(Action<ListPickerBuilder> configure)
         {
+            ArgumentNullException.ThrowIfNull(configure);
             var builder = new ListPickerBuilder();
             configure(builder);
             return WithContent(builder.Build());

--- a/src/Deveel.Messaging.Abstractions/Messaging/MessageContent.cs
+++ b/src/Deveel.Messaging.Abstractions/Messaging/MessageContent.cs
@@ -19,6 +19,10 @@ namespace Deveel.Messaging {
 	// TODO: [JsonDerivedType(typeof(XmlContent), nameof(MessageContentType.Xml))]
 	[JsonDerivedType(typeof(MediaContent), nameof(MessageContentType.Media))]
 	[JsonDerivedType(typeof(LocationContent), nameof(MessageContentType.Location))]
+	[JsonDerivedType(typeof(ButtonContent), nameof(MessageContentType.Button))]
+	[JsonDerivedType(typeof(QuickReplyContent), nameof(MessageContentType.QuickReply))]
+	[JsonDerivedType(typeof(CarouselContent), nameof(MessageContentType.Carousel))]
+	[JsonDerivedType(typeof(ListPickerContent), nameof(MessageContentType.ListPicker))]
 	public abstract class MessageContent : IMessageContent {
 		/// <summary>
 		/// Gets the type of the content.
@@ -69,6 +73,19 @@ namespace Deveel.Messaging {
 			if (content.ContentType == MessageContentType.Location &&
 				content is ILocationContent locationContent)
 				return new LocationContent(locationContent);
+
+			if (content.ContentType == MessageContentType.Button &&
+				content is IButtonContent buttonContent)
+				return new ButtonContent(buttonContent);
+			if (content.ContentType == MessageContentType.QuickReply &&
+				content is IQuickReplyContent quickReplyContent)
+				return new QuickReplyContent(quickReplyContent);
+			if (content.ContentType == MessageContentType.Carousel &&
+				content is ICarouselContent carouselContent)
+				return new CarouselContent(carouselContent);
+			if (content.ContentType == MessageContentType.ListPicker &&
+				content is IListPickerContent listPickerContent)
+				return new ListPickerContent(listPickerContent);
 
 			throw new NotSupportedException($"The content of type '{content.ContentType}' is not supported");
 		}

--- a/src/Deveel.Messaging.Abstractions/Messaging/MessageContentType.cs
+++ b/src/Deveel.Messaging.Abstractions/Messaging/MessageContentType.cs
@@ -71,6 +71,26 @@ namespace Deveel.Messaging
 		/// This represents location data including latitude and longitude coordinates,
 		/// and optionally additional location-specific properties.
 		/// </remarks>
-		Location = 8
+		Location = 8,
+
+		/// <summary>
+		/// The content of the message is a button with a call-to-action.
+		/// </summary>
+		Button = 9,
+
+		/// <summary>
+		/// The content of the message is a quick reply for one-tap responses.
+		/// </summary>
+		QuickReply = 10,
+
+		/// <summary>
+		/// The content of the message is a carousel of horizontally scrollable cards.
+		/// </summary>
+		Carousel = 11,
+
+		/// <summary>
+		/// The content of the message is a structured list picker.
+		/// </summary>
+		ListPicker = 12
 	}
 }

--- a/src/Deveel.Messaging.Abstractions/Messaging/QuickReplyBuilder.cs
+++ b/src/Deveel.Messaging.Abstractions/Messaging/QuickReplyBuilder.cs
@@ -1,0 +1,58 @@
+namespace Deveel.Messaging {
+	/// <summary>
+	/// A builder for constructing <see cref="QuickReplyContent"/> instances
+	/// using a fluent API.
+	/// </summary>
+	public class QuickReplyBuilder {
+		/// <summary>
+		/// Gets or sets the title of the quick reply option.
+		/// </summary>
+		public string Title { get; set; } = string.Empty;
+
+		/// <summary>
+		/// Gets or sets the optional payload returned when selected.
+		/// </summary>
+		public string? Payload { get; set; }
+
+		/// <summary>
+		/// Gets or sets the optional URL of an image to display.
+		/// </summary>
+		public string? ImageUrl { get; set; }
+
+		/// <summary>
+		/// Sets the title of the quick reply option.
+		/// </summary>
+		/// <param name="title">The title text.</param>
+		/// <returns>This instance for chaining.</returns>
+		public QuickReplyBuilder WithTitle(string title) {
+			Title = title;
+			return this;
+		}
+
+		/// <summary>
+		/// Sets the payload returned when the quick reply is selected.
+		/// </summary>
+		/// <param name="payload">The payload string.</param>
+		/// <returns>This instance for chaining.</returns>
+		public QuickReplyBuilder WithPayload(string? payload) {
+			Payload = payload;
+			return this;
+		}
+
+		/// <summary>
+		/// Sets the URL of an image to display alongside the quick reply.
+		/// </summary>
+		/// <param name="imageUrl">The image URL.</param>
+		/// <returns>This instance for chaining.</returns>
+		public QuickReplyBuilder WithImageUrl(string? imageUrl) {
+			ImageUrl = imageUrl;
+			return this;
+		}
+
+		/// <summary>
+		/// Builds a <see cref="QuickReplyContent"/> instance from the configured values.
+		/// </summary>
+		/// <returns>A new <see cref="QuickReplyContent"/>.</returns>
+		public QuickReplyContent Build() => new(Title, Payload, ImageUrl);
+	}
+}

--- a/src/Deveel.Messaging.Abstractions/Messaging/QuickReplyContent.cs
+++ b/src/Deveel.Messaging.Abstractions/Messaging/QuickReplyContent.cs
@@ -1,0 +1,51 @@
+namespace Deveel.Messaging {
+	/// <summary>
+	/// Represents a quick reply option that can be presented
+	/// to the user as a selectable response.
+	/// </summary>
+	public class QuickReplyContent : MessageContent, IQuickReplyContent {
+		/// <summary>
+		/// Constructs the content with the given title and optional payload and image.
+		/// </summary>
+		/// <param name="title">The title of the quick reply option.</param>
+		/// <param name="payload">An optional payload sent back when selected.</param>
+		/// <param name="imageUrl">An optional URL of an image to display.</param>
+		public QuickReplyContent(string title, string? payload = null, string? imageUrl = null) {
+			Title = title;
+			Payload = payload;
+			ImageUrl = imageUrl;
+		}
+
+		/// <summary>
+		/// Constructs the content by copying from the given interface instance.
+		/// </summary>
+		/// <param name="content">The source instance of <see cref="IQuickReplyContent"/>.</param>
+		public QuickReplyContent(IQuickReplyContent content)
+			: this(content?.Title!, content?.Payload, content?.ImageUrl) {
+		}
+
+		/// <summary>
+		/// Initializes a new instance with default values.
+		/// </summary>
+		public QuickReplyContent() {
+		}
+
+		/// <inheritdoc/>
+		public override MessageContentType ContentType => MessageContentType.QuickReply;
+
+		/// <summary>
+		/// Gets or sets the title of the quick reply option.
+		/// </summary>
+		public string Title { get; set; } = string.Empty;
+
+		/// <summary>
+		/// Gets or sets the optional payload sent back when selected.
+		/// </summary>
+		public string? Payload { get; set; }
+
+		/// <summary>
+		/// Gets or sets the optional URL of an image to display.
+		/// </summary>
+		public string? ImageUrl { get; set; }
+	}
+}

--- a/src/Deveel.Messaging.Connector.Abstractions/Messaging/ChannelCapability.cs
+++ b/src/Deveel.Messaging.Connector.Abstractions/Messaging/ChannelCapability.cs
@@ -64,5 +64,11 @@ namespace Deveel.Messaging
 		/// messaging system.
 		/// </summary>
 		HealthCheck = 128,
+
+		/// <summary>
+		/// The connector supports interactive content types
+		/// such as buttons, quick replies, carousels, and list pickers.
+		/// </summary>
+		InteractiveContent = 256,
 	}
 }

--- a/src/Deveel.Messaging.Connector.Facebook/Deveel.Messaging.Connector.Facebook.csproj
+++ b/src/Deveel.Messaging.Connector.Facebook/Deveel.Messaging.Connector.Facebook.csproj
@@ -19,4 +19,8 @@
   <ItemGroup>
     <PackageReference Include="RestSharp" Version="112.1.0" />
   </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Deveel.Messaging.Connector.Facebook.XUnit" />
+  </ItemGroup>
 </Project>

--- a/src/Deveel.Messaging.Connector.Facebook/Messaging/FacebookChannelSchemas.cs
+++ b/src/Deveel.Messaging.Connector.Facebook/Messaging/FacebookChannelSchemas.cs
@@ -152,7 +152,8 @@ namespace Deveel.Messaging
                 ChannelCapability.SendMessages |
                 ChannelCapability.ReceiveMessages |
                 ChannelCapability.MediaAttachments |
-                ChannelCapability.HealthCheck)
+                ChannelCapability.HealthCheck |
+                ChannelCapability.InteractiveContent)
             .AddParameter(new ChannelParameter(FacebookConnectionParameters.PageAccessToken, DataType.String)
             {
                 IsRequired = true,
@@ -177,6 +178,10 @@ namespace Deveel.Messaging
             })
             .AddContentType(MessageContentType.PlainText)
             .AddContentType(MessageContentType.Media)
+            .AddContentType(MessageContentType.Button)
+            .AddContentType(MessageContentType.QuickReply)
+            .AddContentType(MessageContentType.Carousel)
+            .AddContentType(MessageContentType.ListPicker)
             .HandlesMessageEndpoint(EndpointType.UserId, e =>
             {
                 e.CanSend = true;

--- a/src/Deveel.Messaging.Connector.Facebook/Messaging/FacebookConnectorConstants.cs
+++ b/src/Deveel.Messaging.Connector.Facebook/Messaging/FacebookConnectorConstants.cs
@@ -60,5 +60,35 @@ namespace Deveel.Messaging
 		/// The base URL for Facebook Graph API
 		/// </summary>
 		public const string GraphApiBaseUrl = "https://graph.facebook.com";
+
+		/// <summary>
+		/// The maximum number of quick replies allowed per message (Facebook limit).
+		/// </summary>
+		public const int MaxQuickReplies = 13;
+
+		/// <summary>
+		/// The maximum number of buttons per template message (Facebook limit).
+		/// </summary>
+		public const int MaxButtonsPerMessage = 3;
+
+		/// <summary>
+		/// The maximum number of carousel cards (generic template elements).
+		/// </summary>
+		public const int MaxCarouselCards = 10;
+
+		/// <summary>
+		/// The maximum number of buttons per carousel card.
+		/// </summary>
+		public const int MaxButtonsPerCard = 3;
+
+		/// <summary>
+		/// The maximum number of list items.
+		/// </summary>
+		public const int MaxListItems = 4;
+
+		/// <summary>
+		/// The minimum number of list items.
+		/// </summary>
+		public const int MinListItems = 2;
 	}
 }

--- a/src/Deveel.Messaging.Connector.Facebook/Messaging/FacebookMessage.cs
+++ b/src/Deveel.Messaging.Connector.Facebook/Messaging/FacebookMessage.cs
@@ -24,5 +24,10 @@ namespace Deveel.Messaging
         /// Gets or sets the quick reply options available to the recipient.
         /// </summary>
         public List<FacebookQuickReply>? QuickReplies { get; set; }
+
+        /// <summary>
+        /// Gets or sets the structured template payload (button, generic, list).
+        /// </summary>
+        public FacebookTemplate? Template { get; set; }
     }
 }

--- a/src/Deveel.Messaging.Connector.Facebook/Messaging/FacebookMessageBuilder.cs
+++ b/src/Deveel.Messaging.Connector.Facebook/Messaging/FacebookMessageBuilder.cs
@@ -85,10 +85,36 @@ namespace Deveel.Messaging
                         }
                     };
                     break;
+
+                case MessageContentType.QuickReply when message.Content is IQuickReplyContent qrContent:
+                    fbMessage.QuickReplies = new List<FacebookQuickReply>
+                    {
+                        new FacebookQuickReply
+                        {
+                            ContentType = "text",
+                            Title = qrContent.Title,
+                            Payload = qrContent.Payload ?? qrContent.Title,
+                            ImageUrl = qrContent.ImageUrl
+                        }
+                    };
+                    break;
+
+                case MessageContentType.Button when message.Content is IButtonContent btnContent:
+                    fbMessage.Template = BuildButtonTemplate(btnContent);
+                    break;
+
+                case MessageContentType.Carousel when message.Content is ICarouselContent carouselContent:
+                    fbMessage.Template = BuildCarouselTemplate(carouselContent);
+                    break;
+
+                case MessageContentType.ListPicker when message.Content is IListPickerContent listContent:
+                    fbMessage.Template = BuildListTemplate(listContent);
+                    break;
             }
 
-            // Add quick replies if specified
-            if (message.Properties?.TryGetValue("QuickReplies", out var quickRepliesProperty) == true)
+            // Add quick replies if specified (backward compat with raw JSON property)
+            if (fbMessage.QuickReplies == null &&
+                message.Properties?.TryGetValue("QuickReplies", out var quickRepliesProperty) == true)
             {
                 var quickRepliesJson = quickRepliesProperty.Value?.ToString();
                 if (!string.IsNullOrEmpty(quickRepliesJson))
@@ -109,6 +135,123 @@ namespace Deveel.Messaging
             }
 
             return fbMessage;
+        }
+
+        private static FacebookTemplate BuildButtonTemplate(IButtonContent button)
+        {
+            return new FacebookTemplate
+            {
+                TemplateType = "button",
+                Payload = new Dictionary<string, object>
+                {
+                    ["template_type"] = "button",
+                    ["text"] = button.Text,
+                    ["buttons"] = new[]
+                    {
+                        MapButton(button)
+                    }
+                }
+            };
+        }
+
+        private static FacebookTemplate BuildCarouselTemplate(ICarouselContent carousel)
+        {
+            var elements = new List<object>();
+            foreach (var card in carousel.Cards)
+            {
+                var element = new Dictionary<string, object>
+                {
+                    ["title"] = card.Title ?? "",
+                };
+
+                if (!string.IsNullOrEmpty(card.Subtitle))
+                    element["subtitle"] = card.Subtitle;
+                if (!string.IsNullOrEmpty(card.ImageUrl))
+                    element["image_url"] = card.ImageUrl;
+                if (card.Buttons.Count > 0)
+                    element["buttons"] = card.Buttons.Select(MapButton).ToArray();
+
+                elements.Add(element);
+            }
+
+            return new FacebookTemplate
+            {
+                TemplateType = "generic",
+                Payload = new Dictionary<string, object>
+                {
+                    ["template_type"] = "generic",
+                    ["elements"] = elements
+                }
+            };
+        }
+
+        private static FacebookTemplate BuildListTemplate(IListPickerContent listPicker)
+        {
+            var elements = new List<object>();
+            foreach (var item in listPicker.Items)
+            {
+                var element = new Dictionary<string, object>
+                {
+                    ["title"] = item.Title
+                };
+
+                if (!string.IsNullOrEmpty(item.Description))
+                    element["subtitle"] = item.Description;
+                if (!string.IsNullOrEmpty(item.ImageUrl))
+                    element["image_url"] = item.ImageUrl;
+
+                elements.Add(element);
+            }
+
+            var payload = new Dictionary<string, object>
+            {
+                ["template_type"] = "list",
+                ["top_element_style"] = listPicker.Style switch
+                {
+                    ListPickerStyle.Inlined => "compact",
+                    ListPickerStyle.Compact => "compact",
+                    ListPickerStyle.Large => "large",
+                    _ => "large"
+                },
+                ["elements"] = elements
+            };
+
+            return new FacebookTemplate
+            {
+                TemplateType = "list",
+                Payload = payload
+            };
+        }
+
+        private static object MapButton(IButtonContent button)
+        {
+            return button.ButtonType switch
+            {
+                ButtonType.Url => new Dictionary<string, object>
+                {
+                    ["type"] = "web_url",
+                    ["title"] = button.Text,
+                    ["url"] = button.Value ?? ""
+                },
+                ButtonType.Postback => new Dictionary<string, object>
+                {
+                    ["type"] = "postback",
+                    ["title"] = button.Text,
+                    ["payload"] = button.Value ?? button.Text
+                },
+                ButtonType.PhoneNumber => new Dictionary<string, object>
+                {
+                    ["type"] = "phone_number",
+                    ["title"] = button.Text,
+                    ["payload"] = button.Value ?? ""
+                },
+                _ => new Dictionary<string, object>
+                {
+                    ["type"] = "postback",
+                    ["title"] = button.Text,
+                    ["payload"] = button.Value ?? button.Text
+                }
+            };
         }
 
         private static string GetAttachmentType(string mediaType)

--- a/src/Deveel.Messaging.Connector.Facebook/Messaging/FacebookService.cs
+++ b/src/Deveel.Messaging.Connector.Facebook/Messaging/FacebookService.cs
@@ -222,7 +222,7 @@ namespace Deveel.Messaging
                 content["text"] = message.Text;
             }
 
-            // Add attachment
+            // Add attachment (media or template — mutually exclusive in Facebook API)
             if (message.Attachment != null)
             {
                 content["attachment"] = new
@@ -235,9 +235,7 @@ namespace Deveel.Messaging
                     }
                 };
             }
-
-            // Add structured template attachment
-            if (message.Template != null)
+            else if (message.Template != null)
             {
                 content["attachment"] = new
                 {

--- a/src/Deveel.Messaging.Connector.Facebook/Messaging/FacebookService.cs
+++ b/src/Deveel.Messaging.Connector.Facebook/Messaging/FacebookService.cs
@@ -236,6 +236,16 @@ namespace Deveel.Messaging
                 };
             }
 
+            // Add structured template attachment
+            if (message.Template != null)
+            {
+                content["attachment"] = new
+                {
+                    type = "template",
+                    payload = message.Template.Payload
+                };
+            }
+
             // Add quick replies with Facebook specification compliance
             if (message.QuickReplies != null && message.QuickReplies.Count > 0)
             {

--- a/src/Deveel.Messaging.Connector.Facebook/Messaging/FacebookTemplate.cs
+++ b/src/Deveel.Messaging.Connector.Facebook/Messaging/FacebookTemplate.cs
@@ -1,0 +1,17 @@
+namespace Deveel.Messaging {
+	/// <summary>
+	/// Represents a structured template payload used in Facebook
+	/// Messenger messages (e.g., button, generic, list templates).
+	/// </summary>
+	public class FacebookTemplate {
+		/// <summary>
+		/// Gets or sets the type of the template (e.g., "button", "generic", "list").
+		/// </summary>
+		public string TemplateType { get; set; } = string.Empty;
+
+		/// <summary>
+		/// Gets or sets the payload dictionary containing template-specific data.
+		/// </summary>
+		public Dictionary<string, object> Payload { get; set; } = new();
+	}
+}

--- a/src/Deveel.Messaging.Connector.Telegram/Deveel.Messaging.Connector.Telegram.csproj
+++ b/src/Deveel.Messaging.Connector.Telegram/Deveel.Messaging.Connector.Telegram.csproj
@@ -27,4 +27,8 @@
   <ItemGroup>
     <PackageReference Include="Telegram.Bot" Version="22.0.0" />
   </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Deveel.Messaging.Connector.Telegram.XUnit" />
+  </ItemGroup>
 </Project>

--- a/src/Deveel.Messaging.Connector.Telegram/Messaging/TelegramBotConnector.cs
+++ b/src/Deveel.Messaging.Connector.Telegram/Messaging/TelegramBotConnector.cs
@@ -379,6 +379,28 @@ namespace Deveel.Messaging
 				IJsonContent jsonContent when TelegramMessageBuilder.IsLocationMessage(jsonContent) => await SendLocationFromJson(
 					chatId, jsonContent, disableNotification, replyToMessageId, replyMarkup, cancellationToken),
 
+				IButtonContent btnContent => await _telegramService.SendTextMessageAsync(
+					chatId,
+					btnContent.Text,
+					parseMode: parseMode,
+					disableWebPagePreview: disableWebPagePreview,
+					disableNotification: disableNotification,
+					replyToMessageId: replyToMessageId,
+					replyMarkup: TelegramMessageBuilder.CreateInlineKeyboardMarkup(new[] { btnContent }),
+					cancellationToken: cancellationToken),
+
+				IQuickReplyContent qrContent => await _telegramService.SendTextMessageAsync(
+					chatId,
+					qrContent.Title,
+					parseMode: parseMode,
+					disableWebPagePreview: disableWebPagePreview,
+					disableNotification: disableNotification,
+					replyToMessageId: replyToMessageId,
+					replyMarkup: TelegramMessageBuilder.CreateReplyKeyboardMarkup(new[] { qrContent }),
+					cancellationToken: cancellationToken),
+
+				ICarouselContent _ => throw new NotSupportedException("Carousel content is not supported by the Telegram Bot API"),
+				IListPickerContent _ => throw new NotSupportedException("List picker content is not supported by the Telegram Bot API"),
 				_ => throw new NotSupportedException($"Content type {message.Content?.GetType().Name} is not supported")
 			};
 		}

--- a/src/Deveel.Messaging.Connector.Telegram/Messaging/TelegramBotSchemaFactory.cs
+++ b/src/Deveel.Messaging.Connector.Telegram/Messaging/TelegramBotSchemaFactory.cs
@@ -27,7 +27,8 @@ namespace Deveel.Messaging
 					ChannelCapability.ReceiveMessages |
 					ChannelCapability.MessageStatusQuery |
 					ChannelCapability.HandleMessageState |
-					ChannelCapability.HealthCheck)
+					ChannelCapability.HealthCheck |
+					ChannelCapability.InteractiveContent)
             .AddParameter(new ChannelParameter(TelegramConnectionParameters.BotToken, DataType.String)
             {
                 IsRequired = true,
@@ -115,6 +116,8 @@ namespace Deveel.Messaging
 				.AddContentType(MessageContentType.Media)
 				.AddContentType(MessageContentType.Location)
 				.AddContentType(MessageContentType.Json) // For custom data
+				.AddContentType(MessageContentType.Button)
+				.AddContentType(MessageContentType.QuickReply)
 				.HandlesMessageEndpoint(EndpointType.Id, e =>
 				{
 					e.CanSend = true;

--- a/src/Deveel.Messaging.Connector.Telegram/Messaging/TelegramConnectorConstants.cs
+++ b/src/Deveel.Messaging.Connector.Telegram/Messaging/TelegramConnectorConstants.cs
@@ -64,5 +64,15 @@ namespace Deveel.Messaging
 		/// The maximum number of inline keyboard rows.
 		/// </summary>
 		public const int MaxInlineKeyboardRows = 100;
+
+		/// <summary>
+		/// The maximum number of buttons per inline keyboard row.
+		/// </summary>
+		public const int MaxInteractiveButtonsPerRow = 8;
+
+		/// <summary>
+		/// The maximum number of quick reply buttons.
+		/// </summary>
+		public const int MaxQuickReplies = 12;
 	}
 }

--- a/src/Deveel.Messaging.Connector.Telegram/Messaging/TelegramConnectorConstants.cs
+++ b/src/Deveel.Messaging.Connector.Telegram/Messaging/TelegramConnectorConstants.cs
@@ -66,11 +66,6 @@ namespace Deveel.Messaging
 		public const int MaxInlineKeyboardRows = 100;
 
 		/// <summary>
-		/// The maximum number of buttons per inline keyboard row.
-		/// </summary>
-		public const int MaxInteractiveButtonsPerRow = 8;
-
-		/// <summary>
 		/// The maximum number of quick reply buttons.
 		/// </summary>
 		public const int MaxQuickReplies = 12;

--- a/src/Deveel.Messaging.Connector.Telegram/Messaging/TelegramMessageBuilder.cs
+++ b/src/Deveel.Messaging.Connector.Telegram/Messaging/TelegramMessageBuilder.cs
@@ -131,6 +131,44 @@ namespace Deveel.Messaging
         }
 
         /// <summary>
+        /// Creates an <see cref="InlineKeyboardMarkup"/> from a collection of buttons.
+        /// </summary>
+        public static InlineKeyboardMarkup CreateInlineKeyboardMarkup(IReadOnlyList<IButtonContent> buttons)
+        {
+            var rows = new List<InlineKeyboardButton[]>();
+            foreach (var button in buttons)
+            {
+                var tgButton = button.ButtonType switch
+                {
+                    ButtonType.Url => InlineKeyboardButton.WithUrl(button.Text, button.Value ?? ""),
+                    ButtonType.Postback => InlineKeyboardButton.WithCallbackData(button.Text, button.Value ?? button.Text),
+                    _ => InlineKeyboardButton.WithCallbackData(button.Text, button.Value ?? button.Text)
+                };
+                rows.Add(new[] { tgButton });
+            }
+
+            return new InlineKeyboardMarkup(rows.ToArray());
+        }
+
+        /// <summary>
+        /// Creates a <see cref="ReplyKeyboardMarkup"/> from a collection of quick replies.
+        /// </summary>
+        public static ReplyKeyboardMarkup CreateReplyKeyboardMarkup(IReadOnlyList<IQuickReplyContent> quickReplies)
+        {
+            var rows = new List<KeyboardButton[]>();
+            foreach (var qr in quickReplies)
+            {
+                rows.Add(new[] { new KeyboardButton(qr.Title) });
+            }
+
+            return new ReplyKeyboardMarkup(rows.ToArray())
+            {
+                OneTimeKeyboard = true,
+                ResizeKeyboard = true
+            };
+        }
+
+        /// <summary>
         /// Creates an <see cref="InputFile"/> from a media content, preferring a URL over
         /// raw byte data.
         /// </summary>

--- a/src/Deveel.Messaging.Connector.Telegram/Messaging/TelegramMessageBuilder.cs
+++ b/src/Deveel.Messaging.Connector.Telegram/Messaging/TelegramMessageBuilder.cs
@@ -140,8 +140,11 @@ namespace Deveel.Messaging
             {
                 var tgButton = button.ButtonType switch
                 {
-                    ButtonType.Url => InlineKeyboardButton.WithUrl(button.Text, button.Value ?? ""),
+                    ButtonType.Url => string.IsNullOrWhiteSpace(button.Value)
+                        ? throw new ArgumentException("URL button requires a non-empty URL value", nameof(button))
+                        : InlineKeyboardButton.WithUrl(button.Text, button.Value),
                     ButtonType.Postback => InlineKeyboardButton.WithCallbackData(button.Text, button.Value ?? button.Text),
+                    ButtonType.PhoneNumber => throw new NotSupportedException("PhoneNumber buttons are not supported by Telegram inline keyboards"),
                     _ => InlineKeyboardButton.WithCallbackData(button.Text, button.Value ?? button.Text)
                 };
                 rows.Add(new[] { tgButton });

--- a/src/Deveel.Messaging.Connectors/Messaging/InteractiveContentValidator.cs
+++ b/src/Deveel.Messaging.Connectors/Messaging/InteractiveContentValidator.cs
@@ -1,0 +1,90 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Deveel.Messaging {
+	/// <summary>
+	/// Provides validation logic for interactive message content types
+	/// such as buttons, carousels, and list pickers.
+	/// </summary>
+	public static class InteractiveContentValidator {
+		/// <summary>
+		/// Validates that the number of buttons in a message does not
+		/// exceed the maximum allowed by the channel.
+		/// </summary>
+		/// <param name="message">The message to validate.</param>
+		/// <param name="maxButtons">The maximum number of buttons allowed.</param>
+		/// <returns>
+		/// A <see cref="ValidationResult"/> if validation fails; otherwise <c>null</c>.
+		/// </returns>
+		public static ValidationResult? ValidateButtonCount(IMessage message, int maxButtons) {
+			if (message.Content is IButtonContent && maxButtons < 1)
+				return new ValidationResult($"Button content requires at least 1 button, but the maximum is {maxButtons}", new[] { "Content" });
+
+			if (message.Content is ICarouselContent carousel) {
+				foreach (var card in carousel.Cards) {
+					if (card.Buttons.Count > maxButtons)
+						return new ValidationResult($"Carousel card buttons exceed the maximum of {maxButtons}", new[] { "Content.Cards" });
+				}
+			}
+
+			if (message.Content is IListPickerContent listPicker) {
+				if (listPicker.Items.Count > 0) {
+					var lastItem = listPicker.Items[listPicker.Items.Count - 1];
+				}
+			}
+
+			return null;
+		}
+
+		/// <summary>
+		/// Validates that the number of cards in a carousel does not
+		/// exceed the maximum allowed by the channel.
+		/// </summary>
+		/// <param name="carousel">The carousel content to validate.</param>
+		/// <param name="maxCards">The maximum number of cards allowed.</param>
+		/// <returns>
+		/// A <see cref="ValidationResult"/> if validation fails; otherwise <c>null</c>.
+		/// </returns>
+		public static ValidationResult? ValidateCarouselCardCount(ICarouselContent carousel, int maxCards) {
+			if (carousel.Cards.Count > maxCards)
+				return new ValidationResult($"Carousel cards exceed the maximum of {maxCards}", new[] { "Content.Cards" });
+
+			return null;
+		}
+
+		/// <summary>
+		/// Validates that the number of items in a list picker is within
+		/// the allowed range.
+		/// </summary>
+		/// <param name="listPicker">The list picker content to validate.</param>
+		/// <param name="minItems">The minimum number of items required.</param>
+		/// <param name="maxItems">The maximum number of items allowed.</param>
+		/// <returns>
+		/// A <see cref="ValidationResult"/> if validation fails; otherwise <c>null</c>.
+		/// </returns>
+		public static ValidationResult? ValidateListItemCount(IListPickerContent listPicker, int minItems, int maxItems) {
+			if (listPicker.Items.Count < minItems)
+				return new ValidationResult($"List picker requires at least {minItems} items, but found {listPicker.Items.Count}", new[] { "Content.Items" });
+
+			if (listPicker.Items.Count > maxItems)
+				return new ValidationResult($"List picker items exceed the maximum of {maxItems}", new[] { "Content.Items" });
+
+			return null;
+		}
+
+		/// <summary>
+		/// Validates that the button type is within the set of types
+		/// allowed by the channel.
+		/// </summary>
+		/// <param name="button">The button content to validate.</param>
+		/// <param name="allowedTypes">The set of allowed button types.</param>
+		/// <returns>
+		/// A <see cref="ValidationResult"/> if validation fails; otherwise <c>null</c>.
+		/// </returns>
+		public static ValidationResult? ValidateButtonType(IButtonContent button, params ButtonType[] allowedTypes) {
+			if (allowedTypes.Length > 0 && !allowedTypes.Contains(button.ButtonType))
+				return new ValidationResult($"Button type '{button.ButtonType}' is not supported. Allowed types: {string.Join(", ", allowedTypes)}", new[] { "Content.ButtonType" });
+
+			return null;
+		}
+	}
+}

--- a/src/Deveel.Messaging.Connectors/Messaging/InteractiveContentValidator.cs
+++ b/src/Deveel.Messaging.Connectors/Messaging/InteractiveContentValidator.cs
@@ -26,11 +26,8 @@ namespace Deveel.Messaging {
 				}
 			}
 
-			if (message.Content is IListPickerContent listPicker) {
-				if (listPicker.Items.Count > 0) {
-					var lastItem = listPicker.Items[listPicker.Items.Count - 1];
-				}
-			}
+			if (message.Content is IListPickerContent listPicker && listPicker.Items.Count > maxButtons)
+				return new ValidationResult($"List picker items exceed the maximum of {maxButtons}", new[] { "Content.Items" });
 
 			return null;
 		}

--- a/test/Deveel.Messaging.Abstractions.XUnit/Unit/ButtonContentTests.cs
+++ b/test/Deveel.Messaging.Abstractions.XUnit/Unit/ButtonContentTests.cs
@@ -1,0 +1,89 @@
+namespace Deveel.Messaging;
+
+[Trait("Category", "Unit")]
+[Trait("Layer", "Domain")]
+[Trait("Feature", "ButtonContent")]
+public class ButtonContentTests {
+	[Fact]
+	public void Should_SetProperties_When_ButtonContentConstructor() {
+		var content = new ButtonContent("Click Me", ButtonType.Url, "https://example.com");
+
+		Assert.Equal("Click Me", content.Text);
+		Assert.Equal(ButtonType.Url, content.ButtonType);
+		Assert.Equal("https://example.com", content.Value);
+		Assert.Equal(MessageContentType.Button, content.ContentType);
+	}
+
+	[Fact]
+	public void Should_SetPostbackButton_When_ConstructorWithPostback() {
+		var content = new ButtonContent("Buy Now", ButtonType.Postback, "BUY_PRODUCT");
+
+		Assert.Equal("Buy Now", content.Text);
+		Assert.Equal(ButtonType.Postback, content.ButtonType);
+		Assert.Equal("BUY_PRODUCT", content.Value);
+	}
+
+	[Fact]
+	public void Should_SetPhoneNumberButton_When_ConstructorWithPhoneNumber() {
+		var content = new ButtonContent("Call Us", ButtonType.PhoneNumber, "+1234567890");
+
+		Assert.Equal("Call Us", content.Text);
+		Assert.Equal(ButtonType.PhoneNumber, content.ButtonType);
+		Assert.Equal("+1234567890", content.Value);
+	}
+
+	[Fact]
+	public void Should_CopyProperties_When_ButtonContentCopyConstructor() {
+		var source = new ButtonContent("Click Me", ButtonType.Postback, "PAYLOAD");
+		var copy = new ButtonContent(source);
+
+		Assert.Equal(source.Text, copy.Text);
+		Assert.Equal(source.ButtonType, copy.ButtonType);
+		Assert.Equal(source.Value, copy.Value);
+	}
+
+	[Fact]
+	public void Should_UseDefaults_When_ParameterlessConstructor() {
+		var content = new ButtonContent();
+
+		Assert.Equal(string.Empty, content.Text);
+		Assert.Equal(default(ButtonType), content.ButtonType);
+		Assert.Null(content.Value);
+	}
+
+	[Fact]
+	public void Should_AcceptNullValue_When_ButtonContentConstructor() {
+		var content = new ButtonContent("Click Me", ButtonType.Postback);
+
+		Assert.Equal("Click Me", content.Text);
+		Assert.Equal(ButtonType.Postback, content.ButtonType);
+		Assert.Null(content.Value);
+	}
+
+	[Fact]
+	public void Should_UpdateValue_When_ButtonContentPropertySetter() {
+		var content = new ButtonContent("Click", ButtonType.Url);
+		content.Text = "Updated";
+		content.ButtonType = ButtonType.Postback;
+		content.Value = "NEW_PAYLOAD";
+
+		Assert.Equal("Updated", content.Text);
+		Assert.Equal(ButtonType.Postback, content.ButtonType);
+		Assert.Equal("NEW_PAYLOAD", content.Value);
+	}
+
+	[Fact]
+	public void Should_ExposeCorrectType_When_IButtonContentInterface() {
+		IButtonContent content = new ButtonContent("Test", ButtonType.Url, "https://test.com");
+
+		Assert.Equal("Test", content.Text);
+		Assert.Equal(ButtonType.Url, content.ButtonType);
+		Assert.Equal("https://test.com", content.Value);
+	}
+
+	[Fact]
+	public void Should_BeInteractive_When_IInteractiveContentInterface() {
+		IInteractiveContent content = new ButtonContent("Test", ButtonType.Postback, "p");
+		Assert.Equal(MessageContentType.Button, content.ContentType);
+	}
+}

--- a/test/Deveel.Messaging.Abstractions.XUnit/Unit/CarouselBuilderTests.cs
+++ b/test/Deveel.Messaging.Abstractions.XUnit/Unit/CarouselBuilderTests.cs
@@ -1,0 +1,119 @@
+namespace Deveel.Messaging;
+
+[Trait("Category", "Unit")]
+[Trait("Layer", "Domain")]
+[Trait("Feature", "CarouselBuilder")]
+public class CarouselBuilderTests {
+	[Fact]
+	public void Should_BuildCarousel_When_AddCardWithConfigure() {
+		var carousel = new CarouselBuilder()
+			.AddCard(card => card
+				.WithButton("Buy", ButtonType.Postback, "BUY"))
+			.Build();
+
+		Assert.Single(carousel.Cards);
+		Assert.Single(carousel.Cards[0].Buttons);
+		Assert.Equal("Buy", carousel.Cards[0].Buttons[0].Text);
+	}
+
+	[Fact]
+	public void Should_BuildCarousel_When_AddCardWithArgsAndConfigure() {
+		var carousel = new CarouselBuilder()
+			.AddCard("https://img.url", "Title", "Sub", card =>
+				card.WithButton("Go", ButtonType.Url, "https://go.url"))
+			.Build();
+
+		Assert.Single(carousel.Cards);
+		Assert.Equal("Title", carousel.Cards[0].Title);
+		Assert.Equal("Sub", carousel.Cards[0].Subtitle);
+		Assert.Equal("https://img.url", carousel.Cards[0].ImageUrl);
+		Assert.Equal("Go", carousel.Cards[0].Buttons[0].Text);
+	}
+
+	[Fact]
+	public void Should_BuildCarousel_When_AddCardWithArgsNoConfigure() {
+		var carousel = new CarouselBuilder()
+			.AddCard("https://img.url", "Title", "Sub")
+			.Build();
+
+		Assert.Single(carousel.Cards);
+		Assert.Empty(carousel.Cards[0].Buttons);
+	}
+
+	[Fact]
+	public void Should_AddMultipleCards_When_AddCardCalledMultipleTimes() {
+		var carousel = new CarouselBuilder()
+			.AddCard("https://img1.url", "A", "Sub A")
+			.AddCard("https://img2.url", "B", "Sub B")
+			.Build();
+
+		Assert.Equal(2, carousel.Cards.Count);
+		Assert.Equal("A", carousel.Cards[0].Title);
+		Assert.Equal("B", carousel.Cards[1].Title);
+	}
+
+	[Fact]
+	public void Should_ThrowArgumentNullException_When_AddCardWithNullConfigure() {
+		var builder = new CarouselBuilder();
+
+		Assert.Throws<ArgumentNullException>(() => builder.AddCard(null!));
+	}
+
+	[Fact]
+	public void Should_ProduceCarouselContent_When_BuildCalled() {
+		var result = new CarouselBuilder()
+			.AddCard("img", "Title")
+			.Build();
+
+		Assert.IsType<CarouselContent>(result);
+		Assert.Equal(MessageContentType.Carousel, result.ContentType);
+	}
+}
+
+[Trait("Category", "Unit")]
+[Trait("Layer", "Domain")]
+[Trait("Feature", "CarouselCardBuilder")]
+public class CarouselCardBuilderTests {
+	[Fact]
+	public void Should_SetProperties_When_PropertiesAssigned() {
+		var card = new CarouselCardBuilder {
+			ImageUrl = "https://img.url",
+			Title = "Title",
+			Subtitle = "Sub"
+		}.Build();
+
+		Assert.Equal("https://img.url", card.ImageUrl);
+		Assert.Equal("Title", card.Title);
+		Assert.Equal("Sub", card.Subtitle);
+	}
+
+	[Fact]
+	public void Should_AddButton_When_WithButtonCalled() {
+		var card = new CarouselCardBuilder()
+			.WithButton("Click", ButtonType.Url, "https://click.url")
+			.Build();
+
+		Assert.Single(card.Buttons);
+		Assert.Equal("Click", card.Buttons[0].Text);
+		Assert.Equal(ButtonType.Url, card.Buttons[0].ButtonType);
+	}
+
+	[Fact]
+	public void Should_AddMultipleButtons_When_WithButtonCalledMultipleTimes() {
+		var card = new CarouselCardBuilder()
+			.WithButton("A", ButtonType.Postback, "A_P")
+			.WithButton("B", ButtonType.Url, "https://b.url")
+			.Build();
+
+		Assert.Equal(2, card.Buttons.Count);
+	}
+
+	[Fact]
+	public void Should_BuildCarouselCard_When_BuildCalled() {
+		var result = new CarouselCardBuilder()
+			.WithButton("Test", ButtonType.Postback, "P")
+			.Build();
+
+		Assert.IsType<CarouselCard>(result);
+	}
+}

--- a/test/Deveel.Messaging.Abstractions.XUnit/Unit/CarouselContentTests.cs
+++ b/test/Deveel.Messaging.Abstractions.XUnit/Unit/CarouselContentTests.cs
@@ -1,0 +1,95 @@
+namespace Deveel.Messaging;
+
+[Trait("Category", "Unit")]
+[Trait("Layer", "Domain")]
+[Trait("Feature", "CarouselContent")]
+public class CarouselContentTests {
+	[Fact]
+	public void Should_CreateCarousel_When_ConstructorWithCards() {
+		var cards = new List<ICarouselCard> {
+			new CarouselCard("Card 1", "Sub 1", "https://img1.url"),
+			new CarouselCard("Card 2", "Sub 2", "https://img2.url")
+		};
+		var content = new CarouselContent(cards);
+
+		Assert.Equal(2, content.Cards.Count);
+		Assert.Equal(MessageContentType.Carousel, content.ContentType);
+	}
+
+	[Fact]
+	public void Should_AddCard_When_AddCardCalled() {
+		var content = new CarouselContent();
+		content.AddCard(new CarouselCard("Card", "Sub", "img"));
+
+		Assert.Single(content.Cards);
+	}
+
+	[Fact]
+	public void Should_RemoveCard_When_RemoveCardCalled() {
+		var card = new CarouselCard("Card", "Sub", "img");
+		var content = new CarouselContent(new[] { card });
+
+		var result = content.RemoveCard(card);
+
+		Assert.True(result);
+		Assert.Empty(content.Cards);
+	}
+
+	[Fact]
+	public void Should_ClearCards_When_ClearCardsCalled() {
+		var content = new CarouselContent(new[] {
+			new CarouselCard("Card 1"),
+			new CarouselCard("Card 2")
+		});
+		content.ClearCards();
+
+		Assert.Empty(content.Cards);
+	}
+
+	[Fact]
+	public void Should_CopyCards_When_CopyConstructor() {
+		var source = new CarouselContent(new[] {
+			new CarouselCard("Card 1", "Sub", "img") { Buttons = { new ButtonContent("Btn", ButtonType.Url, "url") } }
+		});
+		var copy = new CarouselContent(source);
+
+		Assert.Equal(source.Cards.Count, copy.Cards.Count);
+		Assert.Equal(source.Cards[0].Title, copy.Cards[0].Title);
+	}
+}
+
+[Trait("Category", "Unit")]
+[Trait("Layer", "Domain")]
+[Trait("Feature", "CarouselCard")]
+public class CarouselCardTests {
+	[Fact]
+	public void Should_SetProperties_When_CarouselCardConstructor() {
+		var card = new CarouselCard("Title", "Subtitle", "https://img.url");
+
+		Assert.Equal("Title", card.Title);
+		Assert.Equal("Subtitle", card.Subtitle);
+		Assert.Equal("https://img.url", card.ImageUrl);
+		Assert.Empty(card.Buttons);
+	}
+
+	[Fact]
+	public void Should_AddButton_When_ButtonsListModified() {
+		var card = new CarouselCard();
+		card.Buttons.Add(new ButtonContent("Click", ButtonType.Url, "url"));
+
+		Assert.Single(card.Buttons);
+	}
+
+	[Fact]
+	public void Should_CopyProperties_When_CarouselCardCopyConstructor() {
+		var source = new CarouselCard("Title", "Sub", "img");
+		source.Buttons.Add(new ButtonContent("Btn", ButtonType.Postback, "p"));
+
+		var copy = new CarouselCard(source);
+
+		Assert.Equal(source.Title, copy.Title);
+		Assert.Equal(source.Subtitle, copy.Subtitle);
+		Assert.Equal(source.ImageUrl, copy.ImageUrl);
+		Assert.Equal(source.Buttons.Count, copy.Buttons.Count);
+	}
+}

--- a/test/Deveel.Messaging.Abstractions.XUnit/Unit/DefaultMessageIdGeneratorTests.cs
+++ b/test/Deveel.Messaging.Abstractions.XUnit/Unit/DefaultMessageIdGeneratorTests.cs
@@ -1,0 +1,36 @@
+namespace Deveel.Messaging;
+
+[Trait("Category", "Unit")]
+[Trait("Layer", "Domain")]
+[Trait("Feature", "DefaultMessageIdGenerator")]
+public class DefaultMessageIdGeneratorTests {
+	[Fact]
+	public void Should_GenerateNonEmptyId_When_GenerateMessageId() {
+		var generator = new DefaultMessageIdGenerator();
+
+		var id = generator.GenerateMessageId();
+
+		Assert.NotNull(id);
+		Assert.NotEmpty(id);
+	}
+
+	[Fact]
+	public void Should_GenerateNonEmptyBatchId_When_GenerateBatchId() {
+		var generator = new DefaultMessageIdGenerator();
+
+		var id = generator.GenerateBatchId();
+
+		Assert.NotNull(id);
+		Assert.NotEmpty(id);
+	}
+
+	[Fact]
+	public void Should_GenerateUniqueIds_When_GenerateMessageIdCalledMultipleTimes() {
+		var generator = new DefaultMessageIdGenerator();
+
+		var id1 = generator.GenerateMessageId();
+		var id2 = generator.GenerateMessageId();
+
+		Assert.NotEqual(id1, id2);
+	}
+}

--- a/test/Deveel.Messaging.Abstractions.XUnit/Unit/EnumTests.cs
+++ b/test/Deveel.Messaging.Abstractions.XUnit/Unit/EnumTests.cs
@@ -215,6 +215,10 @@ public class MessageContentTypeTests
         Assert.Equal(5, (int)MessageContentType.Media);
         Assert.Equal(6, (int)MessageContentType.Json);
         Assert.Equal(7, (int)MessageContentType.Binary);
+        Assert.Equal(9, (int)MessageContentType.Button);
+        Assert.Equal(10, (int)MessageContentType.QuickReply);
+        Assert.Equal(11, (int)MessageContentType.Carousel);
+        Assert.Equal(12, (int)MessageContentType.ListPicker);
     }
 
     [Fact]
@@ -238,6 +242,8 @@ public class MessageContentTypeTests
     [InlineData(MessageContentType.Media)]
     [InlineData(MessageContentType.Json)]
     [InlineData(MessageContentType.Binary)]
+    [InlineData(MessageContentType.Button)]
+    [InlineData(MessageContentType.QuickReply)]
     public void Should_CanBeUsedInSwitchStatement_When_MessageContentTypeIsInvoked(MessageContentType contentType)
     {
         // Act
@@ -251,6 +257,10 @@ public class MessageContentTypeTests
             MessageContentType.Media => "Media content",
             MessageContentType.Json => "JSON content",
             MessageContentType.Binary => "Binary content",
+            MessageContentType.Button => "Button content",
+            MessageContentType.QuickReply => "Quick reply content",
+            MessageContentType.Carousel => "Carousel content",
+            MessageContentType.ListPicker => "List picker content",
             _ => "Unknown content type"
         };
 
@@ -269,6 +279,10 @@ public class MessageContentTypeTests
         var mediaString = MessageContentType.Media.ToString();
         var jsonString = MessageContentType.Json.ToString();
         var binaryString = MessageContentType.Binary.ToString();
+        var buttonString = MessageContentType.Button.ToString();
+        var quickReplyString = MessageContentType.QuickReply.ToString();
+        var carouselString = MessageContentType.Carousel.ToString();
+        var listPickerString = MessageContentType.ListPicker.ToString();
 
         // Assert
         Assert.Equal("PlainText", plainTextString);
@@ -278,6 +292,10 @@ public class MessageContentTypeTests
         Assert.Equal("Media", mediaString);
         Assert.Equal("Json", jsonString);
         Assert.Equal("Binary", binaryString);
+        Assert.Equal("Button", buttonString);
+        Assert.Equal("QuickReply", quickReplyString);
+        Assert.Equal("Carousel", carouselString);
+        Assert.Equal("ListPicker", listPickerString);
     }
 
     [Fact]
@@ -293,3 +311,92 @@ public class MessageContentTypeTests
         Assert.Equal(1, (int)minValue);
     }
 }
+
+public class ButtonTypeTests
+{
+    [Fact]
+    public void Should_HaveCorrectValues_When_ButtonTypeIsInvoked()
+    {
+        Assert.Equal(0, (int)ButtonType.Url);
+        Assert.Equal(1, (int)ButtonType.Postback);
+        Assert.Equal(2, (int)ButtonType.PhoneNumber);
+    }
+
+    [Fact]
+    public void Should_AllValuesAreDistinct_When_ButtonTypeIsInvoked()
+    {
+        var values = Enum.GetValues<ButtonType>();
+        var distinctValues = values.Distinct().ToArray();
+        Assert.Equal(values.Length, distinctValues.Length);
+    }
+
+    [Theory]
+    [InlineData(ButtonType.Url)]
+    [InlineData(ButtonType.Postback)]
+    [InlineData(ButtonType.PhoneNumber)]
+    public void Should_CanBeUsedInSwitchStatement_When_ButtonTypeIsInvoked(ButtonType buttonType)
+    {
+        var description = buttonType switch
+        {
+            ButtonType.Url => "URL button",
+            ButtonType.Postback => "Postback button",
+            ButtonType.PhoneNumber => "Phone number button",
+            _ => "Unknown button type"
+        };
+
+        Assert.NotEqual("Unknown button type", description);
+    }
+
+    [Fact]
+    public void Should_CanBeConvertedToString_When_ButtonTypeIsInvoked()
+    {
+        Assert.Equal("Url", ButtonType.Url.ToString());
+        Assert.Equal("Postback", ButtonType.Postback.ToString());
+        Assert.Equal("PhoneNumber", ButtonType.PhoneNumber.ToString());
+    }
+}
+
+public class ListPickerStyleTests
+{
+    [Fact]
+    public void Should_HaveCorrectValues_When_ListPickerStyleIsInvoked()
+    {
+        Assert.Equal(0, (int)ListPickerStyle.Inlined);
+        Assert.Equal(1, (int)ListPickerStyle.Compact);
+        Assert.Equal(2, (int)ListPickerStyle.Large);
+    }
+
+    [Fact]
+    public void Should_AllValuesAreDistinct_When_ListPickerStyleIsInvoked()
+    {
+        var values = Enum.GetValues<ListPickerStyle>();
+        var distinctValues = values.Distinct().ToArray();
+        Assert.Equal(values.Length, distinctValues.Length);
+    }
+
+    [Theory]
+    [InlineData(ListPickerStyle.Inlined)]
+    [InlineData(ListPickerStyle.Compact)]
+    [InlineData(ListPickerStyle.Large)]
+    public void Should_CanBeUsedInSwitchStatement_When_ListPickerStyleIsInvoked(ListPickerStyle style)
+    {
+        var description = style switch
+        {
+            ListPickerStyle.Inlined => "Inlined list",
+            ListPickerStyle.Compact => "Compact list",
+            ListPickerStyle.Large => "Large list",
+            _ => "Unknown style"
+        };
+
+        Assert.NotEqual("Unknown style", description);
+    }
+
+    [Fact]
+    public void Should_CanBeConvertedToString_When_ListPickerStyleIsInvoked()
+    {
+        Assert.Equal("Inlined", ListPickerStyle.Inlined.ToString());
+        Assert.Equal("Compact", ListPickerStyle.Compact.ToString());
+        Assert.Equal("Large", ListPickerStyle.Large.ToString());
+    }
+}
+

--- a/test/Deveel.Messaging.Abstractions.XUnit/Unit/ListPickerBuilderTests.cs
+++ b/test/Deveel.Messaging.Abstractions.XUnit/Unit/ListPickerBuilderTests.cs
@@ -1,0 +1,174 @@
+namespace Deveel.Messaging;
+
+[Trait("Category", "Unit")]
+[Trait("Layer", "Domain")]
+[Trait("Feature", "ListPickerBuilder")]
+public class ListPickerBuilderTests {
+	[Fact]
+	public void Should_BuildListPicker_When_AddItemWithArgs() {
+		var list = new ListPickerBuilder()
+			.AddItem("Pizza", "Delicious cheese pizza")
+			.Build();
+
+		Assert.Single(list.Items);
+		Assert.Equal("Pizza", list.Items[0].Title);
+		Assert.Equal("Delicious cheese pizza", list.Items[0].Description);
+	}
+
+	[Fact]
+	public void Should_BuildListPicker_When_AddItemWithConfigure() {
+		var list = new ListPickerBuilder()
+			.AddItem(item => item
+				.WithTitle("Burger")
+				.WithDescription("Juicy beef burger"))
+			.Build();
+
+		Assert.Single(list.Items);
+		Assert.Equal("Burger", list.Items[0].Title);
+		Assert.Equal("Juicy beef burger", list.Items[0].Description);
+	}
+
+	[Fact]
+	public void Should_SetStyle_When_WithStyleCalled() {
+		var list = new ListPickerBuilder()
+			.WithStyle(ListPickerStyle.Compact)
+			.AddItem("Item")
+			.Build();
+
+		Assert.Equal(ListPickerStyle.Compact, list.Style);
+	}
+
+	[Fact]
+	public void Should_DefaultStyle_When_NotSpecified() {
+		var builder = new ListPickerBuilder();
+		Assert.Equal(ListPickerStyle.Inlined, builder.Style);
+
+		var list = builder.AddItem("Item").Build();
+		Assert.Equal(ListPickerStyle.Inlined, list.Style);
+	}
+
+	[Fact]
+	public void Should_SetStyleViaProperty_When_StylePropertySet() {
+		var builder = new ListPickerBuilder { Style = ListPickerStyle.Large };
+		Assert.Equal(ListPickerStyle.Large, builder.Style);
+	}
+
+	[Fact]
+	public void Should_SetTitle_When_TitlePropertySet() {
+		var list = new ListPickerBuilder {
+			Title = "Menu",
+			Subtitle = "Choose"
+		}.AddItem("Item").Build();
+
+		Assert.Equal("Menu", list.Title);
+		Assert.Equal("Choose", list.Subtitle);
+	}
+
+	[Fact]
+	public void Should_AddMultipleItems_When_AddItemCalledMultipleTimes() {
+		var list = new ListPickerBuilder()
+			.AddItem("A")
+			.AddItem("B")
+			.AddItem("C")
+			.Build();
+
+		Assert.Equal(3, list.Items.Count);
+	}
+
+	[Fact]
+	public void Should_ThrowArgumentNullException_When_AddItemWithNullConfigure() {
+		var builder = new ListPickerBuilder();
+
+		Assert.Throws<ArgumentNullException>(() => builder.AddItem((Action<ListPickerItemBuilder>)null!));
+	}
+
+	[Fact]
+	public void Should_ProduceListPickerContent_When_BuildCalled() {
+		var result = new ListPickerBuilder()
+			.AddItem("Item")
+			.Build();
+
+		Assert.IsType<ListPickerContent>(result);
+		Assert.Equal(MessageContentType.ListPicker, result.ContentType);
+	}
+
+	[Fact]
+	public void Should_AddItemWithAllArgs_When_AddItemCalled() {
+		var list = new ListPickerBuilder()
+			.AddItem("Salad", "Fresh", "https://img.url", "ORDER_SALAD")
+			.Build();
+
+		Assert.Equal("Salad", list.Items[0].Title);
+		Assert.Equal("Fresh", list.Items[0].Description);
+		Assert.Equal("https://img.url", list.Items[0].ImageUrl);
+		Assert.Equal("ORDER_SALAD", list.Items[0].Payload);
+	}
+}
+
+[Trait("Category", "Unit")]
+[Trait("Layer", "Domain")]
+[Trait("Feature", "ListPickerItemBuilder")]
+public class ListPickerItemBuilderTests {
+	[Fact]
+	public void Should_SetProperties_When_FluentMethodsCalled() {
+		var item = new ListPickerItemBuilder()
+			.WithTitle("Item")
+			.WithDescription("Desc")
+			.Build();
+
+		Assert.Equal("Item", item.Title);
+		Assert.Equal("Desc", item.Description);
+	}
+
+	[Fact]
+	public void Should_BuildWithDefaults_When_NoValuesSet() {
+		var item = new ListPickerItemBuilder().Build();
+
+		Assert.Equal(string.Empty, item.Title);
+		Assert.Null(item.Description);
+		Assert.Null(item.ImageUrl);
+		Assert.Null(item.Payload);
+	}
+
+	[Fact]
+	public void Should_SetImageUrl_When_WithImageUrlCalled() {
+		var item = new ListPickerItemBuilder()
+			.WithImageUrl("https://img.url")
+			.Build();
+
+		Assert.Equal("https://img.url", item.ImageUrl);
+	}
+
+	[Fact]
+	public void Should_SetPayload_When_WithPayloadCalled() {
+		var item = new ListPickerItemBuilder()
+			.WithPayload("PAYLOAD")
+			.Build();
+
+		Assert.Equal("PAYLOAD", item.Payload);
+	}
+
+	[Fact]
+	public void Should_SetAllProperties_When_AllFluentMethodsCalled() {
+		var item = new ListPickerItemBuilder()
+			.WithTitle("Item")
+			.WithDescription("Desc")
+			.WithImageUrl("https://img.url")
+			.WithPayload("PAYLOAD")
+			.Build();
+
+		Assert.Equal("Item", item.Title);
+		Assert.Equal("Desc", item.Description);
+		Assert.Equal("https://img.url", item.ImageUrl);
+		Assert.Equal("PAYLOAD", item.Payload);
+	}
+
+	[Fact]
+	public void Should_ProduceListPickerItem_When_BuildCalled() {
+		var result = new ListPickerItemBuilder()
+			.WithTitle("Test")
+			.Build();
+
+		Assert.IsType<ListPickerItem>(result);
+	}
+}

--- a/test/Deveel.Messaging.Abstractions.XUnit/Unit/ListPickerContentTests.cs
+++ b/test/Deveel.Messaging.Abstractions.XUnit/Unit/ListPickerContentTests.cs
@@ -1,0 +1,125 @@
+namespace Deveel.Messaging;
+
+[Trait("Category", "Unit")]
+[Trait("Layer", "Domain")]
+[Trait("Feature", "ListPickerContent")]
+public class ListPickerContentTests {
+	[Fact]
+	public void Should_SetProperties_When_ListPickerContentConstructor() {
+		var items = new List<IListPickerItem> {
+			new ListPickerItem("Item 1", "Desc 1"),
+			new ListPickerItem("Item 2", "Desc 2")
+		};
+		var content = new ListPickerContent("Title", "Subtitle", items, ListPickerStyle.Compact);
+
+		Assert.Equal("Title", content.Title);
+		Assert.Equal("Subtitle", content.Subtitle);
+		Assert.Equal(2, content.Items.Count);
+		Assert.Equal(ListPickerStyle.Compact, content.Style);
+		Assert.Equal(MessageContentType.ListPicker, content.ContentType);
+	}
+
+	[Fact]
+	public void Should_AddItem_When_AddItemCalled() {
+		var content = new ListPickerContent();
+		content.AddItem(new ListPickerItem("Item 1"));
+
+		Assert.Single(content.Items);
+	}
+
+	[Fact]
+	public void Should_RemoveItem_When_RemoveItemCalled() {
+		var item = new ListPickerItem("Item");
+		var content = new ListPickerContent(items: new[] { item });
+
+		var result = content.RemoveItem(item);
+
+		Assert.True(result);
+		Assert.Empty(content.Items);
+	}
+
+	[Fact]
+	public void Should_ClearItems_When_ClearItemsCalled() {
+		var content = new ListPickerContent(items: new[] {
+			new ListPickerItem("Item 1"),
+			new ListPickerItem("Item 2")
+		});
+		content.ClearItems();
+
+		Assert.Empty(content.Items);
+	}
+
+	[Fact]
+	public void Should_CopyProperties_When_ListPickerContentCopyConstructor() {
+		var source = new ListPickerContent("Src Title", "Src Sub",
+			new[] { new ListPickerItem("Item", "Desc") }, ListPickerStyle.Large);
+		var copy = new ListPickerContent(source);
+
+		Assert.Equal(source.Title, copy.Title);
+		Assert.Equal(source.Subtitle, copy.Subtitle);
+		Assert.Equal(source.Items.Count, copy.Items.Count);
+		Assert.Equal(source.Style, copy.Style);
+	}
+
+	[Fact]
+	public void Should_DefaultStyle_When_InlinedSpecified() {
+		var content = new ListPickerContent(style: ListPickerStyle.Inlined);
+		Assert.Equal(ListPickerStyle.Inlined, content.Style);
+	}
+
+	[Fact]
+	public void Should_BeInteractive_When_IInteractiveContentInterface() {
+		IInteractiveContent content = new ListPickerContent();
+		Assert.Equal(MessageContentType.ListPicker, content.ContentType);
+	}
+}
+
+[Trait("Category", "Unit")]
+[Trait("Layer", "Domain")]
+[Trait("Feature", "ListPickerItem")]
+public class ListPickerItemTests {
+	[Fact]
+	public void Should_SetProperties_When_ListPickerItemConstructor() {
+		var item = new ListPickerItem("Title", "Description", "https://img.url", "PAYLOAD");
+
+		Assert.Equal("Title", item.Title);
+		Assert.Equal("Description", item.Description);
+		Assert.Equal("https://img.url", item.ImageUrl);
+		Assert.Equal("PAYLOAD", item.Payload);
+	}
+
+	[Fact]
+	public void Should_SetTitleOnly_When_ListPickerItemConstructorMinimal() {
+		var item = new ListPickerItem("Title");
+
+		Assert.Equal("Title", item.Title);
+		Assert.Null(item.Description);
+		Assert.Null(item.ImageUrl);
+		Assert.Null(item.Payload);
+	}
+
+	[Fact]
+	public void Should_CopyProperties_When_ListPickerItemCopyConstructor() {
+		var source = new ListPickerItem("Src", "Desc", "img", "p");
+		var copy = new ListPickerItem(source);
+
+		Assert.Equal(source.Title, copy.Title);
+		Assert.Equal(source.Description, copy.Description);
+		Assert.Equal(source.ImageUrl, copy.ImageUrl);
+		Assert.Equal(source.Payload, copy.Payload);
+	}
+
+	[Fact]
+	public void Should_UpdateValues_When_ListPickerItemPropertySetters() {
+		var item = new ListPickerItem("Initial");
+		item.Title = "Updated";
+		item.Description = "New desc";
+		item.ImageUrl = "new.img";
+		item.Payload = "NEW_PAYLOAD";
+
+		Assert.Equal("Updated", item.Title);
+		Assert.Equal("New desc", item.Description);
+		Assert.Equal("new.img", item.ImageUrl);
+		Assert.Equal("NEW_PAYLOAD", item.Payload);
+	}
+}

--- a/test/Deveel.Messaging.Abstractions.XUnit/Unit/MessageBatchTests.cs
+++ b/test/Deveel.Messaging.Abstractions.XUnit/Unit/MessageBatchTests.cs
@@ -1,0 +1,66 @@
+namespace Deveel.Messaging;
+
+[Trait("Category", "Unit")]
+[Trait("Layer", "Domain")]
+[Trait("Feature", "MessageBatch")]
+public class MessageBatchTests {
+	[Fact]
+	public void Should_BeEmpty_When_DefaultConstructor() {
+		var batch = new MessageBatch();
+
+		Assert.NotNull(batch.Messages);
+		Assert.Empty(batch.Messages);
+		Assert.Null(batch.Id);
+		Assert.NotNull(batch.Properties);
+		Assert.Empty(batch.Properties);
+	}
+
+	[Fact]
+	public void Should_AddMessages_When_MessagesAddedToList() {
+		var batch = new MessageBatch();
+		batch.Messages.Add(new Message { Id = "msg-1" });
+		batch.Messages.Add(new Message { Id = "msg-2" });
+
+		Assert.Equal(2, batch.Messages.Count);
+	}
+
+	[Fact]
+	public void Should_SetId_When_IdPropertySet() {
+		var batch = new MessageBatch { Id = "batch-1" };
+
+		Assert.Equal("batch-1", batch.Id);
+	}
+
+	[Fact]
+	public void Should_SetProperties_When_PropertiesDictionaryAssigned() {
+		var batch = new MessageBatch {
+			Properties = new Dictionary<string, object> {
+				["key"] = "value"
+			}
+		};
+
+		Assert.NotNull(batch.Properties);
+		Assert.Equal("value", batch.Properties["key"]);
+	}
+
+	[Fact]
+	public void Should_SetProperties_When_AddProperty() {
+		var batch = new MessageBatch();
+		batch.Properties["key"] = "value";
+
+		Assert.Equal("value", batch.Properties["key"]);
+	}
+
+	[Fact]
+	public void Should_SupportIMessageBatchInterface() {
+		IMessageBatch batch = new MessageBatch {
+			Id = "batch-1",
+			Messages = { new Message { Id = "msg-1" } },
+			Properties = { ["k"] = "v" }
+		};
+
+		Assert.Equal("batch-1", batch.Id);
+		Assert.Single(batch.Messages);
+		Assert.Equal("v", batch.Properties["k"]);
+	}
+}

--- a/test/Deveel.Messaging.Abstractions.XUnit/Unit/MessageBuilderTests.cs
+++ b/test/Deveel.Messaging.Abstractions.XUnit/Unit/MessageBuilderTests.cs
@@ -302,4 +302,87 @@ public class MessageBuilderTests
         Assert.NotNull(iMessage.Properties);
         Assert.Equal("testValue", iMessage.Properties["testProp"].Value);
     }
+
+    [Fact]
+    public void Should_BuildWithButton_When_WithButtonCalled() {
+        var message = new MessageBuilder()
+            .WithButton("Click", ButtonType.Url, "https://example.com")
+            .Build();
+
+        Assert.IsType<ButtonContent>(message.Content);
+        var button = (ButtonContent)message.Content!;
+        Assert.Equal("Click", button.Text);
+        Assert.Equal(ButtonType.Url, button.ButtonType);
+        Assert.Equal("https://example.com", button.Value);
+    }
+
+    [Fact]
+    public void Should_BuildWithQuickReply_When_WithQuickReplyCalled() {
+        var message = new MessageBuilder()
+            .WithQuickReply("Yes", "YES_PAYLOAD")
+            .Build();
+
+        Assert.IsType<QuickReplyContent>(message.Content);
+        var qr = (QuickReplyContent)message.Content!;
+        Assert.Equal("Yes", qr.Title);
+        Assert.Equal("YES_PAYLOAD", qr.Payload);
+    }
+
+    [Fact]
+    public void Should_BuildWithQuickReplyBuilder_When_WithQuickReplyWithConfigure() {
+        var message = new MessageBuilder()
+            .WithQuickReply(qr => qr
+                .WithTitle("Maybe")
+                .WithPayload("MAYBE_PAYLOAD"))
+            .Build();
+
+        Assert.IsType<QuickReplyContent>(message.Content);
+        var qr = (QuickReplyContent)message.Content!;
+        Assert.Equal("Maybe", qr.Title);
+        Assert.Equal("MAYBE_PAYLOAD", qr.Payload);
+    }
+
+    [Fact]
+    public void Should_BuildWithCarousel_When_WithCarouselWithConfigure() {
+        var message = new MessageBuilder()
+            .WithCarousel(carousel => carousel
+                .AddCard("https://img.url", "Title", "Sub", card =>
+                    card.WithButton("Go", ButtonType.Url, "https://go.url")))
+            .Build();
+
+        Assert.IsType<CarouselContent>(message.Content);
+        var carousel = (CarouselContent)message.Content!;
+        Assert.Single(carousel.Cards);
+        Assert.Equal("Title", carousel.Cards[0].Title);
+    }
+
+    [Fact]
+    public void Should_BuildWithCarouselFromCards_When_WithCarouselWithCards() {
+        var cards = new[] {
+            new CarouselCard("Card 1"),
+            new CarouselCard("Card 2")
+        };
+
+        var message = new MessageBuilder()
+            .WithCarousel(cards)
+            .Build();
+
+        Assert.IsType<CarouselContent>(message.Content);
+        Assert.Equal(2, ((CarouselContent)message.Content!).Cards.Count);
+    }
+
+    [Fact]
+    public void Should_BuildWithListPicker_When_WithListPickerWithConfigure() {
+        var message = new MessageBuilder()
+            .WithListPicker(list => list
+                .WithStyle(ListPickerStyle.Compact)
+                .AddItem("Item A", "Description A"))
+            .Build();
+
+        Assert.IsType<ListPickerContent>(message.Content);
+        var picker = (ListPickerContent)message.Content!;
+        Assert.Single(picker.Items);
+        Assert.Equal(ListPickerStyle.Compact, picker.Style);
+        Assert.Equal("Item A", picker.Items[0].Title);
+    }
 }

--- a/test/Deveel.Messaging.Abstractions.XUnit/Unit/MessageContentExtendedTests.cs
+++ b/test/Deveel.Messaging.Abstractions.XUnit/Unit/MessageContentExtendedTests.cs
@@ -22,6 +22,42 @@ public class MessageContentExtendedTests
     }
 
     [Fact]
+    public void Should_CreateButtonContent_FromInterface()
+    {
+        IMessageContent source = new ButtonContent("Click", ButtonType.Url, "url");
+        var result = MessageContent.Create(source);
+        Assert.NotNull(result);
+        Assert.Equal(MessageContentType.Button, result.ContentType);
+    }
+
+    [Fact]
+    public void Should_CreateQuickReplyContent_FromInterface()
+    {
+        IMessageContent source = new QuickReplyContent("Yes", "p");
+        var result = MessageContent.Create(source);
+        Assert.NotNull(result);
+        Assert.Equal(MessageContentType.QuickReply, result.ContentType);
+    }
+
+    [Fact]
+    public void Should_CreateCarouselContent_FromInterface()
+    {
+        IMessageContent source = new CarouselContent(new[] { new CarouselCard("Card") });
+        var result = MessageContent.Create(source);
+        Assert.NotNull(result);
+        Assert.Equal(MessageContentType.Carousel, result.ContentType);
+    }
+
+    [Fact]
+    public void Should_CreateListPickerContent_FromInterface()
+    {
+        IMessageContent source = new ListPickerContent(items: new[] { new ListPickerItem("Item") });
+        var result = MessageContent.Create(source);
+        Assert.NotNull(result);
+        Assert.Equal(MessageContentType.ListPicker, result.ContentType);
+    }
+
+    [Fact]
     public void Should_ReturnNull_WhenInputIsNull()
     {
         var result = MessageContent.Create(null);

--- a/test/Deveel.Messaging.Abstractions.XUnit/Unit/MessageContentTests.cs
+++ b/test/Deveel.Messaging.Abstractions.XUnit/Unit/MessageContentTests.cs
@@ -550,6 +550,65 @@ public class MessageContentTests
 
     // Helper classes for testing custom implementations
 
+    [Fact]
+    public void Should_ReturnButtonContent_When_CreateWithButtonContent()
+    {
+        var originalContent = new ButtonContent("Click", ButtonType.Url, "https://example.com");
+        var result = MessageContent.Create(originalContent);
+        Assert.IsType<ButtonContent>(result);
+        Assert.Same(originalContent, result);
+    }
+
+    [Fact]
+    public void Should_ReturnButtonContent_When_CreateWithIButtonContent()
+    {
+        IButtonContent buttonContent = new ButtonContent("Click", ButtonType.Postback, "PAYLOAD");
+        var result = MessageContent.Create(buttonContent);
+        Assert.IsType<ButtonContent>(result);
+        var btnResult = (ButtonContent)result;
+        Assert.Equal("Click", btnResult.Text);
+        Assert.Equal(ButtonType.Postback, btnResult.ButtonType);
+        Assert.Equal("PAYLOAD", btnResult.Value);
+    }
+
+    [Fact]
+    public void Should_ReturnQuickReplyContent_When_CreateWithIQuickReplyContent()
+    {
+        IQuickReplyContent qrContent = new QuickReplyContent("Yes", "YES_PAYLOAD", "https://img.url");
+        var result = MessageContent.Create(qrContent);
+        Assert.IsType<QuickReplyContent>(result);
+        var qrResult = (QuickReplyContent)result;
+        Assert.Equal("Yes", qrResult.Title);
+        Assert.Equal("YES_PAYLOAD", qrResult.Payload);
+        Assert.Equal("https://img.url", qrResult.ImageUrl);
+    }
+
+    [Fact]
+    public void Should_ReturnCarouselContent_When_CreateWithICarouselContent()
+    {
+        ICarouselContent carouselContent = new CarouselContent(new[] {
+            new CarouselCard("Card 1"),
+            new CarouselCard("Card 2")
+        });
+        var result = MessageContent.Create(carouselContent);
+        Assert.IsType<CarouselContent>(result);
+        var carResult = (CarouselContent)result;
+        Assert.Equal(2, carResult.Cards.Count);
+    }
+
+    [Fact]
+    public void Should_ReturnListPickerContent_When_CreateWithIListPickerContent()
+    {
+        IListPickerContent listContent = new ListPickerContent("Title", null,
+            new[] { new ListPickerItem("Item 1") }, ListPickerStyle.Compact);
+        var result = MessageContent.Create(listContent);
+        Assert.IsType<ListPickerContent>(result);
+        var listResult = (ListPickerContent)result;
+        Assert.Equal("Title", listResult.Title);
+        Assert.Single(listResult.Items);
+        Assert.Equal(ListPickerStyle.Compact, listResult.Style);
+    }
+
     private class CustomTextContent : ITextContent
     {
         public CustomTextContent(string text, string? encoding)

--- a/test/Deveel.Messaging.Abstractions.XUnit/Unit/MessageIdGeneratorExtensionsTests.cs
+++ b/test/Deveel.Messaging.Abstractions.XUnit/Unit/MessageIdGeneratorExtensionsTests.cs
@@ -1,0 +1,54 @@
+namespace Deveel.Messaging;
+
+[Trait("Category", "Unit")]
+[Trait("Layer", "Domain")]
+[Trait("Feature", "MessageIdGeneratorExtensions")]
+public class MessageIdGeneratorExtensionsTests {
+	[Fact]
+	public void Should_SetMessageId_When_EnsureMessageIdCalled() {
+		var message = new Message();
+		var generator = new DefaultMessageIdGenerator();
+
+		var id = generator.EnsureMessageId(message);
+
+		Assert.NotNull(id);
+		Assert.NotEmpty(id);
+		Assert.Equal(id, message.Id);
+	}
+
+	[Fact]
+	public void Should_KeepExistingId_When_MessageAlreadyHasId() {
+		var message = new Message { Id = "existing-id" };
+		var generator = new DefaultMessageIdGenerator();
+
+		var id = generator.EnsureMessageId(message);
+
+		Assert.Equal("existing-id", id);
+	}
+
+	[Fact]
+	public void Should_SetBatchId_When_EnsureBatchIdCalled() {
+		var batch = new MessageBatch();
+		var generator = new DefaultMessageIdGenerator();
+
+		var id = generator.EnsureBatchId(batch);
+
+		Assert.NotNull(id);
+		Assert.NotEmpty(id);
+		Assert.Equal(id, batch.Id);
+	}
+
+	[Fact]
+	public void Should_ThrowArgumentNullException_When_GeneratorIsNull() {
+		IMessageIdGenerator? generator = null;
+
+		Assert.Throws<ArgumentNullException>(() => generator!.EnsureMessageId(new Message()));
+	}
+
+	[Fact]
+	public void Should_ThrowArgumentNullException_When_MessageIsNull() {
+		var generator = new DefaultMessageIdGenerator();
+
+		Assert.Throws<ArgumentNullException>(() => generator.EnsureMessageId(null!));
+	}
+}

--- a/test/Deveel.Messaging.Abstractions.XUnit/Unit/QuickReplyBuilderTests.cs
+++ b/test/Deveel.Messaging.Abstractions.XUnit/Unit/QuickReplyBuilderTests.cs
@@ -1,0 +1,51 @@
+namespace Deveel.Messaging;
+
+[Trait("Category", "Unit")]
+[Trait("Layer", "Domain")]
+[Trait("Feature", "QuickReplyBuilder")]
+public class QuickReplyBuilderTests {
+	[Fact]
+	public void Should_SetProperties_When_FluentMethodsCalled() {
+		var qr = new QuickReplyBuilder()
+			.WithTitle("Yes")
+			.WithPayload("YES_PAYLOAD")
+			.WithImageUrl("https://img.url")
+			.Build();
+
+		Assert.Equal("Yes", qr.Title);
+		Assert.Equal("YES_PAYLOAD", qr.Payload);
+		Assert.Equal("https://img.url", qr.ImageUrl);
+	}
+
+	[Fact]
+	public void Should_BuildWithDefaults_When_NoValuesSet() {
+		var qr = new QuickReplyBuilder().Build();
+
+		Assert.Equal(string.Empty, qr.Title);
+		Assert.Null(qr.Payload);
+		Assert.Null(qr.ImageUrl);
+	}
+
+	[Fact]
+	public void Should_ProduceQuickReplyContent_When_BuildCalled() {
+		var result = new QuickReplyBuilder()
+			.WithTitle("Test")
+			.Build();
+
+		Assert.IsType<QuickReplyContent>(result);
+		Assert.Equal(MessageContentType.QuickReply, result.ContentType);
+	}
+
+	[Fact]
+	public void Should_SetProperties_When_PropertiesAssignedDirectly() {
+		var builder = new QuickReplyBuilder {
+			Title = "Maybe",
+			Payload = "MAYBE_PAYLOAD",
+			ImageUrl = "https://img.url"
+		};
+
+		Assert.Equal("Maybe", builder.Title);
+		Assert.Equal("MAYBE_PAYLOAD", builder.Payload);
+		Assert.Equal("https://img.url", builder.ImageUrl);
+	}
+}

--- a/test/Deveel.Messaging.Abstractions.XUnit/Unit/QuickReplyContentTests.cs
+++ b/test/Deveel.Messaging.Abstractions.XUnit/Unit/QuickReplyContentTests.cs
@@ -1,0 +1,71 @@
+namespace Deveel.Messaging;
+
+[Trait("Category", "Unit")]
+[Trait("Layer", "Domain")]
+[Trait("Feature", "QuickReplyContent")]
+public class QuickReplyContentTests {
+	[Fact]
+	public void Should_SetProperties_When_QuickReplyContentConstructor() {
+		var content = new QuickReplyContent("Yes", "YES_PAYLOAD", "https://example.com/icon.png");
+
+		Assert.Equal("Yes", content.Title);
+		Assert.Equal("YES_PAYLOAD", content.Payload);
+		Assert.Equal("https://example.com/icon.png", content.ImageUrl);
+		Assert.Equal(MessageContentType.QuickReply, content.ContentType);
+	}
+
+	[Fact]
+	public void Should_UseDefaults_When_ParameterlessConstructor() {
+		var content = new QuickReplyContent();
+
+		Assert.Equal(string.Empty, content.Title);
+		Assert.Null(content.Payload);
+		Assert.Null(content.ImageUrl);
+	}
+
+	[Fact]
+	public void Should_SetTitleOnly_When_QuickReplyContentConstructorWithoutPayload() {
+		var content = new QuickReplyContent("No");
+
+		Assert.Equal("No", content.Title);
+		Assert.Null(content.Payload);
+		Assert.Null(content.ImageUrl);
+	}
+
+	[Fact]
+	public void Should_CopyProperties_When_QuickReplyContentCopyConstructor() {
+		var source = new QuickReplyContent("Maybe", "MAYBE_PAYLOAD", "https://img.url");
+		var copy = new QuickReplyContent(source);
+
+		Assert.Equal(source.Title, copy.Title);
+		Assert.Equal(source.Payload, copy.Payload);
+		Assert.Equal(source.ImageUrl, copy.ImageUrl);
+	}
+
+	[Fact]
+	public void Should_UpdateValues_When_QuickReplyContentPropertySetters() {
+		var content = new QuickReplyContent("Initial");
+		content.Title = "Updated";
+		content.Payload = "UPDATED_PAYLOAD";
+		content.ImageUrl = "https://new.img";
+
+		Assert.Equal("Updated", content.Title);
+		Assert.Equal("UPDATED_PAYLOAD", content.Payload);
+		Assert.Equal("https://new.img", content.ImageUrl);
+	}
+
+	[Fact]
+	public void Should_ExposeCorrectType_When_IQuickReplyContentInterface() {
+		IQuickReplyContent content = new QuickReplyContent("Test", "p", "img");
+
+		Assert.Equal("Test", content.Title);
+		Assert.Equal("p", content.Payload);
+		Assert.Equal("img", content.ImageUrl);
+	}
+
+	[Fact]
+	public void Should_BeInteractive_When_IInteractiveContentInterface() {
+		IInteractiveContent content = new QuickReplyContent("Test");
+		Assert.Equal(MessageContentType.QuickReply, content.ContentType);
+	}
+}

--- a/test/Deveel.Messaging.Connector.Facebook.XUnit/Deveel.Messaging.Connector.Facebook.XUnit.csproj
+++ b/test/Deveel.Messaging.Connector.Facebook.XUnit/Deveel.Messaging.Connector.Facebook.XUnit.csproj
@@ -27,6 +27,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Deveel.Messaging.Connector.Facebook\Deveel.Messaging.Connector.Facebook.csproj" />
     <ProjectReference Include="..\..\test\Deveel.Messaging.Connector.Abstractions.XUnit\Deveel.Messaging.Connector.Abstractions.XUnit.csproj" />
+    <ProjectReference Include="..\..\test\Deveel.Messaging.Testing\Deveel.Messaging.Testing.csproj" />
   </ItemGroup>
 
 </Project>

--- a/test/Deveel.Messaging.Connector.Facebook.XUnit/Unit/FacebookChannelSchemasTests.cs
+++ b/test/Deveel.Messaging.Connector.Facebook.XUnit/Unit/FacebookChannelSchemasTests.cs
@@ -158,13 +158,15 @@ public class FacebookChannelSchemasTests
         var expectedCapabilities = ChannelCapability.SendMessages | 
                                   ChannelCapability.ReceiveMessages |
                                   ChannelCapability.MediaAttachments |
-                                  ChannelCapability.HealthCheck;
+                                  ChannelCapability.HealthCheck |
+                                  ChannelCapability.InteractiveContent;
 
         Assert.Equal(expectedCapabilities, schema.Capabilities);
         Assert.True(schema.Capabilities.HasFlag(ChannelCapability.SendMessages));
         Assert.True(schema.Capabilities.HasFlag(ChannelCapability.ReceiveMessages));
         Assert.True(schema.Capabilities.HasFlag(ChannelCapability.MediaAttachments));
         Assert.True(schema.Capabilities.HasFlag(ChannelCapability.HealthCheck));
+        Assert.True(schema.Capabilities.HasFlag(ChannelCapability.InteractiveContent));
     }
 
     [Fact]
@@ -217,7 +219,11 @@ public class FacebookChannelSchemasTests
         var contentTypes = schema.ContentTypes.ToList();
         Assert.Contains(MessageContentType.PlainText, contentTypes);
         Assert.Contains(MessageContentType.Media, contentTypes);
-        Assert.Equal(2, contentTypes.Count);
+        Assert.Contains(MessageContentType.Button, contentTypes);
+        Assert.Contains(MessageContentType.QuickReply, contentTypes);
+        Assert.Contains(MessageContentType.Carousel, contentTypes);
+        Assert.Contains(MessageContentType.ListPicker, contentTypes);
+        Assert.Equal(6, contentTypes.Count);
     }
 
     [Fact]

--- a/test/Deveel.Messaging.Connector.Facebook.XUnit/Unit/FacebookInteractiveMappingTests.cs
+++ b/test/Deveel.Messaging.Connector.Facebook.XUnit/Unit/FacebookInteractiveMappingTests.cs
@@ -1,0 +1,71 @@
+//
+// Copyright (c) Antonello Provenzano and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+//
+
+using Deveel.Messaging.Testing;
+
+namespace Deveel.Messaging;
+
+[Trait("Category", "Unit")]
+[Trait("Layer", "Infrastructure")]
+[Trait("Feature", "FacebookInteractiveMapping")]
+public class FacebookInteractiveMappingTests
+{
+    private static Message CreateMessage(MessageContent content)
+    {
+        return new Message
+        {
+            Id = "msg-1",
+            Sender = new Endpoint(EndpointType.UserId, "sender-1"),
+            Receiver = new Endpoint(EndpointType.UserId, "user-1"),
+            Content = content
+        };
+    }
+
+    [Fact]
+    public void Should_MapButtonContent_When_BuildFacebookMessage()
+    {
+        var content = InteractiveContentBuilder.CreateButton();
+        var message = CreateMessage(content);
+
+        var fbMessage = FacebookMessageBuilder.BuildFacebookMessage(message);
+
+        FacebookInteractiveMappingAssertions.AssertMapsToButton(content, fbMessage);
+    }
+
+    [Fact]
+    public void Should_MapQuickReplyContent_When_BuildFacebookMessage()
+    {
+        var content = InteractiveContentBuilder.CreateQuickReply();
+        var message = CreateMessage(content);
+
+        var fbMessage = FacebookMessageBuilder.BuildFacebookMessage(message);
+
+        Assert.NotNull(fbMessage.QuickReplies);
+        var qr = Assert.Single(fbMessage.QuickReplies);
+        FacebookInteractiveMappingAssertions.AssertMapsToQuickReply(content, qr);
+    }
+
+    [Fact]
+    public void Should_MapCarouselContent_When_BuildFacebookMessage()
+    {
+        var content = InteractiveContentBuilder.CreateCarousel(3);
+        var message = CreateMessage(content);
+
+        var fbMessage = FacebookMessageBuilder.BuildFacebookMessage(message);
+
+        FacebookInteractiveMappingAssertions.AssertMapsToCarousel(content, fbMessage);
+    }
+
+    [Fact]
+    public void Should_MapListPickerContent_When_BuildFacebookMessage()
+    {
+        var content = InteractiveContentBuilder.CreateListPicker(3);
+        var message = CreateMessage(content);
+
+        var fbMessage = FacebookMessageBuilder.BuildFacebookMessage(message);
+
+        FacebookInteractiveMappingAssertions.AssertMapsToListPicker(content, fbMessage);
+    }
+}

--- a/test/Deveel.Messaging.Connector.Facebook.XUnit/Unit/FacebookServiceTests.cs
+++ b/test/Deveel.Messaging.Connector.Facebook.XUnit/Unit/FacebookServiceTests.cs
@@ -294,6 +294,113 @@ public class FacebookServiceTests
 
     #endregion
 
+    #region BuildMessageContent Tests
+
+    private static object? BuildMessageContent(FacebookMessage message) {
+        var method = typeof(FacebookService).GetMethod("BuildMessageContent",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        return method!.Invoke(null, new object[] { message });
+    }
+
+    private static Dictionary<string, object?> AsDict(object? obj) =>
+        obj as Dictionary<string, object?> ?? new();
+
+    [Fact]
+    public void Should_SetText_When_BuildMessageContentWithTextOnly() {
+        var message = new FacebookMessage { Text = "Hello" };
+
+        var content = BuildMessageContent(message);
+        var dict = AsDict(content);
+
+        Assert.Contains("text", dict.Keys);
+        Assert.Equal("Hello", dict["text"]);
+        Assert.DoesNotContain("attachment", dict.Keys);
+    }
+
+    [Fact]
+    public void Should_SetAttachment_When_BuildMessageContentWithAttachment() {
+        var message = new FacebookMessage {
+            Text = "See this:",
+            Attachment = new FacebookAttachment {
+                Type = "image",
+                Payload = new FacebookPayload {
+                    Url = "https://example.com/img.png",
+                    IsReusable = true
+                }
+            }
+        };
+
+        var content = BuildMessageContent(message);
+        var dict = AsDict(content);
+
+        Assert.Contains("attachment", dict.Keys);
+        var attachment = (dynamic)dict["attachment"]!;
+        Assert.Equal("image", attachment.type);
+    }
+
+    [Fact]
+    public void Should_SetTemplate_When_BuildMessageContentWithTemplate() {
+        var message = new FacebookMessage {
+            Text = "Pick one:",
+            Template = new FacebookTemplate {
+                Payload = new Dictionary<string, object> {
+                    ["template_type"] = "button",
+                    ["text"] = "Tap",
+                    ["buttons"] = new[] { new Dictionary<string, object> { ["type"] = "postback", ["title"] = "A", ["payload"] = "A" } }
+                }
+            }
+        };
+
+        var content = BuildMessageContent(message);
+        var dict = AsDict(content);
+
+        Assert.Contains("attachment", dict.Keys);
+        var attachment = (dynamic)dict["attachment"]!;
+        Assert.Equal("template", attachment.type);
+    }
+
+    [Fact]
+    public void Should_PreferAttachmentOverTemplate_When_BothSet() {
+        var message = new FacebookMessage {
+            Text = "Hi",
+            Attachment = new FacebookAttachment {
+                Type = "image",
+                Payload = new FacebookPayload {
+                    Url = "https://example.com/img.png",
+                    IsReusable = false
+                }
+            },
+            Template = new FacebookTemplate {
+                Payload = new Dictionary<string, object> {
+                    ["template_type"] = "button",
+                    ["text"] = "Tap",
+                    ["buttons"] = Array.Empty<object>()
+                }
+            }
+        };
+
+        var content = BuildMessageContent(message);
+        var dict = AsDict(content);
+        var attachment = (dynamic)dict["attachment"]!;
+
+        // Should be the media attachment, not the template
+        Assert.Equal("image", attachment.type);
+    }
+
+    [Fact]
+    public void Should_NotContainAttachment_When_NeitherSet() {
+        var message = new FacebookMessage {
+            Text = "Just text"
+        };
+
+        var content = BuildMessageContent(message);
+        var dict = AsDict(content);
+
+        Assert.DoesNotContain("attachment", dict.Keys);
+    }
+
+    #endregion
+
     #region Argument Validation Edge Cases
 
     [Fact]

--- a/test/Deveel.Messaging.Connector.Telegram.XUnit/Deveel.Messaging.Connector.Telegram.XUnit.csproj
+++ b/test/Deveel.Messaging.Connector.Telegram.XUnit/Deveel.Messaging.Connector.Telegram.XUnit.csproj
@@ -31,6 +31,7 @@
     <ProjectReference Include="..\..\src\Deveel.Messaging.Connector.Telegram\Deveel.Messaging.Connector.Telegram.csproj" />
     <ProjectReference Include="..\..\src\Deveel.Messaging.Connector.Abstractions\Deveel.Messaging.Connector.Abstractions.csproj" />
     <ProjectReference Include="..\..\src\Deveel.Messaging.Abstractions\Deveel.Messaging.Abstractions.csproj" />
+    <ProjectReference Include="..\..\test\Deveel.Messaging.Testing\Deveel.Messaging.Testing.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Deveel.Messaging.Connector.Telegram.XUnit/Unit/TelegramInteractiveMappingTests.cs
+++ b/test/Deveel.Messaging.Connector.Telegram.XUnit/Unit/TelegramInteractiveMappingTests.cs
@@ -23,6 +23,33 @@ public class TelegramInteractiveMappingTests
     }
 
     [Fact]
+    public void Should_Throw_When_CreateInlineKeyboardWithPhoneNumberButton()
+    {
+        var button = new ButtonContent("Call", ButtonType.PhoneNumber, "+1234567890");
+
+        Assert.Throws<NotSupportedException>(() =>
+            TelegramMessageBuilder.CreateInlineKeyboardMarkup(new[] { button }));
+    }
+
+    [Fact]
+    public void Should_Throw_When_CreateInlineKeyboardWithUrlButtonWithoutValue()
+    {
+        var button = new ButtonContent("Visit", ButtonType.Url, null);
+
+        Assert.Throws<ArgumentException>(() =>
+            TelegramMessageBuilder.CreateInlineKeyboardMarkup(new[] { button }));
+    }
+
+    [Fact]
+    public void Should_Throw_When_CreateInlineKeyboardWithUrlButtonWithEmptyValue()
+    {
+        var button = new ButtonContent("Visit", ButtonType.Url, "");
+
+        Assert.Throws<ArgumentException>(() =>
+            TelegramMessageBuilder.CreateInlineKeyboardMarkup(new[] { button }));
+    }
+
+    [Fact]
     public void Should_MapQuickReplyContent_When_CreateReplyKeyboardMarkup()
     {
         var quickReplies = InteractiveContentBuilder.CreateQuickReplies(3);

--- a/test/Deveel.Messaging.Connector.Telegram.XUnit/Unit/TelegramInteractiveMappingTests.cs
+++ b/test/Deveel.Messaging.Connector.Telegram.XUnit/Unit/TelegramInteractiveMappingTests.cs
@@ -1,0 +1,34 @@
+//
+// Copyright (c) Antonello Provenzano and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for details.
+//
+
+using Deveel.Messaging.Testing;
+
+namespace Deveel.Messaging;
+
+[Trait("Category", "Unit")]
+[Trait("Layer", "Infrastructure")]
+[Trait("Feature", "TelegramInteractiveMapping")]
+public class TelegramInteractiveMappingTests
+{
+    [Fact]
+    public void Should_MapButtonContent_When_CreateInlineKeyboardMarkup()
+    {
+        var buttons = InteractiveContentBuilder.CreateButtons(2);
+
+        var markup = TelegramMessageBuilder.CreateInlineKeyboardMarkup(buttons);
+
+        TelegramInteractiveMappingAssertions.AssertMapsToInlineKeyboard(buttons, markup);
+    }
+
+    [Fact]
+    public void Should_MapQuickReplyContent_When_CreateReplyKeyboardMarkup()
+    {
+        var quickReplies = InteractiveContentBuilder.CreateQuickReplies(3);
+
+        var markup = TelegramMessageBuilder.CreateReplyKeyboardMarkup(quickReplies);
+
+        TelegramInteractiveMappingAssertions.AssertMapsToReplyKeyboard(quickReplies, markup);
+    }
+}

--- a/test/Deveel.Messaging.Connectors.XUnit/Unit/InteractiveContentValidatorTests.cs
+++ b/test/Deveel.Messaging.Connectors.XUnit/Unit/InteractiveContentValidatorTests.cs
@@ -53,6 +53,34 @@ public class InteractiveContentValidatorTests {
 	}
 
 	[Fact]
+	public void Should_ReturnError_When_ValidateButtonCountListPickerExceedsMax() {
+		var picker = new ListPickerContent(items: new[] {
+			new ListPickerItem("Item 1"),
+			new ListPickerItem("Item 2"),
+			new ListPickerItem("Item 3")
+		});
+		var message = new Message { Content = picker };
+
+		var result = InteractiveContentValidator.ValidateButtonCount(message, 2);
+
+		Assert.NotNull(result);
+		Assert.Contains("exceed the maximum", result.ErrorMessage);
+	}
+
+	[Fact]
+	public void Should_ReturnNull_When_ValidateButtonCountListPickerWithinLimit() {
+		var picker = new ListPickerContent(items: new[] {
+			new ListPickerItem("Item 1"),
+			new ListPickerItem("Item 2")
+		});
+		var message = new Message { Content = picker };
+
+		var result = InteractiveContentValidator.ValidateButtonCount(message, 3);
+
+		Assert.Null(result);
+	}
+
+	[Fact]
 	public void Should_ReturnNull_When_ValidateButtonCountCarouselWithinLimit() {
 		var carousel = new CarouselContent();
 		carousel.AddCard(new CarouselCard("Card", "Sub") {

--- a/test/Deveel.Messaging.Connectors.XUnit/Unit/InteractiveContentValidatorTests.cs
+++ b/test/Deveel.Messaging.Connectors.XUnit/Unit/InteractiveContentValidatorTests.cs
@@ -1,0 +1,159 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Deveel.Messaging;
+
+[Trait("Category", "Unit")]
+[Trait("Layer", "Domain")]
+[Trait("Feature", "InteractiveContentValidator")]
+public class InteractiveContentValidatorTests {
+	[Fact]
+	public void Should_ReturnNull_When_ValidateButtonCountWithNonInteractiveContent() {
+		var message = new Message { Content = new TextContent("Hello") };
+
+		var result = InteractiveContentValidator.ValidateButtonCount(message, 3);
+
+		Assert.Null(result);
+	}
+
+	[Fact]
+	public void Should_ReturnError_When_ValidateButtonCountWithButtonAndMaxLessThanOne() {
+		var message = new Message { Content = new ButtonContent("Click", ButtonType.Postback) };
+
+		var result = InteractiveContentValidator.ValidateButtonCount(message, 0);
+
+		Assert.NotNull(result);
+		Assert.Contains("at least 1", result.ErrorMessage);
+	}
+
+	[Fact]
+	public void Should_ReturnNull_When_ValidateButtonCountWithButtonAndMaxIsOne() {
+		var message = new Message { Content = new ButtonContent("Click", ButtonType.Postback) };
+
+		var result = InteractiveContentValidator.ValidateButtonCount(message, 1);
+
+		Assert.Null(result);
+	}
+
+	[Fact]
+	public void Should_ReturnError_When_ValidateButtonCountCarouselCardExceedsMax() {
+		var carousel = new CarouselContent();
+		carousel.AddCard(new CarouselCard("Card", "Sub") {
+			Buttons = {
+				new ButtonContent("A", ButtonType.Postback),
+				new ButtonContent("B", ButtonType.Postback),
+				new ButtonContent("C", ButtonType.Postback)
+			}
+		});
+		var message = new Message { Content = carousel };
+
+		var result = InteractiveContentValidator.ValidateButtonCount(message, 2);
+
+		Assert.NotNull(result);
+		Assert.Contains("exceed the maximum", result.ErrorMessage);
+	}
+
+	[Fact]
+	public void Should_ReturnNull_When_ValidateButtonCountCarouselWithinLimit() {
+		var carousel = new CarouselContent();
+		carousel.AddCard(new CarouselCard("Card", "Sub") {
+			Buttons = { new ButtonContent("A", ButtonType.Postback) }
+		});
+		var message = new Message { Content = carousel };
+
+		var result = InteractiveContentValidator.ValidateButtonCount(message, 3);
+
+		Assert.Null(result);
+	}
+
+	[Fact]
+	public void Should_ReturnNull_When_ValidateCarouselCardCountWithinLimit() {
+		var carousel = new CarouselContent(new[] {
+			new CarouselCard("Card 1"),
+			new CarouselCard("Card 2")
+		});
+
+		var result = InteractiveContentValidator.ValidateCarouselCardCount(carousel, 5);
+
+		Assert.Null(result);
+	}
+
+	[Fact]
+	public void Should_ReturnError_When_ValidateCarouselCardCountExceedsLimit() {
+		var carousel = new CarouselContent(new[] {
+			new CarouselCard("Card 1"),
+			new CarouselCard("Card 2"),
+			new CarouselCard("Card 3")
+		});
+
+		var result = InteractiveContentValidator.ValidateCarouselCardCount(carousel, 2);
+
+		Assert.NotNull(result);
+		Assert.Contains("exceed the maximum", result.ErrorMessage);
+	}
+
+	[Fact]
+	public void Should_ReturnNull_When_ValidateListItemCountWithinRange() {
+		var picker = new ListPickerContent(items: new[] {
+			new ListPickerItem("Item 1"),
+			new ListPickerItem("Item 2")
+		});
+
+		var result = InteractiveContentValidator.ValidateListItemCount(picker, 1, 5);
+
+		Assert.Null(result);
+	}
+
+	[Fact]
+	public void Should_ReturnError_When_ValidateListItemCountBelowMinimum() {
+		var picker = new ListPickerContent(items: new[] {
+			new ListPickerItem("Item 1")
+		});
+
+		var result = InteractiveContentValidator.ValidateListItemCount(picker, 2, 5);
+
+		Assert.NotNull(result);
+		Assert.Contains("requires at least", result.ErrorMessage);
+	}
+
+	[Fact]
+	public void Should_ReturnError_When_ValidateListItemCountAboveMaximum() {
+		var picker = new ListPickerContent(items: new[] {
+			new ListPickerItem("Item 1"),
+			new ListPickerItem("Item 2"),
+			new ListPickerItem("Item 3")
+		});
+
+		var result = InteractiveContentValidator.ValidateListItemCount(picker, 1, 2);
+
+		Assert.NotNull(result);
+		Assert.Contains("exceed the maximum", result.ErrorMessage);
+	}
+
+	[Fact]
+	public void Should_ReturnNull_When_ValidateButtonTypeIsAllowed() {
+		var button = new ButtonContent("Click", ButtonType.Postback);
+
+		var result = InteractiveContentValidator.ValidateButtonType(button, ButtonType.Postback, ButtonType.Url);
+
+		Assert.Null(result);
+	}
+
+	[Fact]
+	public void Should_ReturnError_When_ValidateButtonTypeIsNotAllowed() {
+		var button = new ButtonContent("Click", ButtonType.PhoneNumber);
+
+		var result = InteractiveContentValidator.ValidateButtonType(button, ButtonType.Url, ButtonType.Postback);
+
+		Assert.NotNull(result);
+		Assert.Contains("not supported", result.ErrorMessage);
+	}
+
+	[Fact]
+	public void Should_ReturnNull_When_ValidateButtonTypeWithEmptyAllowed() {
+		var button = new ButtonContent("Click", ButtonType.Url);
+
+		var result = InteractiveContentValidator.ValidateButtonType(button);
+
+		Assert.Null(result);
+	}
+}

--- a/test/Deveel.Messaging.Testing/Deveel.Messaging.Testing.csproj
+++ b/test/Deveel.Messaging.Testing/Deveel.Messaging.Testing.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <IsTestProject>false</IsTestProject>
+    <UseMicrosoftTestingPlatformRunner>false</UseMicrosoftTestingPlatformRunner>
+    <TestingPlatformDotnetTestSupport>false</TestingPlatformDotnetTestSupport>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Bogus" Version="35.6.2" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Deveel.Messaging.Abstractions\Deveel.Messaging.Abstractions.csproj" />
+    <ProjectReference Include="..\..\src\Deveel.Messaging.Connector.Facebook\Deveel.Messaging.Connector.Facebook.csproj" />
+    <ProjectReference Include="..\..\src\Deveel.Messaging.Connector.Telegram\Deveel.Messaging.Connector.Telegram.csproj" />
+  </ItemGroup>
+</Project>

--- a/test/Deveel.Messaging.Testing/FacebookInteractiveMappingAssertions.cs
+++ b/test/Deveel.Messaging.Testing/FacebookInteractiveMappingAssertions.cs
@@ -1,5 +1,7 @@
 using Xunit;
 
+using Deveel.Messaging;
+
 namespace Deveel.Messaging.Testing;
 
 public static class FacebookInteractiveMappingAssertions {

--- a/test/Deveel.Messaging.Testing/FacebookInteractiveMappingAssertions.cs
+++ b/test/Deveel.Messaging.Testing/FacebookInteractiveMappingAssertions.cs
@@ -1,0 +1,47 @@
+using Xunit;
+
+namespace Deveel.Messaging.Testing;
+
+public static class FacebookInteractiveMappingAssertions {
+	public static void AssertMapsToQuickReply(IQuickReplyContent source, FacebookQuickReply target) {
+		Assert.NotNull(target);
+		Assert.Equal(source.Title, target.Title);
+		Assert.Equal(source.Payload ?? source.Title, target.Payload);
+		Assert.Equal(source.ImageUrl, target.ImageUrl);
+	}
+
+	public static void AssertMapsToButton(IButtonContent source, FacebookMessage target) {
+		Assert.NotNull(target);
+		Assert.NotNull(target.Template);
+		Assert.Equal("button", target.Template.TemplateType);
+		Assert.True(target.Template.Payload.ContainsKey("template_type"));
+		Assert.Equal("button", target.Template.Payload["template_type"]);
+		Assert.True(target.Template.Payload.ContainsKey("text"));
+		Assert.Equal(source.Text, target.Template.Payload["text"]);
+		Assert.True(target.Template.Payload.ContainsKey("buttons"));
+	}
+
+	public static void AssertMapsToCarousel(ICarouselContent source, FacebookMessage target) {
+		Assert.NotNull(target);
+		Assert.NotNull(target.Template);
+		Assert.Equal("generic", target.Template.TemplateType);
+		Assert.True(target.Template.Payload.ContainsKey("elements"));
+		Assert.Equal(source.Cards.Count, ((System.Collections.IList)target.Template.Payload["elements"]).Count);
+	}
+
+	public static void AssertMapsToListPicker(IListPickerContent source, FacebookMessage target) {
+		Assert.NotNull(target);
+		Assert.NotNull(target.Template);
+		Assert.Equal("list", target.Template.TemplateType);
+		Assert.True(target.Template.Payload.ContainsKey("elements"));
+		Assert.Equal(source.Items.Count, ((System.Collections.IList)target.Template.Payload["elements"]).Count);
+		var expectedStyle = source.Style switch {
+			ListPickerStyle.Inlined => "compact",
+			ListPickerStyle.Compact => "compact",
+			ListPickerStyle.Large => "large",
+			_ => "large"
+		};
+		Assert.True(target.Template.Payload.ContainsKey("top_element_style"));
+		Assert.Equal(expectedStyle, target.Template.Payload["top_element_style"]);
+	}
+}

--- a/test/Deveel.Messaging.Testing/InteractiveContentBuilder.cs
+++ b/test/Deveel.Messaging.Testing/InteractiveContentBuilder.cs
@@ -1,13 +1,17 @@
+using Bogus;
+
 using Deveel.Messaging;
 
 namespace Deveel.Messaging.Testing;
 
 public static class InteractiveContentBuilder {
+	private static readonly ButtonType[] SupportedButtonTypes = { ButtonType.Url, ButtonType.Postback };
+
 	public static ButtonContent CreateButton(Action<ButtonContent>? configure = null) {
-		var faker = new Bogus.Faker();
+		var faker = new Faker("en") { Random = new Randomizer(0x5EED) };
 		var button = new ButtonContent(
 			faker.Lorem.Word(),
-			faker.PickRandom<ButtonType>(),
+			faker.PickRandom(SupportedButtonTypes),
 			faker.Internet.Url()
 		);
 		configure?.Invoke(button);
@@ -21,7 +25,7 @@ public static class InteractiveContentBuilder {
 	}
 
 	public static QuickReplyContent CreateQuickReply(Action<QuickReplyContent>? configure = null) {
-		var faker = new Bogus.Faker();
+		var faker = new Faker("en") { Random = new Randomizer(0x5EED) };
 		var qr = new QuickReplyContent(
 			faker.Lorem.Word(),
 			faker.Lorem.Sentence(),
@@ -38,7 +42,7 @@ public static class InteractiveContentBuilder {
 	}
 
 	public static CarouselContent CreateCarousel(int cardCount, Action<CarouselContent>? configure = null) {
-		var faker = new Bogus.Faker();
+		var faker = new Faker("en") { Random = new Randomizer(0x5EED) };
 		var carousel = new CarouselContent();
 		for (int i = 0; i < cardCount; i++) {
 			carousel.AddCard(new CarouselCard(
@@ -52,7 +56,7 @@ public static class InteractiveContentBuilder {
 	}
 
 	public static ListPickerContent CreateListPicker(int itemCount, Action<ListPickerContent>? configure = null) {
-		var faker = new Bogus.Faker();
+		var faker = new Faker("en") { Random = new Randomizer(0x5EED) };
 		var picker = new ListPickerContent(
 			faker.Lorem.Sentence(),
 			faker.Lorem.Sentence(),

--- a/test/Deveel.Messaging.Testing/InteractiveContentBuilder.cs
+++ b/test/Deveel.Messaging.Testing/InteractiveContentBuilder.cs
@@ -1,0 +1,70 @@
+namespace Deveel.Messaging.Testing;
+
+public static class InteractiveContentBuilder {
+	public static ButtonContent CreateButton(Action<ButtonContent>? configure = null) {
+		var faker = new Bogus.Faker();
+		var button = new ButtonContent(
+			faker.Lorem.Word(),
+			faker.PickRandom<ButtonType>(),
+			faker.Internet.Url()
+		);
+		configure?.Invoke(button);
+		return button;
+	}
+
+	public static List<ButtonContent> CreateButtons(int count, Action<ButtonContent>? configure = null) {
+		return Enumerable.Range(0, count)
+			.Select(_ => CreateButton(configure))
+			.ToList();
+	}
+
+	public static QuickReplyContent CreateQuickReply(Action<QuickReplyContent>? configure = null) {
+		var faker = new Bogus.Faker();
+		var qr = new QuickReplyContent(
+			faker.Lorem.Word(),
+			faker.Lorem.Sentence(),
+			faker.Internet.Url()
+		);
+		configure?.Invoke(qr);
+		return qr;
+	}
+
+	public static List<QuickReplyContent> CreateQuickReplies(int count, Action<QuickReplyContent>? configure = null) {
+		return Enumerable.Range(0, count)
+			.Select(_ => CreateQuickReply(configure))
+			.ToList();
+	}
+
+	public static CarouselContent CreateCarousel(int cardCount, Action<CarouselContent>? configure = null) {
+		var faker = new Bogus.Faker();
+		var carousel = new CarouselContent();
+		for (int i = 0; i < cardCount; i++) {
+			carousel.AddCard(new CarouselCard(
+				faker.Lorem.Sentence(),
+				faker.Lorem.Sentence(),
+				faker.Internet.Url()
+			));
+		}
+		configure?.Invoke(carousel);
+		return carousel;
+	}
+
+	public static ListPickerContent CreateListPicker(int itemCount, Action<ListPickerContent>? configure = null) {
+		var faker = new Bogus.Faker();
+		var picker = new ListPickerContent(
+			faker.Lorem.Sentence(),
+			faker.Lorem.Sentence(),
+			style: faker.PickRandom<ListPickerStyle>()
+		);
+		for (int i = 0; i < itemCount; i++) {
+			picker.AddItem(new ListPickerItem(
+				faker.Lorem.Word(),
+				faker.Lorem.Sentence(),
+				faker.Internet.Url(),
+				faker.Lorem.Sentence()
+			));
+		}
+		configure?.Invoke(picker);
+		return picker;
+	}
+}

--- a/test/Deveel.Messaging.Testing/InteractiveContentBuilder.cs
+++ b/test/Deveel.Messaging.Testing/InteractiveContentBuilder.cs
@@ -1,3 +1,5 @@
+using Deveel.Messaging;
+
 namespace Deveel.Messaging.Testing;
 
 public static class InteractiveContentBuilder {

--- a/test/Deveel.Messaging.Testing/TelegramInteractiveMappingAssertions.cs
+++ b/test/Deveel.Messaging.Testing/TelegramInteractiveMappingAssertions.cs
@@ -1,0 +1,50 @@
+using Xunit;
+
+using Telegram.Bot.Types.ReplyMarkups;
+
+namespace Deveel.Messaging.Testing;
+
+public static class TelegramInteractiveMappingAssertions {
+	public static void AssertMapsToInlineKeyboard(IReadOnlyList<IButtonContent> source, InlineKeyboardMarkup target) {
+		Assert.NotNull(target);
+		var buttons = target.InlineKeyboard;
+		Assert.NotNull(buttons);
+		Assert.Equal(source.Count, buttons.Count());
+
+		var index = 0;
+		foreach (var row in buttons) {
+			var sourceButton = source[index];
+			var tgButton = Assert.Single(row);
+
+			switch (sourceButton.ButtonType) {
+				case ButtonType.Url:
+					Assert.Equal(sourceButton.Text, tgButton.Text);
+					Assert.Equal(sourceButton.Value, tgButton.Url);
+					break;
+				case ButtonType.Postback:
+					Assert.Equal(sourceButton.Text, tgButton.Text);
+					Assert.Equal(sourceButton.Value ?? sourceButton.Text, tgButton.CallbackData);
+					break;
+			}
+
+			index++;
+		}
+	}
+
+	public static void AssertMapsToReplyKeyboard(IReadOnlyList<IQuickReplyContent> source, ReplyKeyboardMarkup target) {
+		Assert.NotNull(target);
+		Assert.True(target.OneTimeKeyboard);
+		Assert.True(target.ResizeKeyboard);
+		var keyboard = target.Keyboard;
+		Assert.NotNull(keyboard);
+		Assert.Equal(source.Count, keyboard.Count());
+
+		var index = 0;
+		foreach (var row in keyboard) {
+			var sourceQr = source[index];
+			var tgButton = Assert.Single(row);
+			Assert.Equal(sourceQr.Title, tgButton.Text);
+			index++;
+		}
+	}
+}

--- a/test/Deveel.Messaging.Testing/TelegramInteractiveMappingAssertions.cs
+++ b/test/Deveel.Messaging.Testing/TelegramInteractiveMappingAssertions.cs
@@ -2,6 +2,8 @@ using Xunit;
 
 using Telegram.Bot.Types.ReplyMarkups;
 
+using Deveel.Messaging;
+
 namespace Deveel.Messaging.Testing;
 
 public static class TelegramInteractiveMappingAssertions {


### PR DESCRIPTION
This pull request introduces support for interactive content types—such as buttons, quick replies, carousels, and list pickers—across the messaging model, Facebook Messenger, and Telegram Bot connectors. It updates documentation, expands the sample applications, and enhances DTOs to support these new content types, making it easier to build and test rich interactive messages.

**Interactive Content Support**

- Added new content classes: `ButtonContent`, `QuickReplyContent`, `CarouselContent`, and `ListPickerContent` to the messaging model, with documentation and usage examples for each. Channel support tables clarify which connectors support which content types. [[1]](diffhunk://#diff-3650bec5a5ab213152299fb7b43cc8a3bce34480cd646ba468100213a6fe7b78L131-R131) [[2]](diffhunk://#diff-3650bec5a5ab213152299fb7b43cc8a3bce34480cd646ba468100213a6fe7b78R260-R363)
- Updated Facebook Messenger and Telegram Bot connector docs to list `InteractiveContent` as a capability and enumerate new content types (`Button`, `QuickReply`, `Carousel`, `ListPicker`). Provided code samples for building messages with these types. [[1]](diffhunk://#diff-b19cfe0e1d16c4e7e2fda207d5db05eb7bbb11daea1e27248b5aeb4008084009L34-R35) [[2]](diffhunk://#diff-b19cfe0e1d16c4e7e2fda207d5db05eb7bbb11daea1e27248b5aeb4008084009R81-R129) [[3]](diffhunk://#diff-a5fdbf7fdc760ec2692577be66a572bcbe4a5e785ec8f0bb27780e572c70af6dL34-R35) [[4]](diffhunk://#diff-a5fdbf7fdc760ec2692577be66a572bcbe4a5e785ec8f0bb27780e572c70af6dR120-R140)

**Sample Application Enhancements**

- Expanded the Facebook Messenger sample app to allow sending and validating messages of new interactive types (button, quick reply, carousel, list picker), including new builder and helper methods for constructing these messages interactively. [[1]](diffhunk://#diff-e32e340420c2a1e63daa411f48fcdff193ba0e29d576f109a0df982c5390fc3aR71-R77) [[2]](diffhunk://#diff-e32e340420c2a1e63daa411f48fcdff193ba0e29d576f109a0df982c5390fc3aL113-R129) [[3]](diffhunk://#diff-e32e340420c2a1e63daa411f48fcdff193ba0e29d576f109a0df982c5390fc3aR209-R301) [[4]](diffhunk://#diff-e32e340420c2a1e63daa411f48fcdff193ba0e29d576f109a0df982c5390fc3aR389-R432)

**DTO and Data Model Updates**

- Extended `MessageContentDto` and added new DTO classes (`CarouselCardDto`, `ListPickerItemDto`) in the multi-connector sample to carry data for buttons, quick replies, carousels, and list pickers.

**Solution and Project Structure**

- Added the `Deveel.Messaging.Testing` project to the solution and configured build settings for all platforms. [[1]](diffhunk://#diff-d12b4991fdf0d562c041ce3dc14e9790845713a061ebe4402f0d61271bd2aec5R54-R55) [[2]](diffhunk://#diff-d12b4991fdf0d562c041ce3dc14e9790845713a061ebe4402f0d61271bd2aec5R294-R305) [[3]](diffhunk://#diff-d12b4991fdf0d562c041ce3dc14e9790845713a061ebe4402f0d61271bd2aec5R330)…ick replies, carousels, and list pickers