### PR TITLE
Refactor messaging services and enhance unit test coverage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,28 @@ dotnet test
 
 Keep changes small, readable, and easy to review.
 
+### Use of Automated Agents
+
+Automated agents (AI coding tools, LLM-generated code, etc.) may be used only in **accessory contexts**:
+
+- writing or updating **documentation**
+- writing or updating **tests**
+- generating **samples and scaffolding**
+- minor **refactoring** that does not alter behaviour (e.g. renaming, formatting)
+
+The **core source code** of the framework — including but not limited to the public API surface, connector implementations, message and content models, validation logic, configuration and DI registration, and any logic that runs in production — **must be written by humans**.
+
+#### Rationale
+
+Core messaging infrastructure handles routing, delivery, authentication, error handling, and sensitive data. Every line has implications for reliability, security, and correctness. Human-authored code in these areas benefits from:
+
+- deliberate consideration of edge cases that agents typically miss (timeouts, resource leaks, concurrent access, null states)
+- consistent architectural decisions aligned with the framework's design philosophy
+- accountability — a person owns every production path
+- lower review burden — reviewers trust human judgement in complex domains
+
+Agent-generated contributions to core code will be rejected during review, regardless of whether the agent output was subsequently edited. If you are unsure whether a change falls under core or accessory, ask in an issue or discussion first.
+
 ### Code
 
 - follow the existing coding style and `.editorconfig`

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Locks the public API and ships stable package releases with production-ready gua
 
 - [x] **API freeze and compatibility enforcement** - Prevent breaking API changes without a major version bump.
 - [x] **NuGet GA release** - Publish stable `Deveel.Messaging.*` packages without prerelease suffixes.
-- [ ] **Interactive content model** - Add cross-channel abstractions for buttons, quick replies, carousels, and lists.
+- [x] **Interactive content model** - Add cross-channel abstractions for buttons, quick replies, carousels, and lists.
 - [ ] **Sender identity model** - Provide typed sender identities for phone, email, and bot-based channels.
 
 ### v1.1.0 and beyond - Platform Expansion

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,17 +12,17 @@ This document describes the planned evolution of the **Deveel Messaging Framewor
 
 | Milestone | Version | Features |
 |-----------|---------|----------|
-| [Framework Foundations](#v040--framework-foundations) | v0.4.0 | [Test Coverage Target](#v041--test-coverage-target--80) · [CI/CD Pipeline Hardening](#v042--cicd-pipeline-hardening) · [Structured Logging Improvements](#v043--structured-logging-improvements) · [Documentation](#v044--documentation) |
-| [Inbound Messaging](#v050--inbound-messaging) | v0.5.0 | [Twilio Inbound Messages](#v051--twilio-inbound-messages-sms--whatsapp) · [SendGrid Inbound Messages](#v052--sendgrid-inbound-messages-inbound-parse) · [Firebase Inbound Messages](#v053--firebase-inbound-messages-data--notification-messages) |
-| [First Stable Release](#v100--first-stable-release) | v1.0.0 | [API Freeze](#v101--api-freeze) · [NuGet GA Release](#v102--nuget-ga-release) · [Interactive Content](#v103--interactive-content) · [Sender Identity Model](#v104--sender-identity-model) |
-| [Resilience & Observability](#v110--resilience--observability) | v1.1.0 | [Retry Policies](#v111--retry-policies) · [OpenTelemetry Tracing & Metrics](#v112--opentelemetry-tracing--metrics) · [Health Checks](#v113--health-checks) · [Connector-Level Timeout Configuration](#v114--connector-level-timeout-configuration) |
-| [New SaaS Connectors](#v120--new-saas-connectors) | v1.2.0 | [Slack](#v121--slack-connector) · [Microsoft Teams](#v122--microsoft-teams-connector) · [WhatsApp Business API](#v123--whatsapp-business-api-connector-direct-cloud-api) · [Viber Business](#v124--viber-business-connector) · [LINE](#v125--line-connector) |
-| [Protocol Connectors](#v130--protocol-connectors) | v1.3.0 | [Base Classes](#v131--protocol-connector-base-classes) · [SMPP](#v132--smpp-connector) · [SMTP](#v133--smtp-connector) · [RCS](#v134--rcs-connector) · [APNs](#v135--apns-connector-direct) |
-| [Content Adaptation & Transcoding](#v140--content-adaptation--transcoding) | v1.4.0 | [IContentTranscoder Abstraction](#v141--icontenttrancoder-abstraction) · [Built-In Transcoders](#v142--built-in-transcoders) · [Channel-Aware Fallback](#v143--channel-aware-content-fallback) · [SMS Segmentation](#v144--sms-segmentation) · [Character Encoding Detection](#v145--character-encoding-detection) |
-| [Address & Number Validation](#v150--address--number-validation) | v1.5.0 | [E.164 Normalization](#v151--e164-normalization) · [HLR Lookup](#v152--hlr-home-location-register-lookup) · [Number Portability](#v153--number-portability-awareness) · [Email Validation](#v154--email-address-validation) · [IAddressValidator Abstraction](#v155--iaddressvalidator-abstraction) |
-| [Tooling & Instrumentation](#v160--tooling--instrumentation) | v1.6.0 | [dotnet new Connector Scaffold](#v161--dotnet-new-connector-scaffold) · [ASP.NET Core Diagnostic Middleware](#v162--aspnet-core-diagnostic-middleware) |
-| [Conversations](#v200--conversations) | v2.0.0 | [IConversation Abstraction](#v201--iconversation-abstraction) · [Conversation State Model](#v202--conversation-state-model) · [Conversation Correlation](#v203--conversation-correlation) · [Multi-Channel Conversations](#v204--multi-channel-conversations) · [Multi-Tenant Channel Registry](#v205--multi-tenant-channel-registry) · [xUnit Test Helpers](#v206--xunit-test-helpers-for-conversation-flows) |
-| [Message Templates](#v210--message-templates) | v2.1.0 | [IMessageTemplate Abstraction](#v211--imessagetemplate-abstraction) · [Variable Substitution Engine](#v212--variable-substitution-engine) · [Per-Connector Template Rendering](#v213--per-connector-template-rendering) · [Template Registry](#v214--template-registry) |
+| [Framework Foundations](#v040--framework-foundations) | v0.4.0 | [Test Coverage Target](#test-coverage-target--80) · [CI/CD Pipeline Hardening](#cicd-pipeline-hardening) · [Structured Logging Improvements](#structured-logging-improvements) · [Documentation](#documentation) |
+| [Inbound Messaging](#v050--inbound-messaging) | v0.5.0 | [Twilio Inbound Messages](#twilio-inbound-messages-sms--whatsapp) · [SendGrid Inbound Messages](#sendgrid-inbound-messages-inbound-parse) · [Firebase Inbound Messages](#firebase-inbound-messages-data--notification-messages) |
+| [First Stable Release](#v100--first-stable-release) | v1.0.0 | [API Freeze](#api-freeze) · [NuGet GA Release](#nuget-ga-release) · [Interactive Content](#interactive-content) · [Sender Identity Model](#sender-identity-model) |
+| [Resilience & Observability](#v110--resilience--observability) | v1.1.0 | [Retry Policies](#retry-policies) · [OpenTelemetry Tracing & Metrics](#opentelemetry-tracing--metrics) · [Health Checks](#health-checks) · [Connector-Level Timeout Configuration](#connector-level-timeout-configuration) |
+| [New SaaS Connectors](#v120--new-saas-connectors) | v1.2.0 | [Slack](#slack-connector) · [Microsoft Teams](#microsoft-teams-connector) · [WhatsApp Business API](#whatsapp-business-api-connector-direct-cloud-api) · [Viber Business](#viber-business-connector) · [LINE](#line-connector) |
+| [Protocol Connectors](#v130--protocol-connectors) | v1.3.0 | [Base Classes](#protocol-connector-base-classes) · [SMPP](#smpp-connector) · [SMTP](#smtp-connector) · [RCS](#rcs-connector) · [APNs](#apns-connector-direct) |
+| [Content Adaptation & Transcoding](#v140--content-adaptation--transcoding) | v1.4.0 | [IContentTranscoder Abstraction](#icontenttrancoder-abstraction) · [Built-In Transcoders](#built-in-transcoders) · [Channel-Aware Fallback](#channel-aware-content-fallback) · [SMS Segmentation](#sms-segmentation) · [Character Encoding Detection](#character-encoding-detection) |
+| [Address & Number Validation](#v150--address--number-validation) | v1.5.0 | [E.164 Normalization](#e164-normalization) · [HLR Lookup](#hlr-home-location-register-lookup) · [Number Portability](#number-portability-awareness) · [Email Validation](#email-address-validation) · [IAddressValidator Abstraction](#iaddressvalidator-abstraction) |
+| [Tooling & Instrumentation](#v160--tooling--instrumentation) | v1.6.0 | [dotnet new Connector Scaffold](#dotnet-new-connector-scaffold) · [ASP.NET Core Diagnostic Middleware](#aspnet-core-diagnostic-middleware) |
+| [Conversations](#v200--conversations) | v2.0.0 | [IConversation Abstraction](#iconversation-abstraction) · [Conversation State Model](#conversation-state-model) · [Conversation Correlation](#conversation-correlation) · [Multi-Channel Conversations](#multi-channel-conversations) · [Multi-Tenant Channel Registry](#multi-tenant-channel-registry) · [xUnit Test Helpers](#xunit-test-helpers-for-conversation-flows) |
+| [Message Templates](#v210--message-templates) | v2.1.0 | [IMessageTemplate Abstraction](#imessagetemplate-abstraction) · [Variable Substitution Engine](#variable-substitution-engine) · [Per-Connector Template Rendering](#per-connector-template-rendering) · [Template Registry](#template-registry) |
 
 ---
 
@@ -32,7 +32,7 @@ Today the framework has a working outbound message model and five connector pack
 
 ---
 
-### v0.4.1 — Test Coverage Target (≥ 80%)
+### Test Coverage Target (≥ 80%)
 
 > *"Untested code is a liability disguised as a feature."*
 
@@ -51,7 +51,7 @@ A coverage measurement step in the CI pipeline (Coverlet + ReportGenerator) that
 
 ---
 
-### v0.4.2 — CI/CD Pipeline Hardening
+### CI/CD Pipeline Hardening
 
 > *"A release process that requires manual steps is a release process waiting to fail."*
 
@@ -70,7 +70,7 @@ A fully automated release pipeline: build → test → coverage check → API co
 
 ---
 
-### v0.4.3 — Structured Logging Improvements
+### Structured Logging Improvements
 
 > *"A log message that cannot be queried might as well not exist."*
 
@@ -90,7 +90,7 @@ A standardised logging contract for all connectors: shared event ID ranges per o
 
 ---
 
-### v0.4.4 — Documentation
+### Documentation
 
 > *"Public API without documentation is an API nobody can use; a connector that works but cannot be explained might as well not exist."*
 
@@ -120,7 +120,7 @@ Each feature in this milestone ships with its corresponding xUnit test helper ex
 
 ---
 
-### v0.5.1 — Twilio Inbound Messages (SMS & WhatsApp)
+### Twilio Inbound Messages (SMS & WhatsApp)
 
 > *"A message sent is only half the conversation — we need to hear back."*
 
@@ -140,7 +140,7 @@ A `ReceiveMessagesCoreAsync` implementation for the Twilio SMS and WhatsApp conn
 
 ---
 
-### v0.5.2 — SendGrid Inbound Messages (Inbound Parse)
+### SendGrid Inbound Messages (Inbound Parse)
 
 > *"Email replies carry intent — the framework should surface them, not discard them."*
 
@@ -160,7 +160,7 @@ A `ReceiveMessagesCoreAsync` implementation for the SendGrid connector that pars
 
 ---
 
-### v0.5.3 — Firebase Inbound Messages (Data & Notification Messages)
+### Firebase Inbound Messages (Data & Notification Messages)
 
 > *"A push notification is not a monologue — devices can and do respond."*
 
@@ -186,7 +186,7 @@ All preceding milestones establish the framework's core capabilities: a complete
 
 ---
 
-### v1.0.1 — API Freeze
+### API Freeze
 
 > *"A library that changes its public API unpredictably cannot be trusted as a dependency."*
 
@@ -205,7 +205,7 @@ A formal commitment that no breaking changes will be introduced to any public AP
 
 ---
 
-### v1.0.2 — NuGet GA Release
+### NuGet GA Release
 
 > *"A pre-release suffix is a warning label — version 1.0.0 removes it."*
 
@@ -222,7 +222,7 @@ Stable NuGet releases (no pre-release suffix) for all framework packages, publis
 - Packages are available to all NuGet consumers by default
 - Stable versioning signals production readiness to the community
 
-### v1.0.3 — Interactive Content
+### Interactive Content
 
 > *"Buttons, carousels, and quick replies should be described once and rendered everywhere."*
 
@@ -242,7 +242,7 @@ A new `IInteractiveContent` interface and concrete content types covering the mo
 - New connectors declare interactive support by implementing a mapping, not by introducing new content types
 
 
-### v1.0.4 — Sender Identity Model
+### Sender Identity Model
 
 > *"Who a message comes from is as important as what it says."*
 
@@ -270,7 +270,7 @@ A messaging connector that fails silently, cannot be monitored, or brings down d
 
 ---
 
-### v1.1.1 — Retry Policies
+### Retry Policies
 
 > *"A transient failure from a provider should never be the caller's problem."*
 
@@ -290,7 +290,7 @@ Polly-based retry and circuit-breaker policies integrated at the connector base 
 
 ---
 
-### v1.1.2 — OpenTelemetry Tracing & Metrics
+### OpenTelemetry Tracing & Metrics
 
 > *"You cannot improve what you cannot observe."*
 
@@ -310,7 +310,7 @@ Activity sources and metric instruments built into the connector base: an `Activ
 
 ---
 
-### v1.1.3 — Health Checks
+### Health Checks
 
 > *"If a connector cannot reach its provider, the application should know before a message fails."*
 
@@ -330,7 +330,7 @@ There is no standard way to check whether a connector is operational. The `Healt
 
 ---
 
-### v1.1.4 — Connector-Level Timeout Configuration
+### Connector-Level Timeout Configuration
 
 > *"An unanswered API call should never block indefinitely."*
 
@@ -355,7 +355,7 @@ With a stable, well-documented framework in place, this milestone extends the co
 
 ---
 
-### v1.2.1 — Slack Connector
+### Slack Connector
 
 > *"Slack is where teams live — A2P messages belong there too."*
 
@@ -378,7 +378,7 @@ A `Deveel.Messaging.Connector.Slack` package implementing `IChannelConnector` fo
 
 ---
 
-### v1.2.2 — Microsoft Teams Connector
+### Microsoft Teams Connector
 
 > *"Teams is the enterprise Slack — the framework should speak both languages."*
 
@@ -401,7 +401,7 @@ A `Deveel.Messaging.Connector.Teams` package supporting Incoming Webhooks (for c
 
 ---
 
-### v1.2.3 — WhatsApp Business API Connector (Direct Cloud API)
+### WhatsApp Business API Connector (Direct Cloud API)
 
 > *"Not every team wants Twilio in the middle of their WhatsApp integration."*
 
@@ -429,7 +429,7 @@ The connector is compatible with any BSP that exposes the standard WhatsApp Clou
 
 ---
 
-### v1.2.4 — Viber Business Connector
+### Viber Business Connector
 
 > *"Viber is the dominant messaging platform across Eastern Europe and Southeast Asia — it should not be an afterthought."*
 
@@ -452,7 +452,7 @@ A `Deveel.Messaging.Connector.Viber` package implementing the Viber Business Mes
 
 ---
 
-### v1.2.5 — LINE Connector
+### LINE Connector
 
 > *"LINE dominates messaging in Japan, Thailand, and Taiwan — regional coverage matters."*
 
@@ -481,7 +481,7 @@ SaaS messaging providers abstract away the underlying transport protocol, but th
 
 ---
 
-### v1.3.1 — Protocol Connector Base Classes
+### Protocol Connector Base Classes
 
 > *"Protocol connectors share enough structure that their base should be built once."*
 
@@ -501,7 +501,7 @@ A `Deveel.Messaging.Connector.Protocol` library (or extensions to `Deveel.Messag
 
 ---
 
-### v1.3.2 — SMPP Connector
+### SMPP Connector
 
 > *"Sending SMS through a SaaS provider is convenient — sending through a direct SMSC connection is sovereign."*
 
@@ -527,7 +527,7 @@ A `Deveel.Messaging.Connector.Smpp` package implementing an SMPP v3.4 session cl
 
 ---
 
-### v1.3.3 — SMTP Connector
+### SMTP Connector
 
 > *"Email at its most direct is just SMTP — the framework should support that."*
 
@@ -551,7 +551,7 @@ A `Deveel.Messaging.Connector.Smtp` package using MailKit to deliver messages ov
 
 ---
 
-### v1.3.4 — RCS Connector
+### RCS Connector
 
 > *"RCS is SMS with the richness of a chat app — the next generation of A2P messaging."*
 
@@ -576,7 +576,7 @@ A `Deveel.Messaging.Connector.Rcs` package implementing the RCS Business Messagi
 
 ---
 
-### v1.3.5 — APNs Connector (Direct)
+### APNs Connector (Direct)
 
 > *"Firebase is not the only path to an iPhone — teams with Apple developer accounts should have a direct route."*
 
@@ -606,7 +606,7 @@ A message model that works across channels must acknowledge that channels are no
 
 ---
 
-### v1.4.1 — `IContentTranscoder` Abstraction
+### `IContentTranscoder` Abstraction
 
 > *"Convert once, send anywhere."*
 
@@ -626,7 +626,7 @@ An `IContentTranscoder<TSource, TTarget>` abstraction that converts a content ob
 
 ---
 
-### v1.4.2 — Built-In Transcoders
+### Built-In Transcoders
 
 > *"The most common conversions should not require custom code."*
 
@@ -649,7 +649,7 @@ A set of built-in transcoders registered by default: HTML → plain text (using 
 
 ---
 
-### v1.4.3 — Channel-Aware Content Fallback
+### Channel-Aware Content Fallback
 
 > *"A message that cannot be delivered as-is should be delivered in the best available form, not dropped."*
 
@@ -674,7 +674,7 @@ An automatic fallback mechanism in the connector base that, when a content type 
 
 ---
 
-### v1.4.4 — SMS Segmentation
+### SMS Segmentation
 
 > *"An SMS that is longer than 160 characters is not one message — it is several."*
 
@@ -697,7 +697,7 @@ A `SmsSegmenter` utility that counts characters according to GSM-7 (160 chars / 
 
 ---
 
-### v1.4.5 — Character Encoding Detection
+### Character Encoding Detection
 
 > *"Sending a GSM-7 message with a single emoji doubles its segment count — the framework should warn you."*
 
@@ -722,7 +722,7 @@ Sending a message to an invalid or unreachable address wastes resources, generat
 
 ---
 
-### v1.5.1 — E.164 Normalization
+### E.164 Normalization
 
 > *"A phone number is only unambiguous when it carries its country code."*
 
@@ -742,7 +742,7 @@ An E.164 normalization step applied to `PhoneNumber` endpoints before they are p
 
 ---
 
-### v1.5.2 — HLR (Home Location Register) Lookup
+### HLR (Home Location Register) Lookup
 
 > *"Knowing a number exists is not the same as knowing it can receive a message."*
 
@@ -761,7 +761,7 @@ An optional `INumberReachabilityChecker` abstraction with provider-specific impl
 
 ---
 
-### v1.5.3 — Number Portability Awareness
+### Number Portability Awareness
 
 > *"A number that moved to a new network should still find its way to the right SMSC."*
 
@@ -785,7 +785,7 @@ Integration of number portability data (where available from the HLR lookup resu
 
 ---
 
-### v1.5.4 — Email Address Validation
+### Email Address Validation
 
 > *"An email address that cannot receive mail should not be sent to."*
 
@@ -804,7 +804,7 @@ An `IEmailAddressValidator` that performs: (1) RFC 5321 syntax validation, (2) M
 
 ---
 
-### v1.5.5 — `IAddressValidator` Abstraction
+### `IAddressValidator` Abstraction
 
 > *"Address validation should be as pluggable as the connectors themselves."*
 
@@ -830,7 +830,7 @@ A framework is only as productive as the tools built around it. This milestone i
 
 ---
 
-### v1.6.1 — `dotnet new` Connector Scaffold
+### `dotnet new` Connector Scaffold
 
 > *"The fastest path to a correct connector is starting from one that already compiles."*
 
@@ -850,7 +850,7 @@ A `dotnet new` template package (`Deveel.Messaging.Connector.Templates`) that ge
 
 ---
 
-### v1.6.2 — ASP.NET Core Diagnostic Middleware
+### ASP.NET Core Diagnostic Middleware
 
 > *"An operator should never need a debugger to answer 'is the Twilio connector healthy?'"*
 
@@ -876,7 +876,7 @@ A conversation is more than a sequence of messages. It has participants, a histo
 
 ---
 
-### v2.0.1 — `IConversation` Abstraction
+### `IConversation` Abstraction
 
 > *"A conversation is the unit of meaning — a message is just its atom."*
 
@@ -899,7 +899,7 @@ An `IConversation` interface representing a thread of messages between an applic
 
 ---
 
-### v2.0.2 — Conversation State Model
+### Conversation State Model
 
 > *"A conversation that cannot remember what was said is not a conversation."*
 
@@ -923,7 +923,7 @@ A conversation state model that tracks participants, channel, status transitions
 
 ---
 
-### v2.0.3 — Conversation Correlation
+### Conversation Correlation
 
 > *"When someone replies, the framework should know what they are replying to."*
 
@@ -949,7 +949,7 @@ A correlation mechanism that links inbound messages to the outgoing conversation
 
 ---
 
-### v2.0.4 — Multi-Channel Conversations
+### Multi-Channel Conversations
 
 > *"A conversation that started on SMS should be able to continue on WhatsApp."*
 
@@ -974,7 +974,7 @@ An extension to the conversation model that allows a conversation to be associat
 
 ---
 
-### v2.0.5 — Multi-Tenant Channel Registry
+### Multi-Tenant Channel Registry
 
 > *"Different tenants have different channels — the registry should know the difference."*
 
@@ -998,7 +998,7 @@ A tenant-aware channel registry that resolves connector instances and channel sc
 
 ---
 
-### v2.0.6 — xUnit Test Helpers for Conversation Flows
+### xUnit Test Helpers for Conversation Flows
 
 > *"A conversation that cannot be tested in isolation is a conversation waiting to break."*
 
@@ -1028,7 +1028,7 @@ Templates are how organisations send consistent, personalised messages at scale.
 
 ---
 
-### v2.1.1 — `IMessageTemplate` Abstraction
+### `IMessageTemplate` Abstraction
 
 > *"A template is a promise about the shape of a message — define it once, honour it everywhere."*
 
@@ -1048,7 +1048,7 @@ An `IMessageTemplate` interface that defines a template by name, locale, content
 
 ---
 
-### v2.1.2 — Variable Substitution Engine
+### Variable Substitution Engine
 
 > *"Every personalised message is a template with names filled in."*
 
@@ -1072,7 +1072,7 @@ A local rendering engine that resolves an `IMessageTemplate` with a set of varia
 
 ---
 
-### v2.1.3 — Per-Connector Template Rendering
+### Per-Connector Template Rendering
 
 > *"WhatsApp wants a template name and parameters. SendGrid wants a template ID. The framework should speak both."*
 
@@ -1097,7 +1097,7 @@ Per-connector template adapters that, when a connector detects that a message re
 
 ---
 
-### v2.1.4 — Template Registry
+### Template Registry
 
 > *"A template that cannot be found at send time is a template that cannot be trusted."*
 
@@ -1124,3 +1124,5 @@ An `ITemplateRegistry` that stores and retrieves `IMessageTemplate` instances by
 ## Contributing
 
 If you have feature ideas, bug reports, or want to work on any of the items listed above, please open an issue or pull request on [GitHub](https://github.com/deveel/deveel.messaging). See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on setting up the development environment, coding standards, and the pull request process.
+
+Automated agents (AI) may be used only in accessory contexts such as documentation and tests. The core body of source code must be written by humans to ensure code quality and maintainability.

--- a/src/Deveel.Messaging.Abstractions/Messaging/MessagingErrorCodes.cs
+++ b/src/Deveel.Messaging.Abstractions/Messaging/MessagingErrorCodes.cs
@@ -13,7 +13,7 @@ namespace Deveel.Messaging
     /// These error codes are used for messaging-level errors that occur
     /// outside the scope of channel connectors, such as message routing,
     /// serialization, and general configuration errors.
-    /// Use connector-specific error code classes (e.g., <see cref="TwilioErrorCodes"/>)
+    /// Use connector-specific error code classes (e.g., TwilioErrorCodes)
     /// for errors that originate from a specific provider.
     /// </remarks>
     public static class MessagingErrorCodes

--- a/src/Deveel.Messaging.Connector.Facebook/Deveel.Messaging.Connector.Facebook.csproj
+++ b/src/Deveel.Messaging.Connector.Facebook/Deveel.Messaging.Connector.Facebook.csproj
@@ -20,7 +20,4 @@
     <PackageReference Include="Polly.Core" Version="8.5.0" />
   </ItemGroup>
 
-  <ItemGroup>
-    <InternalsVisibleTo Include="Deveel.Messaging.Connector.Facebook.XUnit" />
-  </ItemGroup>
 </Project>

--- a/src/Deveel.Messaging.Connector.Facebook/Messaging/FacebookConnectionSettingsDefaults.cs
+++ b/src/Deveel.Messaging.Connector.Facebook/Messaging/FacebookConnectionSettingsDefaults.cs
@@ -1,5 +1,8 @@
 namespace Deveel.Messaging
 {
+    /// <summary>
+    /// Provides default values for Facebook Messenger connection settings.
+    /// </summary>
     public static class FacebookConnectionSettingsDefaults
     {
     }

--- a/src/Deveel.Messaging.Connector.Facebook/Messaging/FacebookConnectionSettingsExtensions.cs
+++ b/src/Deveel.Messaging.Connector.Facebook/Messaging/FacebookConnectionSettingsExtensions.cs
@@ -1,16 +1,39 @@
 namespace Deveel.Messaging
 {
+    /// <summary>
+    /// Provides extension methods for <see cref="ConnectionSettings"/> to access Facebook Messenger-specific parameters.
+    /// </summary>
     public static class FacebookConnectionSettingsExtensions
     {
+        /// <summary>
+        /// Gets the Facebook Page Access Token from the connection settings.
+        /// </summary>
+        /// <param name="settings">The connection settings to read from.</param>
+        /// <returns>The page access token, or <c>null</c> if not configured.</returns>
         public static string? GetPageAccessToken(this ConnectionSettings settings)
             => settings.GetParameter<string>(FacebookConnectionParameters.PageAccessToken);
 
+        /// <summary>
+        /// Gets the Facebook Page ID from the connection settings.
+        /// </summary>
+        /// <param name="settings">The connection settings to read from.</param>
+        /// <returns>The page ID, or <c>null</c> if not configured.</returns>
         public static string? GetPageId(this ConnectionSettings settings)
             => settings.GetParameter<string>(FacebookConnectionParameters.PageId);
 
+        /// <summary>
+        /// Gets the webhook URL configured for Facebook Messenger callbacks.
+        /// </summary>
+        /// <param name="settings">The connection settings to read from.</param>
+        /// <returns>The webhook URL, or <c>null</c> if not configured.</returns>
         public static string? GetWebhookUrl(this ConnectionSettings settings)
             => settings.GetParameter<string>(FacebookConnectionParameters.WebhookUrl);
 
+        /// <summary>
+        /// Gets the verify token for Facebook webhook verification.
+        /// </summary>
+        /// <param name="settings">The connection settings to read from.</param>
+        /// <returns>The verify token, or <c>null</c> if not configured.</returns>
         public static string? GetVerifyToken(this ConnectionSettings settings)
             => settings.GetParameter<string>(FacebookConnectionParameters.VerifyToken);
     }

--- a/src/Deveel.Messaging.Connector.Facebook/Messaging/FacebookService.cs
+++ b/src/Deveel.Messaging.Connector.Facebook/Messaging/FacebookService.cs
@@ -12,12 +12,23 @@ using System.Text.Json;
 
 namespace Deveel.Messaging
 {
+    /// <summary>
+    /// Default implementation of <see cref="IFacebookService"/> that communicates
+    /// with the Facebook Graph API to send messages and fetch page information.
+    /// </summary>
     public class FacebookService : IFacebookService
     {
         private readonly HttpClient _httpClient;
         private readonly ResiliencePipeline<HttpResponseMessage> _resiliencePipeline;
         private string? _pageAccessToken;
 
+        /// <summary>
+        /// Constructs the service with an optional HTTP client.
+        /// </summary>
+        /// <param name="httpClient">
+        /// An optional HTTP client used to communicate with the Facebook Graph API.
+        /// If not provided, a new instance is created with the base URL set to the Graph API.
+        /// </param>
         public FacebookService(HttpClient? httpClient = null)
         {
             _httpClient = httpClient ?? new HttpClient { BaseAddress = new Uri(FacebookConnectorConstants.GraphApiBaseUrl) };
@@ -42,6 +53,10 @@ namespace Deveel.Messaging
                 .Build();
         }
 
+        /// <summary>
+        /// Initializes the service with a Facebook Page Access Token.
+        /// </summary>
+        /// <param name="pageAccessToken">The page access token to use for API requests.</param>
         public void Initialize(string pageAccessToken)
         {
             if (string.IsNullOrWhiteSpace(pageAccessToken))
@@ -52,6 +67,14 @@ namespace Deveel.Messaging
             _pageAccessToken = pageAccessToken;
         }
 
+        /// <summary>
+        /// Fetches information about a Facebook page using the Graph API.
+        /// </summary>
+        /// <param name="pageId">The identifier of the Facebook page.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that the operation should be canceled.
+        /// </param>
+        /// <returns>A <see cref="FacebookPageInfo"/> containing page details, or <c>null</c> if not found.</returns>
         public async Task<FacebookPageInfo?> FetchPageAsync(string pageId, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(_pageAccessToken))
@@ -100,6 +123,14 @@ namespace Deveel.Messaging
             }
         }
 
+        /// <summary>
+        /// Sends a message to a Facebook recipient using the Graph API.
+        /// </summary>
+        /// <param name="request">The message request containing recipient, content, and options.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that the operation should be canceled.
+        /// </param>
+        /// <returns>A <see cref="FacebookMessageResponse"/> containing the result of the send operation.</returns>
         public async Task<FacebookMessageResponse> SendMessageAsync(FacebookMessageRequest request, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(_pageAccessToken))

--- a/src/Deveel.Messaging.Connector.Firebase/Deveel.Messaging.Connector.Firebase.csproj
+++ b/src/Deveel.Messaging.Connector.Firebase/Deveel.Messaging.Connector.Firebase.csproj
@@ -29,4 +29,5 @@
     <PackageReference Include="FirebaseAdmin" Version="2.4.0" />
     <PackageReference Include="Google.Apis.Auth" Version="1.68.0" />
   </ItemGroup>
+
 </Project>

--- a/src/Deveel.Messaging.Connector.Firebase/Messaging/FirebaseConnectionSettingsExtensions.cs
+++ b/src/Deveel.Messaging.Connector.Firebase/Messaging/FirebaseConnectionSettingsExtensions.cs
@@ -1,13 +1,31 @@
 namespace Deveel.Messaging
 {
+    /// <summary>
+    /// Provides extension methods for <see cref="ConnectionSettings"/> to access Firebase-specific parameters.
+    /// </summary>
     public static class FirebaseConnectionSettingsExtensions
     {
+        /// <summary>
+        /// Gets the Firebase project identifier from the connection settings.
+        /// </summary>
+        /// <param name="settings">The connection settings to read from.</param>
+        /// <returns>The project ID, or <c>null</c> if not configured.</returns>
         public static string? GetProjectId(this ConnectionSettings settings)
             => settings.GetParameter<string>(FirebaseConnectionParameters.ProjectId);
 
+        /// <summary>
+        /// Gets the Firebase service account key (JSON) from the connection settings.
+        /// </summary>
+        /// <param name="settings">The connection settings to read from.</param>
+        /// <returns>The service account key, or <c>null</c> if not configured.</returns>
         public static string? GetServiceAccountKey(this ConnectionSettings settings)
             => settings.GetParameter<string>(FirebaseConnectionParameters.ServiceAccountKey);
 
+        /// <summary>
+        /// Gets whether the dry-run mode is enabled for Firebase message sending.
+        /// </summary>
+        /// <param name="settings">The connection settings to read from.</param>
+        /// <returns><c>true</c> if dry-run mode is enabled, or <c>null</c> if not configured.</returns>
         public static bool? GetDryRun(this ConnectionSettings settings)
             => settings.GetParameter<bool?>(FirebaseConnectionParameters.DryRun);
     }

--- a/src/Deveel.Messaging.Connector.Firebase/Messaging/FirebaseMessagingClient.cs
+++ b/src/Deveel.Messaging.Connector.Firebase/Messaging/FirebaseMessagingClient.cs
@@ -7,17 +7,24 @@ namespace Deveel.Messaging
     {
         private readonly FirebaseAdmin.Messaging.FirebaseMessaging _messaging;
 
+        /// <summary>
+        /// Constructs a client wrapping the given Firebase Messaging instance.
+        /// </summary>
+        /// <param name="messaging">The Firebase Messaging instance to wrap.</param>
         public FirebaseMessagingClient(FirebaseAdmin.Messaging.FirebaseMessaging messaging)
         {
             _messaging = messaging ?? throw new ArgumentNullException(nameof(messaging));
         }
 
+        /// <inheritdoc/>
         public Task<string> SendAsync(FirebaseAdmin.Messaging.Message message, bool dryRun, CancellationToken cancellationToken)
             => _messaging.SendAsync(message, dryRun, cancellationToken);
 
+        /// <inheritdoc/>
         public Task<FirebaseAdmin.Messaging.BatchResponse> SendEachAsync(IEnumerable<FirebaseAdmin.Messaging.Message> messages, bool dryRun, CancellationToken cancellationToken)
             => _messaging.SendEachAsync(messages, dryRun, cancellationToken);
 
+        /// <inheritdoc/>
         public Task<FirebaseAdmin.Messaging.BatchResponse> SendMulticastAsync(FirebaseAdmin.Messaging.MulticastMessage message, bool dryRun, CancellationToken cancellationToken)
             => _messaging.SendMulticastAsync(message, dryRun, cancellationToken);
     }

--- a/src/Deveel.Messaging.Connector.Firebase/Messaging/FirebaseMessagingClient.cs
+++ b/src/Deveel.Messaging.Connector.Firebase/Messaging/FirebaseMessagingClient.cs
@@ -1,0 +1,24 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Deveel.Messaging
+{
+    [ExcludeFromCodeCoverage]
+    public class FirebaseMessagingClient : IFirebaseMessagingClient
+    {
+        private readonly FirebaseAdmin.Messaging.FirebaseMessaging _messaging;
+
+        public FirebaseMessagingClient(FirebaseAdmin.Messaging.FirebaseMessaging messaging)
+        {
+            _messaging = messaging ?? throw new ArgumentNullException(nameof(messaging));
+        }
+
+        public Task<string> SendAsync(FirebaseAdmin.Messaging.Message message, bool dryRun, CancellationToken cancellationToken)
+            => _messaging.SendAsync(message, dryRun, cancellationToken);
+
+        public Task<FirebaseAdmin.Messaging.BatchResponse> SendEachAsync(IEnumerable<FirebaseAdmin.Messaging.Message> messages, bool dryRun, CancellationToken cancellationToken)
+            => _messaging.SendEachAsync(messages, dryRun, cancellationToken);
+
+        public Task<FirebaseAdmin.Messaging.BatchResponse> SendMulticastAsync(FirebaseAdmin.Messaging.MulticastMessage message, bool dryRun, CancellationToken cancellationToken)
+            => _messaging.SendMulticastAsync(message, dryRun, cancellationToken);
+    }
+}

--- a/src/Deveel.Messaging.Connector.Firebase/Messaging/FirebaseService.cs
+++ b/src/Deveel.Messaging.Connector.Firebase/Messaging/FirebaseService.cs
@@ -10,7 +10,7 @@ using Google.Apis.Auth.OAuth2;
 
 namespace Deveel.Messaging
 {
-	/// <summary>
+    /// <summary>
 	/// Default implementation of <see cref="IFirebaseService"/> using the Firebase Admin SDK.
 	/// </summary>
 	public class FirebaseService : IFirebaseService
@@ -18,6 +18,9 @@ namespace Deveel.Messaging
         private FirebaseApp? _app;
         private IFirebaseMessagingClient? _messagingClient;
 
+        /// <summary>
+        /// Constructs a <see cref="FirebaseService"/> instance.
+        /// </summary>
         public FirebaseService()
         {
         }
@@ -203,6 +206,11 @@ namespace Deveel.Messaging
             }
         }
 
+        /// <summary>
+        /// Maps a Firebase Admin SDK <see cref="MessagingErrorCode"/> to an internal messaging error code.
+        /// </summary>
+        /// <param name="errorCode">The Firebase error code to map.</param>
+        /// <returns>The corresponding internal error code string.</returns>
         public static string MapFirebaseErrorCode(MessagingErrorCode? errorCode)
         {
             if (!errorCode.HasValue)

--- a/src/Deveel.Messaging.Connector.Firebase/Messaging/FirebaseService.cs
+++ b/src/Deveel.Messaging.Connector.Firebase/Messaging/FirebaseService.cs
@@ -16,14 +16,22 @@ namespace Deveel.Messaging
 	public class FirebaseService : IFirebaseService
     {
         private FirebaseApp? _app;
-        private FirebaseMessaging? _messaging;
+        private IFirebaseMessagingClient? _messagingClient;
 
+        public FirebaseService()
+        {
+        }
+
+        internal FirebaseService(IFirebaseMessagingClient messagingClient)
+        {
+            _messagingClient = messagingClient;
+        }
 
         /// <inheritdoc/>
         public FirebaseApp? App => _app;
 
         /// <inheritdoc/>
-        public bool IsInitialized => _app != null && _messaging != null;
+        public bool IsInitialized => _messagingClient != null;
 
         /// <inheritdoc/>
         public async Task InitializeAsync(string serviceAccountKey, string projectId)
@@ -38,7 +46,7 @@ namespace Deveel.Messaging
                 {
                     _app.Delete();
                     _app = null;
-                    _messaging = null;
+                    _messagingClient = null;
                 }
 
                 // Create credential from service account key
@@ -52,7 +60,8 @@ namespace Deveel.Messaging
                 });
 
                 // Initialize messaging service
-                _messaging = FirebaseMessaging.GetMessaging(_app);
+                var messaging = FirebaseMessaging.GetMessaging(_app);
+                _messagingClient = new FirebaseMessagingClient(messaging);
 
                 await Task.CompletedTask;
             }
@@ -82,7 +91,7 @@ namespace Deveel.Messaging
 
             try
             {
-                return await _messaging!.SendAsync(message, dryRun, cancellationToken);
+                return await _messagingClient!.SendAsync(message, dryRun, cancellationToken);
             }
             catch (FirebaseMessagingException ex)
             {
@@ -110,7 +119,7 @@ namespace Deveel.Messaging
 
             try
             {
-                return await _messaging!.SendEachAsync(messages, dryRun, cancellationToken);
+                return await _messagingClient!.SendEachAsync(messages, dryRun, cancellationToken);
             }
             catch (FirebaseMessagingException ex)
             {
@@ -138,7 +147,7 @@ namespace Deveel.Messaging
 
             try
             {
-                return await _messaging!.SendMulticastAsync(message, dryRun, cancellationToken);
+                return await _messagingClient!.SendMulticastAsync(message, dryRun, cancellationToken);
             }
             catch (FirebaseMessagingException ex)
             {
@@ -179,7 +188,7 @@ namespace Deveel.Messaging
                 };
 
                 // This will validate credentials and connectivity without sending
-                await _messaging!.SendAsync(testMessage, dryRun: true, cancellationToken);
+                await _messagingClient!.SendAsync(testMessage, dryRun: true, cancellationToken);
                 return true;
             }
             catch (FirebaseMessagingException ex) when (ex.MessagingErrorCode == MessagingErrorCode.InvalidArgument)
@@ -194,7 +203,7 @@ namespace Deveel.Messaging
             }
         }
 
-        private static string MapFirebaseErrorCode(MessagingErrorCode? errorCode)
+        public static string MapFirebaseErrorCode(MessagingErrorCode? errorCode)
         {
             if (!errorCode.HasValue)
                 return MessagingErrorCodes.SendMessageFailed;

--- a/src/Deveel.Messaging.Connector.Firebase/Messaging/IFirebaseMessagingClient.cs
+++ b/src/Deveel.Messaging.Connector.Firebase/Messaging/IFirebaseMessagingClient.cs
@@ -1,11 +1,41 @@
 namespace Deveel.Messaging
 {
+    /// <summary>
+    /// Provides an abstraction over the Firebase Admin SDK for sending messages.
+    /// </summary>
     public interface IFirebaseMessagingClient
     {
+        /// <summary>
+        /// Sends a single Firebase Cloud Message.
+        /// </summary>
+        /// <param name="message">The message to send.</param>
+        /// <param name="dryRun">If <c>true</c>, the message is validated but not actually sent.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that the operation should be canceled.
+        /// </param>
+        /// <returns>The message ID assigned by Firebase.</returns>
         Task<string> SendAsync(FirebaseAdmin.Messaging.Message message, bool dryRun, CancellationToken cancellationToken);
 
+        /// <summary>
+        /// Sends multiple messages individually via Firebase Cloud Messaging.
+        /// </summary>
+        /// <param name="messages">The messages to send.</param>
+        /// <param name="dryRun">If <c>true</c>, messages are validated but not actually sent.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that the operation should be canceled.
+        /// </param>
+        /// <returns>A <see cref="BatchResponse"/> with per-message results.</returns>
         Task<FirebaseAdmin.Messaging.BatchResponse> SendEachAsync(IEnumerable<FirebaseAdmin.Messaging.Message> messages, bool dryRun, CancellationToken cancellationToken);
 
+        /// <summary>
+        /// Sends a multicast message to multiple recipients via Firebase Cloud Messaging.
+        /// </summary>
+        /// <param name="message">The multicast message to send.</param>
+        /// <param name="dryRun">If <c>true</c>, the message is validated but not actually sent.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that the operation should be canceled.
+        /// </param>
+        /// <returns>A <see cref="BatchResponse"/> with per-recipient results.</returns>
         Task<FirebaseAdmin.Messaging.BatchResponse> SendMulticastAsync(FirebaseAdmin.Messaging.MulticastMessage message, bool dryRun, CancellationToken cancellationToken);
     }
 }

--- a/src/Deveel.Messaging.Connector.Firebase/Messaging/IFirebaseMessagingClient.cs
+++ b/src/Deveel.Messaging.Connector.Firebase/Messaging/IFirebaseMessagingClient.cs
@@ -1,0 +1,11 @@
+namespace Deveel.Messaging
+{
+    public interface IFirebaseMessagingClient
+    {
+        Task<string> SendAsync(FirebaseAdmin.Messaging.Message message, bool dryRun, CancellationToken cancellationToken);
+
+        Task<FirebaseAdmin.Messaging.BatchResponse> SendEachAsync(IEnumerable<FirebaseAdmin.Messaging.Message> messages, bool dryRun, CancellationToken cancellationToken);
+
+        Task<FirebaseAdmin.Messaging.BatchResponse> SendMulticastAsync(FirebaseAdmin.Messaging.MulticastMessage message, bool dryRun, CancellationToken cancellationToken);
+    }
+}

--- a/src/Deveel.Messaging.Connector.Sendgrid/Deveel.Messaging.Connector.Sendgrid.csproj
+++ b/src/Deveel.Messaging.Connector.Sendgrid/Deveel.Messaging.Connector.Sendgrid.csproj
@@ -28,4 +28,5 @@
   <ItemGroup>
     <PackageReference Include="SendGrid" Version="9.29.3" />
   </ItemGroup>
+
 </Project>

--- a/src/Deveel.Messaging.Connector.Sendgrid/Messaging/SendGridConnectionSettingsExtensions.cs
+++ b/src/Deveel.Messaging.Connector.Sendgrid/Messaging/SendGridConnectionSettingsExtensions.cs
@@ -1,22 +1,55 @@
 namespace Deveel.Messaging
 {
+    /// <summary>
+    /// Provides extension methods for <see cref="ConnectionSettings"/> to access SendGrid-specific parameters.
+    /// </summary>
     public static class SendGridConnectionSettingsExtensions
     {
+        /// <summary>
+        /// Gets the SendGrid API key from the connection settings.
+        /// </summary>
+        /// <param name="settings">The connection settings to read from.</param>
+        /// <returns>The API key, or <c>null</c> if not configured.</returns>
         public static string? GetApiKey(this ConnectionSettings settings)
             => settings.GetParameter<string>(SendGridConnectionParameters.ApiKey);
 
+        /// <summary>
+        /// Gets whether sandbox mode is enabled for testing.
+        /// </summary>
+        /// <param name="settings">The connection settings to read from.</param>
+        /// <returns><c>true</c> if sandbox mode is enabled, or <c>null</c> if not configured.</returns>
         public static bool? GetSandboxMode(this ConnectionSettings settings)
             => settings.GetParameter<bool?>(SendGridConnectionParameters.SandboxMode);
 
+        /// <summary>
+        /// Gets the webhook URL configured for SendGrid event callbacks.
+        /// </summary>
+        /// <param name="settings">The connection settings to read from.</param>
+        /// <returns>The webhook URL, or <c>null</c> if not configured.</returns>
         public static string? GetWebhookUrl(this ConnectionSettings settings)
             => settings.GetParameter<string>(SendGridConnectionParameters.WebhookUrl);
 
+        /// <summary>
+        /// Gets whether tracking settings (e.g., open tracking) are enabled.
+        /// </summary>
+        /// <param name="settings">The connection settings to read from.</param>
+        /// <returns><c>true</c> if tracking is enabled, or <c>null</c> if not configured.</returns>
         public static bool? GetTrackingSettings(this ConnectionSettings settings)
             => settings.GetParameter<bool?>(SendGridConnectionParameters.TrackingSettings);
 
+        /// <summary>
+        /// Gets the default sender name for outgoing emails.
+        /// </summary>
+        /// <param name="settings">The connection settings to read from.</param>
+        /// <returns>The default from name, or <c>null</c> if not configured.</returns>
         public static string? GetDefaultFromName(this ConnectionSettings settings)
             => settings.GetParameter<string>(SendGridConnectionParameters.DefaultFromName);
 
+        /// <summary>
+        /// Gets the default reply-to address for outgoing emails.
+        /// </summary>
+        /// <param name="settings">The connection settings to read from.</param>
+        /// <returns>The default reply-to, or <c>null</c> if not configured.</returns>
         public static string? GetDefaultReplyTo(this ConnectionSettings settings)
             => settings.GetParameter<string>(SendGridConnectionParameters.DefaultReplyTo);
     }

--- a/src/Deveel.Messaging.Connector.Telegram/Deveel.Messaging.Connector.Telegram.csproj
+++ b/src/Deveel.Messaging.Connector.Telegram/Deveel.Messaging.Connector.Telegram.csproj
@@ -28,7 +28,4 @@
     <PackageReference Include="Telegram.Bot" Version="22.0.0" />
   </ItemGroup>
 
-  <ItemGroup>
-    <InternalsVisibleTo Include="Deveel.Messaging.Connector.Telegram.XUnit" />
-  </ItemGroup>
 </Project>

--- a/src/Deveel.Messaging.Connector.Telegram/Messaging/TelegramConnectionSettingsExtensions.cs
+++ b/src/Deveel.Messaging.Connector.Telegram/Messaging/TelegramConnectionSettingsExtensions.cs
@@ -1,37 +1,95 @@
 namespace Deveel.Messaging
 {
+    /// <summary>
+    /// Provides extension methods for <see cref="ConnectionSettings"/> to access Telegram-specific parameters.
+    /// </summary>
     public static class TelegramConnectionSettingsExtensions
     {
+        /// <summary>
+        /// Gets the Telegram bot token from the connection settings.
+        /// </summary>
+        /// <param name="settings">The connection settings to read from.</param>
+        /// <returns>The bot token, or <c>null</c> if not configured.</returns>
         public static string? GetBotToken(this ConnectionSettings settings)
             => settings.GetParameter<string>(TelegramConnectionParameters.BotToken);
 
+        /// <summary>
+        /// Gets the webhook URL configured for Telegram bot callbacks.
+        /// </summary>
+        /// <param name="settings">The connection settings to read from.</param>
+        /// <returns>The webhook URL, or <c>null</c> if not configured.</returns>
         public static string? GetWebhookUrl(this ConnectionSettings settings)
             => settings.GetParameter<string>(TelegramConnectionParameters.WebhookUrl);
 
+        /// <summary>
+        /// Gets the secret token for securing Telegram webhook requests.
+        /// </summary>
+        /// <param name="settings">The connection settings to read from.</param>
+        /// <returns>The secret token, or <c>null</c> if not configured.</returns>
         public static string? GetSecretToken(this ConnectionSettings settings)
             => settings.GetParameter<string>(TelegramConnectionParameters.SecretToken);
 
+        /// <summary>
+        /// Gets whether the web page preview is disabled in messages.
+        /// </summary>
+        /// <param name="settings">The connection settings to read from.</param>
+        /// <returns><c>true</c> if disabled, <c>false</c> if enabled, or <c>null</c> if not configured.</returns>
         public static bool? GetDisableWebPagePreview(this ConnectionSettings settings)
             => settings.GetParameter<bool?>(TelegramConnectionParameters.DisableWebPagePreview);
 
+        /// <summary>
+        /// Gets whether notifications are disabled for messages.
+        /// </summary>
+        /// <param name="settings">The connection settings to read from.</param>
+        /// <returns><c>true</c> if disabled, <c>false</c> if enabled, or <c>null</c> if not configured.</returns>
         public static bool? GetDisableNotification(this ConnectionSettings settings)
             => settings.GetParameter<bool?>(TelegramConnectionParameters.DisableNotification);
 
+        /// <summary>
+        /// Gets the parse mode (e.g., HTML, Markdown) for Telegram messages.
+        /// </summary>
+        /// <param name="settings">The connection settings to read from.</param>
+        /// <returns>The parse mode, or <c>null</c> if not configured.</returns>
         public static string? GetParseMode(this ConnectionSettings settings)
             => settings.GetParameter<string>(TelegramConnectionParameters.ParseMode);
 
+        /// <summary>
+        /// Gets the maximum number of retries when sending messages.
+        /// </summary>
+        /// <param name="settings">The connection settings to read from.</param>
+        /// <returns>The maximum retries, or <c>null</c> if not configured.</returns>
         public static int? GetMaxRetries(this ConnectionSettings settings)
             => settings.GetParameter<int?>(TelegramConnectionParameters.MaxRetries);
 
+        /// <summary>
+        /// Gets the timeout in seconds for HTTP requests.
+        /// </summary>
+        /// <param name="settings">The connection settings to read from.</param>
+        /// <returns>The timeout in seconds, or <c>null</c> if not configured.</returns>
         public static int? GetTimeoutSeconds(this ConnectionSettings settings)
             => settings.GetParameter<int?>(TelegramConnectionParameters.TimeoutSeconds);
 
+        /// <summary>
+        /// Gets the maximum number of connections allowed.
+        /// </summary>
+        /// <param name="settings">The connection settings to read from.</param>
+        /// <returns>The maximum connections, or <c>null</c> if not configured.</returns>
         public static int? GetMaxConnections(this ConnectionSettings settings)
             => settings.GetParameter<int?>(TelegramConnectionParameters.MaxConnections);
 
+        /// <summary>
+        /// Gets whether pending updates should be dropped when starting the bot.
+        /// </summary>
+        /// <param name="settings">The connection settings to read from.</param>
+        /// <returns><c>true</c> to drop pending updates, or <c>null</c> if not configured.</returns>
         public static bool? GetDropPendingUpdates(this ConnectionSettings settings)
             => settings.GetParameter<bool?>(TelegramConnectionParameters.DropPendingUpdates);
 
+        /// <summary>
+        /// Gets the default chat identifier for sending messages.
+        /// </summary>
+        /// <param name="settings">The connection settings to read from.</param>
+        /// <returns>The default chat ID, or <c>null</c> if not configured.</returns>
         public static string? GetDefaultChatId(this ConnectionSettings settings)
             => settings.GetParameter<string>(TelegramConnectionParameters.DefaultChatId);
     }

--- a/src/Deveel.Messaging.Connector.Twilio/Deveel.Messaging.Connector.Twilio.csproj
+++ b/src/Deveel.Messaging.Connector.Twilio/Deveel.Messaging.Connector.Twilio.csproj
@@ -27,4 +27,5 @@
   <ItemGroup>
     <PackageReference Include="Twilio" Version="7.6.0" />
   </ItemGroup>
+
 </Project>

--- a/src/Deveel.Messaging.Connector.Twilio/Messaging/ITwilioApiClient.cs
+++ b/src/Deveel.Messaging.Connector.Twilio/Messaging/ITwilioApiClient.cs
@@ -3,14 +3,39 @@ using Twilio.Rest.Api.V2010.Account;
 
 namespace Deveel.Messaging
 {
+    /// <summary>
+    /// Provides an abstraction over the Twilio SDK for creating and fetching messages and accounts.
+    /// </summary>
     public interface ITwilioApiClient
     {
+        /// <summary>
+        /// Initializes the Twilio client with the given account credentials.
+        /// </summary>
+        /// <param name="accountSid">The Twilio Account SID.</param>
+        /// <param name="authToken">The Twilio authentication token.</param>
         void Initialize(string accountSid, string authToken);
 
+        /// <summary>
+        /// Fetches the Twilio account information for the given account SID.
+        /// </summary>
+        /// <param name="accountSid">The Twilio Account SID to fetch.</param>
+        /// <returns>
+        /// A <see cref="AccountResource"/> representing the account, or <c>null</c> if not found.
+        /// </returns>
         Task<AccountResource?> FetchAccountAsync(string accountSid);
 
+        /// <summary>
+        /// Creates a new message using the given options.
+        /// </summary>
+        /// <param name="options">The options describing the message to create.</param>
+        /// <returns>A <see cref="MessageResource"/> representing the created message.</returns>
         Task<MessageResource> CreateMessageAsync(CreateMessageOptions options);
 
+        /// <summary>
+        /// Fetches a message by its SID from the Twilio API.
+        /// </summary>
+        /// <param name="messageSid">The SID of the message to fetch.</param>
+        /// <returns>A <see cref="MessageResource"/> representing the fetched message.</returns>
         Task<MessageResource> FetchMessageAsync(string messageSid);
     }
 }

--- a/src/Deveel.Messaging.Connector.Twilio/Messaging/ITwilioApiClient.cs
+++ b/src/Deveel.Messaging.Connector.Twilio/Messaging/ITwilioApiClient.cs
@@ -1,0 +1,16 @@
+using Twilio.Rest.Api.V2010;
+using Twilio.Rest.Api.V2010.Account;
+
+namespace Deveel.Messaging
+{
+    public interface ITwilioApiClient
+    {
+        void Initialize(string accountSid, string authToken);
+
+        Task<AccountResource?> FetchAccountAsync(string accountSid);
+
+        Task<MessageResource> CreateMessageAsync(CreateMessageOptions options);
+
+        Task<MessageResource> FetchMessageAsync(string messageSid);
+    }
+}

--- a/src/Deveel.Messaging.Connector.Twilio/Messaging/TwilioApiClient.cs
+++ b/src/Deveel.Messaging.Connector.Twilio/Messaging/TwilioApiClient.cs
@@ -1,0 +1,26 @@
+using System.Diagnostics.CodeAnalysis;
+
+using Twilio;
+using Twilio.Rest.Api.V2010;
+using Twilio.Rest.Api.V2010.Account;
+
+namespace Deveel.Messaging
+{
+    [ExcludeFromCodeCoverage]
+    public class TwilioApiClient : ITwilioApiClient
+    {
+        public void Initialize(string accountSid, string authToken)
+        {
+            TwilioClient.Init(accountSid, authToken);
+        }
+
+        public Task<AccountResource?> FetchAccountAsync(string accountSid)
+            => AccountResource.FetchAsync(accountSid);
+
+        public Task<MessageResource> CreateMessageAsync(CreateMessageOptions options)
+            => MessageResource.CreateAsync(options);
+
+        public Task<MessageResource> FetchMessageAsync(string messageSid)
+            => MessageResource.FetchAsync(messageSid);
+    }
+}

--- a/src/Deveel.Messaging.Connector.Twilio/Messaging/TwilioApiClient.cs
+++ b/src/Deveel.Messaging.Connector.Twilio/Messaging/TwilioApiClient.cs
@@ -9,17 +9,21 @@ namespace Deveel.Messaging
     [ExcludeFromCodeCoverage]
     public class TwilioApiClient : ITwilioApiClient
     {
+        /// <inheritdoc/>
         public void Initialize(string accountSid, string authToken)
         {
             TwilioClient.Init(accountSid, authToken);
         }
 
+        /// <inheritdoc/>
         public Task<AccountResource?> FetchAccountAsync(string accountSid)
             => AccountResource.FetchAsync(accountSid);
 
+        /// <inheritdoc/>
         public Task<MessageResource> CreateMessageAsync(CreateMessageOptions options)
             => MessageResource.CreateAsync(options);
 
+        /// <inheritdoc/>
         public Task<MessageResource> FetchMessageAsync(string messageSid)
             => MessageResource.FetchAsync(messageSid);
     }

--- a/src/Deveel.Messaging.Connector.Twilio/Messaging/TwilioConnectionSettingsExtensions.cs
+++ b/src/Deveel.Messaging.Connector.Twilio/Messaging/TwilioConnectionSettingsExtensions.cs
@@ -1,25 +1,63 @@
 namespace Deveel.Messaging;
 
+/// <summary>
+/// Provides extension methods for <see cref="ConnectionSettings"/> to access Twilio-specific parameters.
+/// </summary>
 public static class TwilioConnectionSettingsExtensions
 {
+    /// <summary>
+    /// Gets the Twilio Account SID from the connection settings.
+    /// </summary>
+    /// <param name="settings">The connection settings to read from.</param>
+    /// <returns>The Account SID, or <c>null</c> if not configured.</returns>
     public static string? GetAccountSid(this ConnectionSettings settings)
         => settings.GetParameter<string>(TwilioConnectionParameters.AccountSid);
 
+    /// <summary>
+    /// Gets the Twilio authentication token from the connection settings.
+    /// </summary>
+    /// <param name="settings">The connection settings to read from.</param>
+    /// <returns>The authentication token, or <c>null</c> if not configured.</returns>
     public static string? GetAuthToken(this ConnectionSettings settings)
         => settings.GetParameter<string>(TwilioConnectionParameters.AuthToken);
 
+    /// <summary>
+    /// Gets the webhook URL configured for Twilio callbacks.
+    /// </summary>
+    /// <param name="settings">The connection settings to read from.</param>
+    /// <returns>The webhook URL, or <c>null</c> if not configured.</returns>
     public static string? GetWebhookUrl(this ConnectionSettings settings)
         => settings.GetParameter<string>(TwilioConnectionParameters.WebhookUrl);
 
+    /// <summary>
+    /// Gets the status callback URL for Twilio message status updates.
+    /// </summary>
+    /// <param name="settings">The connection settings to read from.</param>
+    /// <returns>The status callback URL, or <c>null</c> if not configured.</returns>
     public static string? GetStatusCallback(this ConnectionSettings settings)
         => settings.GetParameter<string>(TwilioConnectionParameters.StatusCallback);
 
+    /// <summary>
+    /// Gets the validity period (in seconds) for Twilio messages.
+    /// </summary>
+    /// <param name="settings">The connection settings to read from.</param>
+    /// <returns>The validity period, or <c>null</c> if not configured.</returns>
     public static int? GetValidityPeriod(this ConnectionSettings settings)
         => settings.GetParameter<int?>(TwilioConnectionParameters.ValidityPeriod);
 
+    /// <summary>
+    /// Gets the maximum price allowed for messages.
+    /// </summary>
+    /// <param name="settings">The connection settings to read from.</param>
+    /// <returns>The maximum price, or <c>null</c> if not configured.</returns>
     public static double? GetMaxPrice(this ConnectionSettings settings)
         => settings.GetParameter<double?>(TwilioConnectionParameters.MaxPrice);
 
+    /// <summary>
+    /// Gets the Messaging Service SID for Twilio.
+    /// </summary>
+    /// <param name="settings">The connection settings to read from.</param>
+    /// <returns>The Messaging Service SID, or <c>null</c> if not configured.</returns>
     public static string? GetMessagingServiceSid(this ConnectionSettings settings)
         => settings.GetParameter<string>(TwilioConnectionParameters.MessagingServiceSid);
 }

--- a/src/Deveel.Messaging.Connector.Twilio/Messaging/TwilioService.cs
+++ b/src/Deveel.Messaging.Connector.Twilio/Messaging/TwilioService.cs
@@ -12,10 +12,13 @@ namespace Deveel.Messaging;
 /// <summary>
 /// Default implementation of <see cref="ITwilioService"/> that wraps the actual Twilio SDK calls.
 /// </summary>
-public class TwilioService : ITwilioService
+    public class TwilioService : ITwilioService
 {
     private readonly ITwilioApiClient _client;
 
+    /// <summary>
+    /// Constructs a <see cref="TwilioService"/> using the default <see cref="TwilioApiClient"/>.
+    /// </summary>
     public TwilioService()
     {
         _client = new TwilioApiClient();
@@ -85,6 +88,11 @@ public class TwilioService : ITwilioService
         }
     }
 
+    /// <summary>
+    /// Maps a Twilio API error code to an internal messaging error code.
+    /// </summary>
+    /// <param name="twilioCode">The Twilio error code to map.</param>
+    /// <returns>The corresponding internal error code string.</returns>
     public static string MapTwilioErrorCode(int? twilioCode)
     {
         // Map common Twilio error codes to internal error codes

--- a/src/Deveel.Messaging.Connector.Twilio/Messaging/TwilioService.cs
+++ b/src/Deveel.Messaging.Connector.Twilio/Messaging/TwilioService.cs
@@ -3,7 +3,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for details.
 //
 
-using Twilio;
 using Twilio.Exceptions;
 using Twilio.Rest.Api.V2010;
 using Twilio.Rest.Api.V2010.Account;
@@ -15,10 +14,22 @@ namespace Deveel.Messaging;
 /// </summary>
 public class TwilioService : ITwilioService
 {
+    private readonly ITwilioApiClient _client;
+
+    public TwilioService()
+    {
+        _client = new TwilioApiClient();
+    }
+
+    internal TwilioService(ITwilioApiClient client)
+    {
+        _client = client;
+    }
+
     /// <inheritdoc/>
     public void Initialize(string accountSid, string authToken)
     {
-        TwilioClient.Init(accountSid, authToken);
+        _client.Initialize(accountSid, authToken);
     }
 
     /// <inheritdoc/>
@@ -26,7 +37,7 @@ public class TwilioService : ITwilioService
     {
         try
         {
-            return await AccountResource.FetchAsync(accountSid);
+            return await _client.FetchAccountAsync(accountSid);
         }
         catch (ApiException ex)
         {
@@ -43,7 +54,7 @@ public class TwilioService : ITwilioService
     {
         try
         {
-            return await MessageResource.CreateAsync(options);
+            return await _client.CreateMessageAsync(options);
         }
         catch (ApiException ex)
         {
@@ -62,7 +73,7 @@ public class TwilioService : ITwilioService
     {
         try
         {
-            return await MessageResource.FetchAsync(messageSid);
+            return await _client.FetchMessageAsync(messageSid);
         }
         catch (ApiException ex)
         {
@@ -74,7 +85,7 @@ public class TwilioService : ITwilioService
         }
     }
 
-    private static string MapTwilioErrorCode(int? twilioCode)
+    public static string MapTwilioErrorCode(int? twilioCode)
     {
         // Map common Twilio error codes to internal error codes
         return twilioCode switch

--- a/src/Deveel.Messaging.Connectors/Messaging/ChannelConnectorBase.cs
+++ b/src/Deveel.Messaging.Connectors/Messaging/ChannelConnectorBase.cs
@@ -11,6 +11,11 @@ using System.Runtime.CompilerServices;
 
 namespace Deveel.Messaging
 {
+    /// <summary>
+    /// Provides a base implementation for a channel connector that handles
+    /// authentication, initialization, message sending, receiving, and
+    /// health monitoring.
+    /// </summary>
     public abstract class ChannelConnectorBase : IChannelConnector
     {
         private ConnectorState _state = ConnectorState.Uninitialized;
@@ -20,6 +25,24 @@ namespace Deveel.Messaging
         private bool _autoAuthenticationAttempted;
         private readonly IMessageIdGenerator _idGenerator;
 
+        /// <summary>
+        /// Constructs the connector base with the given schema and optional settings.
+        /// </summary>
+        /// <param name="schema">
+        /// The channel schema that defines the capabilities and configuration of the connector.
+        /// </param>
+        /// <param name="connectionSettings">
+        /// An optional set of connection settings to use for the connector.
+        /// </param>
+        /// <param name="logger">
+        /// An optional logger instance used to log diagnostic information.
+        /// </param>
+        /// <param name="authenticationManager">
+        /// An optional authentication manager used to handle authentication operations.
+        /// </param>
+        /// <param name="idGenerator">
+        /// An optional message identifier generator used to generate unique message identifiers.
+        /// </param>
         protected ChannelConnectorBase(
             IChannelSchema schema,
             ConnectionSettings? connectionSettings = null,
@@ -34,18 +57,39 @@ namespace Deveel.Messaging
             _idGenerator = idGenerator ?? new DefaultMessageIdGenerator();
         }
 
+        /// <summary>
+        /// Gets the channel schema that defines the capabilities and configuration of the connector.
+        /// </summary>
         public IChannelSchema Schema { get; }
 
+        /// <summary>
+        /// Gets the connection settings used by the connector.
+        /// </summary>
         public ConnectionSettings ConnectionSettings { get; }
 
+        /// <summary>
+        /// Gets the logger used to log diagnostic information.
+        /// </summary>
         protected ILogger Logger { get; }
 
+        /// <summary>
+        /// Gets the authentication manager used to handle authentication operations.
+        /// </summary>
         protected IAuthenticationManager AuthenticationManager => _authenticationManager;
 
+        /// <summary>
+        /// Gets the current authentication credential, if authentication has been performed.
+        /// </summary>
         protected AuthenticationCredential? AuthenticationCredential => _authenticationCredential;
 
+        /// <summary>
+        /// Gets the message identifier generator used to generate unique message identifiers.
+        /// </summary>
         protected IMessageIdGenerator IdGenerator => _idGenerator;
 
+        /// <summary>
+        /// Gets the current state of the connector.
+        /// </summary>
         public ConnectorState State
         {
             get
@@ -57,6 +101,10 @@ namespace Deveel.Messaging
             }
         }
 
+        /// <summary>
+        /// Sets the state of the connector in a thread-safe manner.
+        /// </summary>
+        /// <param name="newState">The new state to set for the connector.</param>
         protected void SetState(ConnectorState newState)
         {
             lock (_stateLock)
@@ -65,6 +113,13 @@ namespace Deveel.Messaging
             }
         }
 
+        /// <summary>
+        /// Validates that the connector supports the given capability.
+        /// </summary>
+        /// <param name="capability">The capability to validate.</param>
+        /// <exception cref="MessagingException">
+        /// Thrown if the connector does not support the specified capability.
+        /// </exception>
         protected void ValidateCapability(ChannelCapability capability)
         {
             if (!Schema.Capabilities.HasFlag(capability))
@@ -73,6 +128,12 @@ namespace Deveel.Messaging
             }
         }
 
+        /// <summary>
+        /// Ensures the connector is initialized before performing any operation.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that the operation should be canceled.
+        /// </param>
         protected async Task EnsureInitializedAsync(CancellationToken cancellationToken)
         {
             if (State == ConnectorState.Uninitialized)
@@ -81,6 +142,12 @@ namespace Deveel.Messaging
             ValidateOperationalState();
         }
 
+        /// <summary>
+        /// Validates that the connector is in an operational state.
+        /// </summary>
+        /// <exception cref="MessagingException">
+        /// Thrown if the connector is not in an operational state.
+        /// </exception>
         protected void ValidateOperationalState()
         {
             var currentState = State;
@@ -93,6 +160,12 @@ namespace Deveel.Messaging
             }
         }
 
+        /// <summary>
+        /// Begins a logging scope that includes the channel type and version information.
+        /// </summary>
+        /// <returns>
+        /// An <see cref="IDisposable"/> instance that ends the logging scope when disposed.
+        /// </returns>
         protected virtual IDisposable? BeginConnectorLoggerScope()
         {
             return Logger.BeginScope(
@@ -101,11 +174,27 @@ namespace Deveel.Messaging
                     Schema.Version);
         }
 
+        /// <summary>
+        /// Begins a logging scope that includes the message identifier.
+        /// </summary>
+        /// <param name="message">The message to create the logging scope for.</param>
+        /// <returns>
+        /// An <see cref="IDisposable"/> instance that ends the logging scope when disposed.
+        /// </returns>
         protected virtual IDisposable? BeginMessageLoggerScope(IMessage message)
         {
             return Logger.BeginScope("[MessageId:{MessageId}]", message.Id ?? "(unknown)");
         }
 
+        /// <summary>
+        /// Initializes the connector and attempts auto-authentication if required by the schema.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that the operation should be canceled.
+        /// </param>
+        /// <returns>
+        /// Returns an <see cref="OperationResult{T}"/> indicating whether the initialization was successful.
+        /// </returns>
         public async ValueTask<OperationResult<bool>> InitializeAsync(CancellationToken cancellationToken)
         {
             using var scope = BeginConnectorLoggerScope();
@@ -162,8 +251,24 @@ namespace Deveel.Messaging
             }
         }
 
+        /// <summary>
+        /// Performs connector-specific initialization logic when the connector is initialized.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that the operation should be canceled.
+        /// </param>
         protected abstract ValueTask InitializeConnectorAsync(CancellationToken cancellationToken);
 
+        /// <summary>
+        /// Authenticates the connector using the first matching authentication configuration
+        /// found in the schema for the provided connection settings.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that the operation should be canceled.
+        /// </param>
+        /// <returns>
+        /// Returns an <see cref="OperationResult{T}"/> indicating whether authentication succeeded.
+        /// </returns>
         protected async Task<OperationResult<bool>> AuthenticateAsync(CancellationToken cancellationToken = default)
         {
             using var scope = BeginConnectorLoggerScope();
@@ -220,6 +325,16 @@ namespace Deveel.Messaging
             }
         }
 
+        /// <summary>
+        /// Refreshes the current authentication credential, or performs a new
+        /// authentication if no credential exists.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that the operation should be canceled.
+        /// </param>
+        /// <returns>
+        /// Returns an <see cref="OperationResult{T}"/> indicating whether the refresh succeeded.
+        /// </returns>
         protected async Task<OperationResult<bool>> RefreshAuthenticationAsync(CancellationToken cancellationToken = default)
         {
             using var scope = BeginConnectorLoggerScope();
@@ -275,6 +390,14 @@ namespace Deveel.Messaging
             }
         }
 
+        /// <summary>
+        /// Gets the authentication header value from the current credential,
+        /// based on the authentication scheme.
+        /// </summary>
+        /// <returns>
+        /// A string containing the authentication header value, or <c>null</c> if
+        /// no credential is available or the scheme is not supported.
+        /// </returns>
         protected virtual string? GetAuthenticationHeader()
         {
             if (_authenticationCredential == null)
@@ -295,6 +418,13 @@ namespace Deveel.Messaging
             return null;
         }
 
+        /// <summary>
+        /// Gets the API key from the current authentication credential,
+        /// if the scheme is <see cref="AuthenticationScheme.ApiKey"/>.
+        /// </summary>
+        /// <returns>
+        /// The API key string, or <c>null</c> if the credential is not an API key.
+        /// </returns>
         protected virtual string? GetApiKey()
         {
             return _authenticationCredential?.Scheme == AuthenticationScheme.ApiKey
@@ -302,12 +432,29 @@ namespace Deveel.Messaging
                 : null;
         }
 
+        /// <summary>
+        /// Determines whether the connector uses anonymous authentication
+        /// (no authentication configurations or all are set to <see cref="AuthenticationScheme.None"/>).
+        /// </summary>
+        /// <returns>
+        /// <c>true</c> if the connector is anonymous; otherwise, <c>false</c>.
+        /// </returns>
         protected virtual bool IsAnonymousConnector()
         {
             return Schema.AuthenticationConfigurations.Count == 0 ||
                    Schema.AuthenticationConfigurations.All(c => c.Scheme == AuthenticationScheme.None);
         }
 
+        /// <summary>
+        /// Tests the connection to the remote service by performing a connector-specific
+        /// connection test.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that the operation should be canceled.
+        /// </param>
+        /// <returns>
+        /// Returns an <see cref="OperationResult{T}"/> indicating whether the connection test succeeded.
+        /// </returns>
         public async ValueTask<OperationResult<bool>> TestConnectionAsync(CancellationToken cancellationToken)
         {
             await EnsureInitializedAsync(cancellationToken);
@@ -340,8 +487,24 @@ namespace Deveel.Messaging
             }
         }
 
+        /// <summary>
+        /// Performs connector-specific connection testing logic.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that the operation should be canceled.
+        /// </param>
         protected abstract ValueTask TestConnectorConnectionAsync(CancellationToken cancellationToken);
 
+        /// <summary>
+        /// Sends a message through the connector after validating it.
+        /// </summary>
+        /// <param name="message">The message to send.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that the operation should be canceled.
+        /// </param>
+        /// <returns>
+        /// Returns an <see cref="OperationResult{T}"/> containing the result of the send operation.
+        /// </returns>
         public async ValueTask<OperationResult<SendResult>> SendMessageAsync(IMessage message, CancellationToken cancellationToken)
         {
             ArgumentNullException.ThrowIfNull(message);
@@ -398,8 +561,28 @@ namespace Deveel.Messaging
             }
         }
 
+        /// <summary>
+        /// Performs the core logic of sending a message to the remote service.
+        /// </summary>
+        /// <param name="message">The message to send.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that the operation should be canceled.
+        /// </param>
+        /// <returns>
+        /// A <see cref="SendResult"/> containing the result of the send operation.
+        /// </returns>
         protected abstract Task<SendResult> SendMessageCoreAsync(IMessage message, CancellationToken cancellationToken);
 
+        /// <summary>
+        /// Sends a batch of messages through the connector after validating each message.
+        /// </summary>
+        /// <param name="batch">The batch of messages to send.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that the operation should be canceled.
+        /// </param>
+        /// <returns>
+        /// Returns an <see cref="OperationResult{T}"/> containing the result of the batch send operation.
+        /// </returns>
         public virtual async ValueTask<OperationResult<BatchSendResult>> SendBatchAsync(IMessageBatch batch, CancellationToken cancellationToken)
         {
             ArgumentNullException.ThrowIfNull(batch);
@@ -465,11 +648,30 @@ namespace Deveel.Messaging
             }
         }
 
+        /// <summary>
+        /// Performs the core logic of sending a batch of messages.
+        /// </summary>
+        /// <param name="batch">The batch of messages to send.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that the operation should be canceled.
+        /// </param>
+        /// <returns>
+        /// A <see cref="BatchSendResult"/> containing the result of the batch send operation.
+        /// </returns>
         protected virtual Task<BatchSendResult> SendBatchCoreAsync(IMessageBatch batch, CancellationToken cancellationToken)
         {
             throw new NotSupportedException("Batch sending is not supported by this connector.");
         }
 
+        /// <summary>
+        /// Gets the current status of the connector.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that the operation should be canceled.
+        /// </param>
+        /// <returns>
+        /// Returns an <see cref="OperationResult{T}"/> containing the status information of the connector.
+        /// </returns>
         public async ValueTask<OperationResult<StatusInfo>> GetStatusAsync(CancellationToken cancellationToken)
         {
             using var scope = BeginConnectorLoggerScope();
@@ -496,8 +698,27 @@ namespace Deveel.Messaging
             }
         }
 
+        /// <summary>
+        /// Performs connector-specific logic to retrieve the current status.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that the operation should be canceled.
+        /// </param>
+        /// <returns>
+        /// A <see cref="StatusInfo"/> containing the connector status.
+        /// </returns>
         protected abstract Task<StatusInfo> GetConnectorStatusAsync(CancellationToken cancellationToken);
 
+        /// <summary>
+        /// Gets the status updates for a specific message.
+        /// </summary>
+        /// <param name="messageId">The identifier of the message to query.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that the operation should be canceled.
+        /// </param>
+        /// <returns>
+        /// Returns an <see cref="OperationResult{T}"/> containing the status updates for the message.
+        /// </returns>
         public async ValueTask<OperationResult<StatusUpdatesResult>> GetMessageStatusAsync(string messageId, CancellationToken cancellationToken)
         {
             ArgumentException.ThrowIfNullOrWhiteSpace(messageId);
@@ -528,11 +749,31 @@ namespace Deveel.Messaging
             }
         }
 
+        /// <summary>
+        /// Performs the core logic of retrieving message status from the remote service.
+        /// </summary>
+        /// <param name="messageId">The identifier of the message.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that the operation should be canceled.
+        /// </param>
+        /// <returns>
+        /// A <see cref="StatusUpdatesResult"/> containing the status updates.
+        /// </returns>
         protected virtual Task<StatusUpdatesResult> GetMessageStatusCoreAsync(string messageId, CancellationToken cancellationToken)
         {
             throw new NotSupportedException("Message status querying is not supported by this connector.");
         }
 
+        /// <summary>
+        /// Validates the message against the channel schema and any additional connector rules.
+        /// </summary>
+        /// <param name="message">The message to validate.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that the operation should be canceled.
+        /// </param>
+        /// <returns>
+        /// An asynchronous enumerable of <see cref="ValidationResult"/> objects describing validation errors.
+        /// </returns>
         public virtual async IAsyncEnumerable<ValidationResult> ValidateMessageAsync(IMessage message, [EnumeratorCancellation] CancellationToken cancellationToken)
         {
             ArgumentNullException.ThrowIfNull(message);
@@ -543,6 +784,16 @@ namespace Deveel.Messaging
             }
         }
 
+        /// <summary>
+        /// Performs the core validation logic against the channel schema.
+        /// </summary>
+        /// <param name="message">The message to validate.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that the operation should be canceled.
+        /// </param>
+        /// <returns>
+        /// An asynchronous enumerable of <see cref="ValidationResult"/> objects describing validation errors.
+        /// </returns>
         protected virtual async IAsyncEnumerable<ValidationResult> ValidateMessageCoreAsync(IMessage message, [EnumeratorCancellation] CancellationToken cancellationToken)
         {
             var validationResults = Schema.ValidateMessage(message);
@@ -562,6 +813,13 @@ namespace Deveel.Messaging
             await Task.CompletedTask;
         }
 
+        /// <summary>
+        /// Gets a string representation of the endpoint type for use in API calls.
+        /// </summary>
+        /// <param name="endpoint">The endpoint to get the type for.</param>
+        /// <returns>
+        /// A string representing the endpoint type, or <c>null</c> if the type is not recognized.
+        /// </returns>
         protected virtual string? GetEndpointType(IEndpoint endpoint)
         {
             return endpoint.Type switch
@@ -580,6 +838,16 @@ namespace Deveel.Messaging
             };
         }
 
+        /// <summary>
+        /// Determines whether the given endpoint type is supported by the connector
+        /// for the specified roles (sender and/or receiver).
+        /// </summary>
+        /// <param name="endpointType">The endpoint type to check.</param>
+        /// <param name="asSender">If <c>true</c>, checks if the type is supported as a sender.</param>
+        /// <param name="asReceiver">If <c>true</c>, checks if the type is supported as a receiver.</param>
+        /// <returns>
+        /// <c>true</c> if the endpoint type is supported; otherwise, <c>false</c>.
+        /// </returns>
         protected virtual bool IsEndpointTypeSupported(EndpointType endpointType, bool asSender = false, bool asReceiver = false)
         {
             return Schema.Endpoints.Any(e =>
@@ -588,6 +856,16 @@ namespace Deveel.Messaging
                 (!asReceiver || e.CanReceive));
         }
 
+        /// <summary>
+        /// Receives a status update for a message from the remote service.
+        /// </summary>
+        /// <param name="source">The source of the message status update.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that the operation should be canceled.
+        /// </param>
+        /// <returns>
+        /// Returns an <see cref="OperationResult{T}"/> containing the status update result.
+        /// </returns>
         public async ValueTask<OperationResult<StatusUpdateResult>> ReceiveMessageStatusAsync(MessageSource source, CancellationToken cancellationToken)
         {
             ValidateCapability(ChannelCapability.HandleMessageState);
@@ -617,11 +895,31 @@ namespace Deveel.Messaging
             }
         }
 
+        /// <summary>
+        /// Performs the core logic of receiving a message status update from the remote service.
+        /// </summary>
+        /// <param name="source">The source of the message status update.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that the operation should be canceled.
+        /// </param>
+        /// <returns>
+        /// A <see cref="StatusUpdateResult"/> containing the status update.
+        /// </returns>
         protected virtual Task<StatusUpdateResult> ReceiveMessageStatusCoreAsync(MessageSource source, CancellationToken cancellationToken)
         {
             throw new NotSupportedException("Status receiving is not supported by this connector.");
         }
 
+        /// <summary>
+        /// Receives messages from the remote service.
+        /// </summary>
+        /// <param name="source">The source to receive messages from.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that the operation should be canceled.
+        /// </param>
+        /// <returns>
+        /// Returns an <see cref="OperationResult{T}"/> containing the received messages.
+        /// </returns>
         public async ValueTask<OperationResult<ReceiveResult>> ReceiveMessagesAsync(MessageSource source, CancellationToken cancellationToken)
         {
             ValidateCapability(ChannelCapability.ReceiveMessages);
@@ -653,11 +951,30 @@ namespace Deveel.Messaging
             }
         }
 
+        /// <summary>
+        /// Performs the core logic of receiving messages from the remote service.
+        /// </summary>
+        /// <param name="source">The source to receive messages from.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that the operation should be canceled.
+        /// </param>
+        /// <returns>
+        /// A <see cref="ReceiveResult"/> containing the received messages.
+        /// </returns>
         protected virtual Task<ReceiveResult> ReceiveMessagesCoreAsync(MessageSource source, CancellationToken cancellationToken)
         {
             throw new NotSupportedException("Message receiving is not supported by this connector.");
         }
 
+        /// <summary>
+        /// Gets the health status of the connector.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that the operation should be canceled.
+        /// </param>
+        /// <returns>
+        /// Returns an <see cref="OperationResult{T}"/> containing the health information.
+        /// </returns>
         public virtual async ValueTask<OperationResult<ConnectorHealth>> GetHealthAsync(CancellationToken cancellationToken)
         {
             ValidateCapability(ChannelCapability.HealthCheck);
@@ -686,6 +1003,15 @@ namespace Deveel.Messaging
             }
         }
 
+        /// <summary>
+        /// Performs connector-specific logic to determine health status.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that the operation should be canceled.
+        /// </param>
+        /// <returns>
+        /// A <see cref="ConnectorHealth"/> containing the health information.
+        /// </returns>
         protected virtual Task<ConnectorHealth> GetConnectorHealthAsync(CancellationToken cancellationToken)
         {
             var health = new ConnectorHealth
@@ -704,6 +1030,12 @@ namespace Deveel.Messaging
             return Task.FromResult(health);
         }
 
+        /// <summary>
+        /// Shuts down the connector gracefully.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that the operation should be canceled.
+        /// </param>
         public async ValueTask ShutdownAsync(CancellationToken cancellationToken)
         {
             using var scope = BeginConnectorLoggerScope();
@@ -725,6 +1057,12 @@ namespace Deveel.Messaging
             }
         }
 
+        /// <summary>
+        /// Performs connector-specific shutdown logic.
+        /// </summary>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that the operation should be canceled.
+        /// </param>
         protected virtual Task ShutdownConnectorAsync(CancellationToken cancellationToken)
         {
             return Task.CompletedTask;

--- a/src/Deveel.Messaging.Connectors/Messaging/ChannelSchemaBuilder.cs
+++ b/src/Deveel.Messaging.Connectors/Messaging/ChannelSchemaBuilder.cs
@@ -5,6 +5,10 @@
 
 namespace Deveel.Messaging
 {
+    /// <summary>
+    /// Provides a builder pattern for constructing <see cref="ChannelSchema"/> instances
+    /// with parameters, message properties, authentication configurations, and endpoint configurations.
+    /// </summary>
     public class ChannelSchemaBuilder
     {
         private string _channelProvider;
@@ -19,6 +23,12 @@ namespace Deveel.Messaging
         private readonly List<AuthenticationConfiguration> _authenticationConfigurations = new();
         private readonly List<ChannelEndpointConfiguration> _endpoints = new();
 
+        /// <summary>
+        /// Constructs a new builder for a channel schema with the given provider, type, and version.
+        /// </summary>
+        /// <param name="channelProvider">The name of the channel provider (e.g., "Twilio", "SendGrid").</param>
+        /// <param name="channelType">The type of the channel (e.g., "sms", "email").</param>
+        /// <param name="version">The version of the channel schema.</param>
         public ChannelSchemaBuilder(string channelProvider, string channelType, string version)
         {
             ArgumentException.ThrowIfNullOrWhiteSpace(channelProvider, nameof(channelProvider));
@@ -95,6 +105,15 @@ namespace Deveel.Messaging
             }
         }
 
+        /// <summary>
+        /// Creates a new <see cref="ChannelSchemaBuilder"/> from an existing schema,
+        /// copying all its configuration.
+        /// </summary>
+        /// <param name="source">The source schema to copy from.</param>
+        /// <param name="derivedDisplayName">
+        /// An optional display name for the derived schema; defaults to the source name with "(Copy)" suffix.
+        /// </param>
+        /// <returns>A new builder pre-populated with the source schema's configuration.</returns>
         public static ChannelSchemaBuilder From(IChannelSchema source, string? derivedDisplayName = null)
         {
             var builder = new ChannelSchemaBuilder(source);
@@ -102,42 +121,80 @@ namespace Deveel.Messaging
             return builder;
         }
 
+        /// <summary>
+        /// Sets the identifier of the schema (currently a no-op placeholder).
+        /// </summary>
+        /// <param name="id">The identifier to set.</param>
+        /// <returns>This builder for chaining.</returns>
         public ChannelSchemaBuilder WithId(string id) => this;
 
+        /// <summary>
+        /// Sets the display name of the schema.
+        /// </summary>
+        /// <param name="displayName">The display name to set.</param>
+        /// <returns>This builder for chaining.</returns>
         public ChannelSchemaBuilder WithDisplayName(string? displayName)
         {
             _displayName = displayName;
             return this;
         }
 
+        /// <summary>
+        /// Replaces the capabilities of the schema with the given value.
+        /// </summary>
+        /// <param name="capabilities">The capabilities to set.</param>
+        /// <returns>This builder for chaining.</returns>
         public ChannelSchemaBuilder WithCapabilities(ChannelCapability capabilities)
         {
             _capabilities = capabilities;
             return this;
         }
 
+        /// <summary>
+        /// Adds a capability to the schema.
+        /// </summary>
+        /// <param name="capability">The capability to add.</param>
+        /// <returns>This builder for chaining.</returns>
         public ChannelSchemaBuilder WithCapability(ChannelCapability capability)
         {
             _capabilities |= capability;
             return this;
         }
 
+        /// <summary>
+        /// Sets whether the schema should use strict mode validation.
+        /// </summary>
+        /// <param name="isStrict"><c>true</c> for strict mode; <c>false</c> for flexible mode.</param>
+        /// <returns>This builder for chaining.</returns>
         public ChannelSchemaBuilder WithStrictMode(bool isStrict)
         {
             _isStrict = isStrict;
             return this;
         }
 
+        /// <summary>
+        /// Enables strict mode validation for the schema.
+        /// </summary>
+        /// <returns>This builder for chaining.</returns>
         public ChannelSchemaBuilder WithStrictMode()
         {
             return WithStrictMode(true);
         }
 
+        /// <summary>
+        /// Enables flexible mode validation for the schema.
+        /// </summary>
+        /// <returns>This builder for chaining.</returns>
         public ChannelSchemaBuilder WithFlexibleMode()
         {
             return WithStrictMode(false);
         }
 
+        /// <summary>
+        /// Adds a pre-built parameter to the schema.
+        /// </summary>
+        /// <param name="parameter">The parameter to add.</param>
+        /// <returns>This builder for chaining.</returns>
         public ChannelSchemaBuilder AddParameter(ChannelParameter parameter)
         {
             ArgumentNullException.ThrowIfNull(parameter, nameof(parameter));
@@ -145,6 +202,13 @@ namespace Deveel.Messaging
             return this;
         }
 
+        /// <summary>
+        /// Creates and adds a parameter with the given name and type, optionally configuring it.
+        /// </summary>
+        /// <param name="parameterName">The name of the parameter.</param>
+        /// <param name="parameterType">The data type of the parameter.</param>
+        /// <param name="configure">An optional action to configure the parameter.</param>
+        /// <returns>This builder for chaining.</returns>
         public ChannelSchemaBuilder AddParameter(string parameterName, DataType parameterType, Action<ChannelParameter>? configure = null)
         {
             ArgumentException.ThrowIfNullOrWhiteSpace(parameterName, nameof(parameterName));
@@ -153,9 +217,21 @@ namespace Deveel.Messaging
             return AddParameter(parameter);
         }
 
+        /// <summary>
+        /// Creates and adds a required parameter, optionally marking it as sensitive.
+        /// </summary>
+        /// <param name="parameterName">The name of the parameter.</param>
+        /// <param name="parameterType">The data type of the parameter.</param>
+        /// <param name="sensitive">If <c>true</c>, marks the parameter as sensitive.</param>
+        /// <returns>This builder for chaining.</returns>
         public ChannelSchemaBuilder AddRequiredParameter(string parameterName, DataType parameterType, bool sensitive = false)
             => AddParameter(parameterName, parameterType, param => { param.IsRequired = true; param.IsSensitive = sensitive; });
 
+        /// <summary>
+        /// Adds a pre-built message property configuration to the schema.
+        /// </summary>
+        /// <param name="property">The message property configuration to add.</param>
+        /// <returns>This builder for chaining.</returns>
         public ChannelSchemaBuilder AddMessageProperty(MessagePropertyConfiguration property)
         {
             ArgumentNullException.ThrowIfNull(property, nameof(property));
@@ -167,6 +243,13 @@ namespace Deveel.Messaging
             return this;
         }
 
+        /// <summary>
+        /// Creates and adds a message property configuration with the given name and type.
+        /// </summary>
+        /// <param name="propertyName">The name of the message property.</param>
+        /// <param name="propertyType">The data type of the message property.</param>
+        /// <param name="configure">An optional action to configure the property.</param>
+        /// <returns>This builder for chaining.</returns>
         public ChannelSchemaBuilder AddMessageProperty(string propertyName, DataType propertyType, Action<MessagePropertyConfiguration>? configure = null)
         {
             ArgumentException.ThrowIfNullOrWhiteSpace(propertyName, nameof(propertyName));
@@ -175,6 +258,11 @@ namespace Deveel.Messaging
             return AddMessageProperty(property);
         }
 
+        /// <summary>
+        /// Adds a content type to the list of supported content types for the schema.
+        /// </summary>
+        /// <param name="contentType">The content type to add.</param>
+        /// <returns>This builder for chaining.</returns>
         public ChannelSchemaBuilder AddContentType(MessageContentType contentType)
         {
             _contentTypes.Add(contentType);
@@ -208,6 +296,12 @@ namespace Deveel.Messaging
             return AddAuthenticationScheme(authenticationType);
         }
 
+        /// <summary>
+        /// Adds a pre-built authentication configuration to the schema, automatically
+        /// creating corresponding channel parameters for principal fields.
+        /// </summary>
+        /// <param name="authenticationConfiguration">The authentication configuration to add.</param>
+        /// <returns>This builder for chaining.</returns>
         public ChannelSchemaBuilder AddAuthenticationConfiguration(AuthenticationConfiguration authenticationConfiguration)
         {
             ArgumentNullException.ThrowIfNull(authenticationConfiguration, nameof(authenticationConfiguration));
@@ -237,6 +331,11 @@ namespace Deveel.Messaging
             return this;
         }
 
+        /// <summary>
+        /// Creates and adds an authentication configuration using the provided factory function.
+        /// </summary>
+        /// <param name="configurationFactory">A function that creates the authentication configuration.</param>
+        /// <returns>This builder for chaining.</returns>
         public ChannelSchemaBuilder AddAuthenticationConfiguration(Func<AuthenticationConfiguration> configurationFactory)
         {
             ArgumentNullException.ThrowIfNull(configurationFactory, nameof(configurationFactory));
@@ -244,6 +343,11 @@ namespace Deveel.Messaging
             return AddAuthenticationConfiguration(config);
         }
 
+        /// <summary>
+        /// Adds a pre-built endpoint configuration to the schema.
+        /// </summary>
+        /// <param name="endpoint">The endpoint configuration to add.</param>
+        /// <returns>This builder for chaining.</returns>
         public ChannelSchemaBuilder HandlesMessageEndpoint(ChannelEndpointConfiguration endpoint)
         {
             ArgumentNullException.ThrowIfNull(endpoint, nameof(endpoint));
@@ -255,6 +359,12 @@ namespace Deveel.Messaging
             return this;
         }
 
+        /// <summary>
+        /// Creates and adds an endpoint configuration for the given endpoint type.
+        /// </summary>
+        /// <param name="endpointType">The type of the endpoint.</param>
+        /// <param name="configure">An optional action to configure the endpoint.</param>
+        /// <returns>This builder for chaining.</returns>
         public ChannelSchemaBuilder HandlesMessageEndpoint(EndpointType endpointType, Action<ChannelEndpointConfiguration>? configure = null)
         {
             var endpoint = new ChannelEndpointConfiguration(endpointType);
@@ -262,6 +372,10 @@ namespace Deveel.Messaging
             return HandlesMessageEndpoint(endpoint);
         }
 
+        /// <summary>
+        /// Configures the schema to allow any endpoint type (both sending and receiving).
+        /// </summary>
+        /// <returns>This builder for chaining.</returns>
         public ChannelSchemaBuilder AllowsAnyMessageEndpoint()
         {
             if (_endpoints.Any(e => e.Type == EndpointType.Any))
@@ -275,6 +389,11 @@ namespace Deveel.Messaging
             return this;
         }
 
+        /// <summary>
+        /// Removes a parameter from the schema by name.
+        /// </summary>
+        /// <param name="parameterName">The name of the parameter to remove.</param>
+        /// <returns>This builder for chaining.</returns>
         public ChannelSchemaBuilder RemoveParameter(string parameterName)
         {
             ArgumentException.ThrowIfNullOrWhiteSpace(parameterName, nameof(parameterName));
@@ -284,6 +403,11 @@ namespace Deveel.Messaging
             return this;
         }
 
+        /// <summary>
+        /// Removes a message property configuration from the schema by name.
+        /// </summary>
+        /// <param name="propertyName">The name of the message property to remove.</param>
+        /// <returns>This builder for chaining.</returns>
         public ChannelSchemaBuilder RemoveMessageProperty(string propertyName)
         {
             ArgumentException.ThrowIfNullOrWhiteSpace(propertyName, nameof(propertyName));
@@ -293,6 +417,11 @@ namespace Deveel.Messaging
             return this;
         }
 
+        /// <summary>
+        /// Removes a content type from the list of supported content types.
+        /// </summary>
+        /// <param name="contentType">The content type to remove.</param>
+        /// <returns>This builder for chaining.</returns>
         public ChannelSchemaBuilder RemoveContentType(MessageContentType contentType)
         {
             _contentTypes.Remove(contentType);
@@ -365,12 +494,22 @@ namespace Deveel.Messaging
                 .WithField("CertificatePassword", DataType.String, f => { f.AuthenticationRole = "credential"; f.IsSensitive = true; });
         }
 
+        /// <summary>
+        /// Removes a capability from the schema.
+        /// </summary>
+        /// <param name="capability">The capability to remove.</param>
+        /// <returns>This builder for chaining.</returns>
         public ChannelSchemaBuilder RemoveCapability(ChannelCapability capability)
         {
             _capabilities &= ~capability;
             return this;
         }
 
+        /// <summary>
+        /// Removes an endpoint configuration from the schema by type.
+        /// </summary>
+        /// <param name="endpointType">The endpoint type to remove.</param>
+        /// <returns>This builder for chaining.</returns>
         public ChannelSchemaBuilder RemoveEndpoint(EndpointType endpointType)
         {
             var endpoint = _endpoints.FirstOrDefault(e => e.Type == endpointType);
@@ -379,12 +518,22 @@ namespace Deveel.Messaging
             return this;
         }
 
+        /// <summary>
+        /// Restricts the capabilities of the schema to only those that match the given mask.
+        /// </summary>
+        /// <param name="allowedCapabilities">The capabilities mask to restrict to.</param>
+        /// <returns>This builder for chaining.</returns>
         public ChannelSchemaBuilder RestrictCapabilities(ChannelCapability allowedCapabilities)
         {
             _capabilities &= allowedCapabilities;
             return this;
         }
 
+        /// <summary>
+        /// Restricts the supported content types to only the specified ones.
+        /// </summary>
+        /// <param name="allowedContentTypes">The content types to allow.</param>
+        /// <returns>This builder for chaining.</returns>
         public ChannelSchemaBuilder RestrictContentTypes(params MessageContentType[] allowedContentTypes)
         {
             _contentTypes.Clear();
@@ -393,6 +542,11 @@ namespace Deveel.Messaging
             return this;
         }
 
+        /// <summary>
+        /// Restricts the authentication schemes to only the specified ones.
+        /// </summary>
+        /// <param name="allowedSchemes">The authentication schemes to allow.</param>
+        /// <returns>This builder for chaining.</returns>
         public ChannelSchemaBuilder RestrictAuthenticationSchemes(params AuthenticationScheme[] allowedSchemes)
         {
             var configurationsToRemove = _authenticationConfigurations
@@ -403,6 +557,11 @@ namespace Deveel.Messaging
             return this;
         }
 
+        /// <summary>
+        /// Replaces all authentication configurations with only the specified ones.
+        /// </summary>
+        /// <param name="allowedConfigurations">The authentication configurations to allow.</param>
+        /// <returns>This builder for chaining.</returns>
         public ChannelSchemaBuilder RestrictAuthenticationConfigurations(params AuthenticationConfiguration[] allowedConfigurations)
         {
             _authenticationConfigurations.Clear();
@@ -411,6 +570,12 @@ namespace Deveel.Messaging
             return this;
         }
 
+        /// <summary>
+        /// Updates a parameter in the schema by name using the provided action.
+        /// </summary>
+        /// <param name="parameterName">The name of the parameter to update.</param>
+        /// <param name="updateAction">The action to apply to the parameter.</param>
+        /// <returns>This builder for chaining.</returns>
         public ChannelSchemaBuilder UpdateParameter(string parameterName, Action<ChannelParameter> updateAction)
         {
             var parameter = _parameters.FirstOrDefault(p => string.Equals(p.Name, parameterName, StringComparison.OrdinalIgnoreCase));
@@ -420,6 +585,12 @@ namespace Deveel.Messaging
             return this;
         }
 
+        /// <summary>
+        /// Updates a message property configuration in the schema by name using the provided action.
+        /// </summary>
+        /// <param name="propertyName">The name of the message property to update.</param>
+        /// <param name="updateAction">The action to apply to the message property.</param>
+        /// <returns>This builder for chaining.</returns>
         public ChannelSchemaBuilder UpdateMessageProperty(string propertyName, Action<MessagePropertyConfiguration> updateAction)
         {
             var property = _messageProperties.FirstOrDefault(p => string.Equals(p.Name, propertyName, StringComparison.OrdinalIgnoreCase));
@@ -429,6 +600,12 @@ namespace Deveel.Messaging
             return this;
         }
 
+        /// <summary>
+        /// Updates an endpoint configuration in the schema by type using the provided action.
+        /// </summary>
+        /// <param name="endpointType">The endpoint type to update.</param>
+        /// <param name="updateAction">The action to apply to the endpoint configuration.</param>
+        /// <returns>This builder for chaining.</returns>
         public ChannelSchemaBuilder UpdateEndpoint(EndpointType endpointType, Action<ChannelEndpointConfiguration> updateAction)
         {
             var endpoint = _endpoints.FirstOrDefault(e => e.Type == endpointType);

--- a/src/Deveel.Messaging.Connectors/Messaging/ClientCredentialsAuthenticationProvider.cs
+++ b/src/Deveel.Messaging.Connectors/Messaging/ClientCredentialsAuthenticationProvider.cs
@@ -11,11 +11,24 @@ using System.Text.Json;
 
 namespace Deveel.Messaging
 {
+    /// <summary>
+    /// Implements the OAuth 2.0 Client Credentials authentication flow,
+    /// obtaining access tokens from a token endpoint using client credentials.
+    /// </summary>
     public class ClientCredentialsAuthenticationProvider : AuthenticationProviderBase
     {
         private readonly HttpClient _httpClient;
         private readonly ILogger<ClientCredentialsAuthenticationProvider> _logger;
 
+        /// <summary>
+        /// Constructs the provider with an optional HTTP client and logger.
+        /// </summary>
+        /// <param name="httpClient">
+        /// An optional HTTP client used to communicate with the token endpoint.
+        /// </param>
+        /// <param name="logger">
+        /// An optional logger instance for diagnostic information.
+        /// </param>
         public ClientCredentialsAuthenticationProvider(HttpClient? httpClient = null, ILogger<ClientCredentialsAuthenticationProvider>? logger = null)
             : base(AuthenticationScheme.OAuthClientCredentials, "OAuth 2.0 Client Credentials")
         {
@@ -23,6 +36,15 @@ namespace Deveel.Messaging
             _logger = logger ?? NullLogger<ClientCredentialsAuthenticationProvider>.Instance;
         }
 
+        /// <summary>
+        /// Obtains an OAuth 2.0 access token using the client credentials grant type.
+        /// </summary>
+        /// <param name="connectionSettings">The connection settings containing client credentials and token endpoint.</param>
+        /// <param name="configuration">The authentication configuration describing the expected fields.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that the operation should be canceled.
+        /// </param>
+        /// <returns>An <see cref="AuthenticationResult"/> containing the obtained credential.</returns>
         public override async Task<AuthenticationResult> ObtainCredentialAsync(ConnectionSettings connectionSettings, AuthenticationConfiguration configuration, CancellationToken cancellationToken = default)
         {
             try
@@ -141,6 +163,16 @@ namespace Deveel.Messaging
             }
         }
 
+        /// <summary>
+        /// Refreshes an existing OAuth 2.0 access token, using a refresh token if available.
+        /// </summary>
+        /// <param name="existingCredential">The existing credential to refresh.</param>
+        /// <param name="connectionSettings">The connection settings containing client credentials and token endpoint.</param>
+        /// <param name="configuration">The authentication configuration describing the expected fields.</param>
+        /// <param name="cancellationToken">
+        /// A cancellation token used to propagate notification that the operation should be canceled.
+        /// </param>
+        /// <returns>An <see cref="AuthenticationResult"/> containing the refreshed credential.</returns>
         public override async Task<AuthenticationResult> RefreshCredentialAsync(AuthenticationCredential existingCredential, ConnectionSettings connectionSettings, AuthenticationConfiguration configuration, CancellationToken cancellationToken = default)
         {
             try
@@ -241,6 +273,9 @@ namespace Deveel.Messaging
             return Success(credential);
         }
 
+        /// <summary>
+        /// Disposes the HTTP client used by this provider.
+        /// </summary>
         public void Dispose()
         {
             _httpClient?.Dispose();

--- a/src/Deveel.Messaging/Deveel.Messaging.csproj
+++ b/src/Deveel.Messaging/Deveel.Messaging.csproj
@@ -9,10 +9,6 @@
     <ProjectReference Include="..\Deveel.Messaging.Connector.Abstractions\Deveel.Messaging.Connector.Abstractions.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <InternalsVisibleTo Include="Deveel.Messaging.XUnit" />
-  </ItemGroup>
-
   <ItemGroup Condition="$(TargetFramework) == 'net8.0'">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />

--- a/test/Deeveel.Messaging.Connectors.XUnit/Unit/AuthenticationManagerEdgeTests.cs
+++ b/test/Deeveel.Messaging.Connectors.XUnit/Unit/AuthenticationManagerEdgeTests.cs
@@ -1,0 +1,88 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Deveel.Messaging;
+
+[Trait("Category", "Unit")]
+[Trait("Feature", "Authentication")]
+public class AuthenticationManagerEdgeTests
+{
+    private class ThrowingProvider : AuthenticationProviderBase
+    {
+        public ThrowingProvider() : base(AuthenticationScheme.ApiKey, "Throwing") { }
+
+        public override Task<AuthenticationResult> ObtainCredentialAsync(
+            ConnectionSettings connectionSettings,
+            AuthenticationConfiguration configuration,
+            CancellationToken cancellationToken = default)
+        {
+            throw new InvalidOperationException("Unexpected error");
+        }
+    }
+
+    [Fact]
+    public async Task Should_ReturnFailure_When_NoProviderMatchesScheme()
+    {
+        var manager = new AuthenticationManager();
+        var config = new AuthenticationConfiguration(AuthenticationScheme.Certificate, "Certificate");
+
+        var result = await manager.AuthenticateAsync(
+            new ConnectionSettings(),
+            config,
+            TestContext.Current.CancellationToken);
+
+        Assert.False(result.IsSuccessful);
+        Assert.Equal("NO_PROVIDER", result.ErrorCode);
+    }
+
+    [Fact]
+    public async Task Should_HandleException_When_ProviderThrows()
+    {
+        var manager = new AuthenticationManager(new[] { new ThrowingProvider() });
+        var settings = new ConnectionSettings().SetParameter("ApiKey", "key-1");
+        var config = new AuthenticationConfiguration(AuthenticationScheme.ApiKey, "API Key Authentication")
+            .WithField("ApiKey", DataType.String, f => { f.AuthenticationRole = "principal"; f.IsSensitive = true; });
+
+        var result = await manager.AuthenticateAsync(settings, config, TestContext.Current.CancellationToken);
+
+        Assert.False(result.IsSuccessful);
+        Assert.Equal("AUTHENTICATION_ERROR", result.ErrorCode);
+        Assert.Contains("Unexpected error", result.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task Should_ThrowArgumentNullException_When_ConnectionSettingsNull()
+    {
+        var manager = new AuthenticationManager();
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            manager.AuthenticateAsync(null!, new AuthenticationConfiguration(AuthenticationScheme.ApiKey, "Test"), TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task Should_ThrowArgumentNullException_When_ConfigurationNull()
+    {
+        var manager = new AuthenticationManager();
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            manager.AuthenticateAsync(new ConnectionSettings(), null!, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public void Should_ThrowArgumentNullException_When_InvalidateWithNullConnectionSettings()
+    {
+        var manager = new AuthenticationManager();
+
+        Assert.Throws<ArgumentNullException>(() =>
+            manager.InvalidateCredential(null!, new AuthenticationConfiguration(AuthenticationScheme.ApiKey, "Test")));
+    }
+
+    [Fact]
+    public void Should_ThrowArgumentNullException_When_InvalidateWithNullConfiguration()
+    {
+        var manager = new AuthenticationManager();
+
+        Assert.Throws<ArgumentNullException>(() =>
+            manager.InvalidateCredential(new ConnectionSettings(), null!));
+    }
+}

--- a/test/Deeveel.Messaging.Connectors.XUnit/Unit/AuthenticationMechanismTests.cs
+++ b/test/Deeveel.Messaging.Connectors.XUnit/Unit/AuthenticationMechanismTests.cs
@@ -403,6 +403,106 @@ namespace Deveel.Messaging
             Assert.Equal(ConnectorState.Ready, connector.State);
             Assert.Null(connector.TestAuthenticationCredential);
         }
+
+        [Fact]
+        public void Should_SetPropertiesCorrectly_When_AuthenticationCredentialCreateClientCredentials()
+        {
+            var token = "client-cred-token";
+            var expiresAt = DateTime.UtcNow.AddHours(2);
+
+            var credential = AuthenticationCredential.ForClientCredentials(token, expiresAt, "Bearer", "refresh-token-xyz");
+
+            Assert.Equal(AuthenticationScheme.Bearer, credential.Scheme);
+            Assert.Equal(token, credential.Value);
+            Assert.Equal(expiresAt, credential.ExpiresAt);
+            Assert.Equal("Bearer", credential.Properties["TokenType"]);
+            Assert.Equal("client_credentials", credential.Properties["GrantType"]);
+            Assert.Equal("refresh-token-xyz", credential.Properties["RefreshToken"]);
+        }
+
+        [Fact]
+        public void Should_SetPropertiesCorrectly_When_AuthenticationCredentialCreateClientCredentialsWithoutRefresh()
+        {
+            var token = "client-cred-token";
+
+            var credential = AuthenticationCredential.ForClientCredentials(token, null, "Bearer");
+
+            Assert.Equal(AuthenticationScheme.Bearer, credential.Scheme);
+            Assert.Equal(token, credential.Value);
+            Assert.Equal("Bearer", credential.Properties["TokenType"]);
+            Assert.Equal("client_credentials", credential.Properties["GrantType"]);
+            Assert.False(credential.Properties.ContainsKey("RefreshToken"));
+        }
+
+        [Fact]
+        public void Should_Throw_When_AuthenticationCredentialCreateClientCredentialsNullToken()
+        {
+            Assert.Throws<ArgumentNullException>(() => AuthenticationCredential.ForClientCredentials(null!));
+        }
+
+        [Fact]
+        public void Should_SetPropertiesCorrectly_When_AuthenticationCredentialCreateCertificate()
+        {
+            var certData = "cert-data-123";
+
+            var credential = AuthenticationCredential.ForCertificate(certData);
+
+            Assert.Equal(AuthenticationScheme.Certificate, credential.Scheme);
+            Assert.Equal(certData, credential.Value);
+            Assert.Equal("Certificate", credential.Properties["CredentialType"]);
+            Assert.False(credential.Properties.ContainsKey("CertificatePassword"));
+        }
+
+        [Fact]
+        public void Should_SetPropertiesCorrectly_When_AuthenticationCredentialCreateCertificateWithPassword()
+        {
+            var certData = "cert-data-123";
+
+            var credential = AuthenticationCredential.ForCertificate(certData, "p@ssw0rd");
+
+            Assert.Equal(AuthenticationScheme.Certificate, credential.Scheme);
+            Assert.Equal(certData, credential.Value);
+            Assert.Equal("Certificate", credential.Properties["CredentialType"]);
+            Assert.Equal("p@ssw0rd", credential.Properties["CertificatePassword"]);
+        }
+
+        [Fact]
+        public void Should_ReturnNull_When_AuthenticationCredentialGetTimeUntilExpirationNoExpiry()
+        {
+            var credential = AuthenticationCredential.ForApiKey("test-key");
+
+            var result = credential.GetTimeUntilExpiration();
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void Should_ReturnPositive_When_AuthenticationCredentialGetTimeUntilExpirationFuture()
+        {
+            var credential = AuthenticationCredential.ForBearerToken("token", DateTime.UtcNow.AddHours(1));
+
+            var result = credential.GetTimeUntilExpiration();
+
+            Assert.NotNull(result);
+            Assert.True(result > TimeSpan.Zero);
+        }
+
+        [Fact]
+        public void Should_ReturnZero_When_AuthenticationCredentialGetTimeUntilExpirationPast()
+        {
+            var credential = AuthenticationCredential.ForBearerToken("token", DateTime.UtcNow.AddMinutes(-5));
+
+            var result = credential.GetTimeUntilExpiration();
+
+            Assert.NotNull(result);
+            Assert.Equal(TimeSpan.Zero, result);
+        }
+
+        [Fact]
+        public void Should_Throw_When_AuthenticationCredentialCreateCertificateNullData()
+        {
+            Assert.Throws<ArgumentNullException>(() => AuthenticationCredential.ForCertificate(null!));
+        }
     }
 
     /// <summary>

--- a/test/Deveel.Messaging.Connector.Facebook.XUnit/Unit/FacebookInteractiveMappingTests.cs
+++ b/test/Deveel.Messaging.Connector.Facebook.XUnit/Unit/FacebookInteractiveMappingTests.cs
@@ -1,8 +1,3 @@
-//
-// Copyright (c) Antonello Provenzano and contributors. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for details.
-//
-
 using Deveel.Messaging.Testing;
 
 namespace Deveel.Messaging;
@@ -23,13 +18,22 @@ public class FacebookInteractiveMappingTests
         };
     }
 
+    private static FacebookMessage BuildFacebookMessage(Message message)
+    {
+        var type = typeof(FacebookService).Assembly.GetTypes()
+            .First(t => t.Name == "FacebookMessageBuilder");
+        var method = type.GetMethod("BuildFacebookMessage",
+            System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
+        return (FacebookMessage)method!.Invoke(null, new object?[] { message, null })!;
+    }
+
     [Fact]
     public void Should_MapButtonContent_When_BuildFacebookMessage()
     {
         var content = InteractiveContentBuilder.CreateButton();
         var message = CreateMessage(content);
 
-        var fbMessage = FacebookMessageBuilder.BuildFacebookMessage(message);
+        var fbMessage = BuildFacebookMessage(message);
 
         FacebookInteractiveMappingAssertions.AssertMapsToButton(content, fbMessage);
     }
@@ -40,7 +44,7 @@ public class FacebookInteractiveMappingTests
         var content = InteractiveContentBuilder.CreateQuickReply();
         var message = CreateMessage(content);
 
-        var fbMessage = FacebookMessageBuilder.BuildFacebookMessage(message);
+        var fbMessage = BuildFacebookMessage(message);
 
         Assert.NotNull(fbMessage.QuickReplies);
         var qr = Assert.Single(fbMessage.QuickReplies);
@@ -53,7 +57,7 @@ public class FacebookInteractiveMappingTests
         var content = InteractiveContentBuilder.CreateCarousel(3);
         var message = CreateMessage(content);
 
-        var fbMessage = FacebookMessageBuilder.BuildFacebookMessage(message);
+        var fbMessage = BuildFacebookMessage(message);
 
         FacebookInteractiveMappingAssertions.AssertMapsToCarousel(content, fbMessage);
     }
@@ -64,7 +68,7 @@ public class FacebookInteractiveMappingTests
         var content = InteractiveContentBuilder.CreateListPicker(3);
         var message = CreateMessage(content);
 
-        var fbMessage = FacebookMessageBuilder.BuildFacebookMessage(message);
+        var fbMessage = BuildFacebookMessage(message);
 
         FacebookInteractiveMappingAssertions.AssertMapsToListPicker(content, fbMessage);
     }

--- a/test/Deveel.Messaging.Connector.Facebook.XUnit/Unit/FacebookMessageBuilderExtensionsTests.cs
+++ b/test/Deveel.Messaging.Connector.Facebook.XUnit/Unit/FacebookMessageBuilderExtensionsTests.cs
@@ -1,0 +1,39 @@
+namespace Deveel.Messaging
+{
+    [Trait("Category", "Unit")]
+    [Trait("Feature", "FacebookMessageBuilder")]
+    public class FacebookMessageBuilderExtensionsTests
+    {
+        [Fact]
+        public void Should_SetMessagingType_When_WithMessagingType()
+        {
+            var builder = new MessageBuilder();
+            var result = builder.WithMessagingType("RESPONSE");
+            Assert.Same(builder, result);
+        }
+
+        [Fact]
+        public void Should_SetNotificationType_When_WithNotificationType()
+        {
+            var builder = new MessageBuilder();
+            var result = builder.WithNotificationType("REGULAR");
+            Assert.Same(builder, result);
+        }
+
+        [Fact]
+        public void Should_SetTag_When_WithTag()
+        {
+            var builder = new MessageBuilder();
+            var result = builder.WithTag("CONFIRMED_EVENT_UPDATE");
+            Assert.Same(builder, result);
+        }
+
+        [Fact]
+        public void Should_SetQuickReplies_When_WithQuickReplies()
+        {
+            var builder = new MessageBuilder();
+            var result = builder.WithQuickReplies("[{\"title\":\"Yes\"}]");
+            Assert.Same(builder, result);
+        }
+    }
+}

--- a/test/Deveel.Messaging.Connector.Facebook.XUnit/Unit/FacebookServiceTests.cs
+++ b/test/Deveel.Messaging.Connector.Facebook.XUnit/Unit/FacebookServiceTests.cs
@@ -329,8 +329,9 @@ public class FacebookServiceTests
         var dict = AsDict(content);
 
         Assert.Contains("attachment", dict.Keys);
-        var attachment = (dynamic)dict["attachment"]!;
-        Assert.Equal("image", attachment.type);
+        var attachment = dict["attachment"]!;
+        var attachmentType = attachment.GetType().GetProperty("type")!.GetValue(attachment);
+        Assert.Equal("image", attachmentType);
     }
 
     [Fact]
@@ -350,8 +351,9 @@ public class FacebookServiceTests
         var dict = AsDict(content);
 
         Assert.Contains("attachment", dict.Keys);
-        var attachment = (dynamic)dict["attachment"]!;
-        Assert.Equal("template", attachment.type);
+        var attachment = dict["attachment"]!;
+        var attachmentType = attachment.GetType().GetProperty("type")!.GetValue(attachment);
+        Assert.Equal("template", attachmentType);
     }
 
     [Fact]
@@ -376,10 +378,11 @@ public class FacebookServiceTests
 
         var content = BuildMessageContent(message);
         var dict = AsDict(content);
-        var attachment = (dynamic)dict["attachment"]!;
+        var attachment = dict["attachment"]!;
 
         // Should be the media attachment, not the template
-        Assert.Equal("image", attachment.type);
+        var attachmentType = attachment.GetType().GetProperty("type")!.GetValue(attachment);
+        Assert.Equal("image", attachmentType);
     }
 
     [Fact]
@@ -441,8 +444,11 @@ public class FacebookServiceTests
 
     #region BuildFacebookMessagePayload Tests
 
-    private static object BuildFacebookMessagePayload(FacebookMessageRequest request) =>
-        FacebookService.BuildFacebookMessagePayload(request);
+    private static object BuildFacebookMessagePayload(FacebookMessageRequest request) {
+        var method = typeof(FacebookService).GetMethod("BuildFacebookMessagePayload",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        return method!.Invoke(null, new object[] { request })!;
+    }
 
     [Fact]
     public void Should_IncludeNotificationType_When_NotRegular()

--- a/test/Deveel.Messaging.Connector.Facebook.XUnit/Unit/FacebookServiceTests.cs
+++ b/test/Deveel.Messaging.Connector.Facebook.XUnit/Unit/FacebookServiceTests.cs
@@ -513,29 +513,12 @@ public class FacebookServiceTests
 
     #region SendMessageAsync API Interaction Tests
 
-    private static (Mock<HttpMessageHandler> Handler, HttpClient Client) CreateMockHttpClient()
-    {
-        var handlerMock = new Mock<HttpMessageHandler>();
-        var httpClient = new HttpClient(handlerMock.Object)
-        {
-            BaseAddress = new Uri(FacebookConnectorConstants.GraphApiBaseUrl)
-        };
-        return (handlerMock, httpClient);
-    }
-
     [Fact]
     public async Task Should_SendMessageSuccessfully_When_ValidTextOnly()
     {
         var (handlerMock, httpClient) = CreateMockHttpClient();
-        handlerMock.Protected()
-            .Setup<Task<HttpResponseMessage>>("SendAsync",
-                ItExpr.IsAny<HttpRequestMessage>(),
-                ItExpr.IsAny<CancellationToken>())
-            .ReturnsAsync(new HttpResponseMessage
-            {
-                StatusCode = HttpStatusCode.OK,
-                Content = new StringContent("""{"message_id":"m_mid.123456"}""")
-            });
+        var capture = new RequestCapture();
+        SetupSendAsync(handlerMock, capture, HttpStatusCode.OK, """{"message_id":"m_mid.123456"}""");
 
         var service = new FacebookService(httpClient);
         service.Initialize("EAATest123456789|ValidPageAccessToken");
@@ -551,21 +534,29 @@ public class FacebookServiceTests
         Assert.NotNull(response);
         Assert.Equal("m_mid.123456", response.MessageId);
         Assert.Equal("user-123", response.RecipientId);
+
+        Assert.NotNull(capture.Request);
+        Assert.Equal(HttpMethod.Post, capture.Request.Method);
+        Assert.Equal("/v21.0/me/messages", capture.Request.RequestUri!.AbsolutePath);
+        Assert.Equal("EAATest123456789|ValidPageAccessToken", Uri.UnescapeDataString(capture.Request.RequestUri.Query.TrimStart('?')
+            .Split('&').First(q => q.StartsWith("access_token=")).Split('=')[1]));
+
+        var body = capture.Body;
+        var json = JsonSerializer.Deserialize<JsonElement>(body);
+
+        Assert.Equal("user-123", json.GetProperty("recipient").GetProperty("id").GetString());
+        Assert.Equal("RESPONSE", json.GetProperty("messaging_type").GetString());
+        Assert.Equal("Hello!", json.GetProperty("message").GetProperty("text").GetString());
+        Assert.False(json.TryGetProperty("notification_type", out _));
+        Assert.False(json.TryGetProperty("tag", out _));
     }
 
     [Fact]
     public async Task Should_SendMessageSuccessfully_When_WithAttachment()
     {
         var (handlerMock, httpClient) = CreateMockHttpClient();
-        handlerMock.Protected()
-            .Setup<Task<HttpResponseMessage>>("SendAsync",
-                ItExpr.IsAny<HttpRequestMessage>(),
-                ItExpr.IsAny<CancellationToken>())
-            .ReturnsAsync(new HttpResponseMessage
-            {
-                StatusCode = HttpStatusCode.OK,
-                Content = new StringContent("""{"message_id":"m_mid.789"}""")
-            });
+        var capture = new RequestCapture();
+        SetupSendAsync(handlerMock, capture, HttpStatusCode.OK, """{"message_id":"m_mid.789"}""");
 
         var service = new FacebookService(httpClient);
         service.Initialize("EAATest123456789|ValidPageAccessToken");
@@ -592,21 +583,26 @@ public class FacebookServiceTests
 
         Assert.NotNull(response);
         Assert.Equal("m_mid.789", response.MessageId);
+
+        Assert.NotNull(capture.Request);
+        Assert.Equal(HttpMethod.Post, capture.Request.Method);
+        Assert.Equal("/v21.0/me/messages", capture.Request.RequestUri!.AbsolutePath);
+
+        var body = capture.Body;
+        var json = JsonSerializer.Deserialize<JsonElement>(body);
+
+        Assert.Equal("user-456", json.GetProperty("recipient").GetProperty("id").GetString());
+        Assert.Equal("Check this!", json.GetProperty("message").GetProperty("text").GetString());
+        Assert.Equal("image", json.GetProperty("message").GetProperty("attachment").GetProperty("type").GetString());
+        Assert.Equal("https://example.com/img.png", json.GetProperty("message").GetProperty("attachment").GetProperty("payload").GetProperty("url").GetString());
     }
 
     [Fact]
     public async Task Should_SendMessageSuccessfully_When_WithTemplate()
     {
         var (handlerMock, httpClient) = CreateMockHttpClient();
-        handlerMock.Protected()
-            .Setup<Task<HttpResponseMessage>>("SendAsync",
-                ItExpr.IsAny<HttpRequestMessage>(),
-                ItExpr.IsAny<CancellationToken>())
-            .ReturnsAsync(new HttpResponseMessage
-            {
-                StatusCode = HttpStatusCode.OK,
-                Content = new StringContent("""{"message_id":"m_mid.tpl"}""")
-            });
+        var capture = new RequestCapture();
+        SetupSendAsync(handlerMock, capture, HttpStatusCode.OK, """{"message_id":"m_mid.tpl"}""");
 
         var service = new FacebookService(httpClient);
         service.Initialize("EAATest123456789|ValidPageAccessToken");
@@ -641,21 +637,25 @@ public class FacebookServiceTests
 
         Assert.NotNull(response);
         Assert.Equal("m_mid.tpl", response.MessageId);
+
+        Assert.NotNull(capture.Request);
+        Assert.Equal(HttpMethod.Post, capture.Request.Method);
+        Assert.Equal("/v21.0/me/messages", capture.Request.RequestUri!.AbsolutePath);
+
+        var body = capture.Body;
+        var json = JsonSerializer.Deserialize<JsonElement>(body);
+
+        Assert.Equal("user-789", json.GetProperty("recipient").GetProperty("id").GetString());
+        Assert.Equal("template", json.GetProperty("message").GetProperty("attachment").GetProperty("type").GetString());
+        Assert.Equal("button", json.GetProperty("message").GetProperty("attachment").GetProperty("payload").GetProperty("template_type").GetString());
     }
 
     [Fact]
     public async Task Should_SendMessageSuccessfully_When_WithQuickReplies()
     {
         var (handlerMock, httpClient) = CreateMockHttpClient();
-        handlerMock.Protected()
-            .Setup<Task<HttpResponseMessage>>("SendAsync",
-                ItExpr.IsAny<HttpRequestMessage>(),
-                ItExpr.IsAny<CancellationToken>())
-            .ReturnsAsync(new HttpResponseMessage
-            {
-                StatusCode = HttpStatusCode.OK,
-                Content = new StringContent("""{"message_id":"m_mid.qr"}""")
-            });
+        var capture = new RequestCapture();
+        SetupSendAsync(handlerMock, capture, HttpStatusCode.OK, """{"message_id":"m_mid.qr"}""");
 
         var service = new FacebookService(httpClient);
         service.Initialize("EAATest123456789|ValidPageAccessToken");
@@ -678,21 +678,29 @@ public class FacebookServiceTests
 
         Assert.NotNull(response);
         Assert.Equal("m_mid.qr", response.MessageId);
+
+        Assert.NotNull(capture.Request);
+        Assert.Equal(HttpMethod.Post, capture.Request.Method);
+        Assert.Equal("/v21.0/me/messages", capture.Request.RequestUri!.AbsolutePath);
+
+        var body = capture.Body;
+        var json = JsonSerializer.Deserialize<JsonElement>(body);
+
+        Assert.Equal("user-999", json.GetProperty("recipient").GetProperty("id").GetString());
+        Assert.Equal("Choose:", json.GetProperty("message").GetProperty("text").GetString());
+
+        var quickReplies = json.GetProperty("message").GetProperty("quick_replies");
+        Assert.Equal(2, quickReplies.GetArrayLength());
+        Assert.Equal("Yes", quickReplies[0].GetProperty("title").GetString());
+        Assert.Equal("No", quickReplies[1].GetProperty("title").GetString());
     }
 
     [Fact]
     public async Task Should_SendMessageSuccessfully_When_WithNotificationTypeSilent()
     {
         var (handlerMock, httpClient) = CreateMockHttpClient();
-        handlerMock.Protected()
-            .Setup<Task<HttpResponseMessage>>("SendAsync",
-                ItExpr.IsAny<HttpRequestMessage>(),
-                ItExpr.IsAny<CancellationToken>())
-            .ReturnsAsync(new HttpResponseMessage
-            {
-                StatusCode = HttpStatusCode.OK,
-                Content = new StringContent("""{"message_id":"m_mid.silent"}""")
-            });
+        var capture = new RequestCapture();
+        SetupSendAsync(handlerMock, capture, HttpStatusCode.OK, """{"message_id":"m_mid.silent"}""");
 
         var service = new FacebookService(httpClient);
         service.Initialize("EAATest123456789|ValidPageAccessToken");
@@ -708,21 +716,23 @@ public class FacebookServiceTests
 
         Assert.NotNull(response);
         Assert.Equal("m_mid.silent", response.MessageId);
+
+        Assert.NotNull(capture.Request);
+        Assert.Equal(HttpMethod.Post, capture.Request.Method);
+        Assert.Equal("/v21.0/me/messages", capture.Request.RequestUri!.AbsolutePath);
+
+        var body = capture.Body;
+        var json = JsonSerializer.Deserialize<JsonElement>(body);
+
+        Assert.Equal("SILENT_PUSH", json.GetProperty("notification_type").GetString());
     }
 
     [Fact]
     public async Task Should_SendMessageSuccessfully_When_WithTag()
     {
         var (handlerMock, httpClient) = CreateMockHttpClient();
-        handlerMock.Protected()
-            .Setup<Task<HttpResponseMessage>>("SendAsync",
-                ItExpr.IsAny<HttpRequestMessage>(),
-                ItExpr.IsAny<CancellationToken>())
-            .ReturnsAsync(new HttpResponseMessage
-            {
-                StatusCode = HttpStatusCode.OK,
-                Content = new StringContent("""{"message_id":"m_mid.tag"}""")
-            });
+        var capture = new RequestCapture();
+        SetupSendAsync(handlerMock, capture, HttpStatusCode.OK, """{"message_id":"m_mid.tag"}""");
 
         var service = new FacebookService(httpClient);
         service.Initialize("EAATest123456789|ValidPageAccessToken");
@@ -738,29 +748,31 @@ public class FacebookServiceTests
 
         Assert.NotNull(response);
         Assert.Equal("m_mid.tag", response.MessageId);
+
+        Assert.NotNull(capture.Request);
+        Assert.Equal(HttpMethod.Post, capture.Request.Method);
+        Assert.Equal("/v21.0/me/messages", capture.Request.RequestUri!.AbsolutePath);
+
+        var body = capture.Body;
+        var json = JsonSerializer.Deserialize<JsonElement>(body);
+
+        Assert.Equal("CONFIRMED_EVENT_UPDATE", json.GetProperty("tag").GetString());
     }
 
     [Fact]
     public async Task Should_ThrowConnectorException_When_ApiReturnsError()
     {
         var (handlerMock, httpClient) = CreateMockHttpClient();
-        handlerMock.Protected()
-            .Setup<Task<HttpResponseMessage>>("SendAsync",
-                ItExpr.IsAny<HttpRequestMessage>(),
-                ItExpr.IsAny<CancellationToken>())
-            .ReturnsAsync(new HttpResponseMessage
+        var capture = new RequestCapture();
+        SetupSendAsync(handlerMock, capture, HttpStatusCode.BadRequest, """
             {
-                StatusCode = HttpStatusCode.BadRequest,
-                Content = new StringContent("""
-                    {
-                        "error": {
-                            "message": "(#100) Invalid parameter",
-                            "code": 100,
-                            "error_subcode": 1234
-                        }
-                    }
-                    """)
-            });
+                "error": {
+                    "message": "(#100) Invalid parameter",
+                    "code": 100,
+                    "error_subcode": 1234
+                }
+            }
+            """);
 
         var service = new FacebookService(httpClient);
         service.Initialize("EAATest123456789|ValidPageAccessToken");
@@ -776,29 +788,28 @@ public class FacebookServiceTests
 
         Assert.Equal(FacebookErrorCodes.GraphApiError, ex.ErrorCode);
         Assert.Equal(FacebookErrorCodes.ErrorDomain, ex.ErrorDomain);
+
+        Assert.NotNull(capture.Request);
+        Assert.Equal(HttpMethod.Post, capture.Request.Method);
+        Assert.Equal("/v21.0/me/messages", capture.Request.RequestUri!.AbsolutePath);
+        Assert.Equal("EAATest123456789|ValidPageAccessToken", Uri.UnescapeDataString(capture.Request.RequestUri.Query.TrimStart('?')
+            .Split('&').First(q => q.StartsWith("access_token=")).Split('=')[1]));
     }
 
     [Fact]
     public async Task Should_ThrowConnectorExceptionWithInvalidAccessToken_When_ApiReturnsTokenError()
     {
         var (handlerMock, httpClient) = CreateMockHttpClient();
-        handlerMock.Protected()
-            .Setup<Task<HttpResponseMessage>>("SendAsync",
-                ItExpr.IsAny<HttpRequestMessage>(),
-                ItExpr.IsAny<CancellationToken>())
-            .ReturnsAsync(new HttpResponseMessage
+        var capture = new RequestCapture();
+        SetupSendAsync(handlerMock, capture, HttpStatusCode.Unauthorized, """
             {
-                StatusCode = HttpStatusCode.Unauthorized,
-                Content = new StringContent("""
-                    {
-                        "error": {
-                            "message": "Error validating access token",
-                            "code": 190,
-                            "error_subcode": 467
-                        }
-                    }
-                    """)
-            });
+                "error": {
+                    "message": "Error validating access token",
+                    "code": 190,
+                    "error_subcode": 467
+                }
+            }
+            """);
 
         var service = new FacebookService(httpClient);
         service.Initialize("EAATest123456789|ValidPageAccessToken");
@@ -813,21 +824,18 @@ public class FacebookServiceTests
             service.SendMessageAsync(request, TestContext.Current.CancellationToken));
 
         Assert.Equal(FacebookErrorCodes.InvalidAccessToken, ex.ErrorCode);
+
+        Assert.NotNull(capture.Request);
+        Assert.Equal(HttpMethod.Post, capture.Request.Method);
+        Assert.Equal("/v21.0/me/messages", capture.Request.RequestUri!.AbsolutePath);
     }
 
     [Fact]
     public async Task Should_ThrowConnectorException_When_ApiReturnsEmptyResponse()
     {
         var (handlerMock, httpClient) = CreateMockHttpClient();
-        handlerMock.Protected()
-            .Setup<Task<HttpResponseMessage>>("SendAsync",
-                ItExpr.IsAny<HttpRequestMessage>(),
-                ItExpr.IsAny<CancellationToken>())
-            .ReturnsAsync(new HttpResponseMessage
-            {
-                StatusCode = HttpStatusCode.OK,
-                Content = new StringContent("")
-            });
+        var capture = new RequestCapture();
+        SetupSendAsync(handlerMock, capture, HttpStatusCode.OK, "");
 
         var service = new FacebookService(httpClient);
         service.Initialize("EAATest123456789|ValidPageAccessToken");
@@ -842,21 +850,18 @@ public class FacebookServiceTests
             service.SendMessageAsync(request, TestContext.Current.CancellationToken));
 
         Assert.Equal(FacebookErrorCodes.GraphApiError, ex.ErrorCode);
+
+        Assert.NotNull(capture.Request);
+        Assert.Equal(HttpMethod.Post, capture.Request.Method);
+        Assert.Equal("/v21.0/me/messages", capture.Request.RequestUri!.AbsolutePath);
     }
 
     [Fact]
     public async Task Should_ThrowConnectorException_When_ApiReturnsMalformedJson()
     {
         var (handlerMock, httpClient) = CreateMockHttpClient();
-        handlerMock.Protected()
-            .Setup<Task<HttpResponseMessage>>("SendAsync",
-                ItExpr.IsAny<HttpRequestMessage>(),
-                ItExpr.IsAny<CancellationToken>())
-            .ReturnsAsync(new HttpResponseMessage
-            {
-                StatusCode = HttpStatusCode.OK,
-                Content = new StringContent("this is not json")
-            });
+        var capture = new RequestCapture();
+        SetupSendAsync(handlerMock, capture, HttpStatusCode.OK, "this is not json");
 
         var service = new FacebookService(httpClient);
         service.Initialize("EAATest123456789|ValidPageAccessToken");
@@ -874,6 +879,48 @@ public class FacebookServiceTests
         Assert.Equal(FacebookErrorCodes.ErrorDomain, ex.ErrorDomain);
         Assert.NotNull(ex.InnerException);
         Assert.IsType<JsonException>(ex.InnerException);
+
+        Assert.NotNull(capture.Request);
+        Assert.Equal(HttpMethod.Post, capture.Request.Method);
+        Assert.Equal("/v21.0/me/messages", capture.Request.RequestUri!.AbsolutePath);
+
+        var body = capture.Body;
+        var json = JsonSerializer.Deserialize<JsonElement>(body);
+        Assert.Equal("Hello!", json.GetProperty("message").GetProperty("text").GetString());
+    }
+
+    private static (Mock<HttpMessageHandler> Handler, HttpClient Client) CreateMockHttpClient()
+    {
+        var handlerMock = new Mock<HttpMessageHandler>();
+        var httpClient = new HttpClient(handlerMock.Object)
+        {
+            BaseAddress = new Uri(FacebookConnectorConstants.GraphApiBaseUrl)
+        };
+        return (handlerMock, httpClient);
+    }
+
+    private sealed class RequestCapture
+    {
+        public HttpRequestMessage? Request { get; set; }
+        public string? Body { get; set; }
+    }
+
+    private static void SetupSendAsync(Mock<HttpMessageHandler> handlerMock, RequestCapture capture, HttpStatusCode statusCode, string content)
+    {
+        handlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((req, _) =>
+            {
+                capture.Request = req;
+                capture.Body = req.Content?.ReadAsStringAsync().GetAwaiter().GetResult();
+            })
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = statusCode,
+                Content = new StringContent(content)
+            });
     }
 
     #endregion
@@ -884,21 +931,14 @@ public class FacebookServiceTests
     public async Task Should_FetchPageSuccessfully_When_ValidResponse()
     {
         var (handlerMock, httpClient) = CreateMockHttpClient();
-        handlerMock.Protected()
-            .Setup<Task<HttpResponseMessage>>("SendAsync",
-                ItExpr.IsAny<HttpRequestMessage>(),
-                ItExpr.IsAny<CancellationToken>())
-            .ReturnsAsync(new HttpResponseMessage
+        var capture = new RequestCapture();
+        SetupSendAsync(handlerMock, capture, HttpStatusCode.OK, """
             {
-                StatusCode = HttpStatusCode.OK,
-                Content = new StringContent("""
-                    {
-                        "id": "123456789",
-                        "name": "Test Page",
-                        "category": "Business"
-                    }
-                    """)
-            });
+                "id": "123456789",
+                "name": "Test Page",
+                "category": "Business"
+            }
+            """);
 
         var service = new FacebookService(httpClient);
         service.Initialize("EAATest123456789|ValidPageAccessToken");
@@ -909,26 +949,27 @@ public class FacebookServiceTests
         Assert.Equal("123456789", result.Id);
         Assert.Equal("Test Page", result.Name);
         Assert.Equal("Business", result.Category);
+
+        Assert.NotNull(capture.Request);
+        Assert.Equal(HttpMethod.Get, capture.Request.Method);
+        Assert.Equal("/v21.0/123456789", capture.Request.RequestUri!.AbsolutePath);
+
+        var query = capture.Request.RequestUri.Query;
+        Assert.Contains("fields=id%2Cname%2Ccategory%2Caccess_token", query);
+        Assert.Contains("access_token=EAATest123456789%7CValidPageAccessToken", query);
     }
 
     [Fact]
     public async Task Should_FallbackToPageId_When_ResponseMissingId()
     {
         var (handlerMock, httpClient) = CreateMockHttpClient();
-        handlerMock.Protected()
-            .Setup<Task<HttpResponseMessage>>("SendAsync",
-                ItExpr.IsAny<HttpRequestMessage>(),
-                ItExpr.IsAny<CancellationToken>())
-            .ReturnsAsync(new HttpResponseMessage
+        var capture = new RequestCapture();
+        SetupSendAsync(handlerMock, capture, HttpStatusCode.OK, """
             {
-                StatusCode = HttpStatusCode.OK,
-                Content = new StringContent("""
-                    {
-                        "name": "Unnamed Page",
-                        "category": "Business"
-                    }
-                    """)
-            });
+                "name": "Unnamed Page",
+                "category": "Business"
+            }
+            """);
 
         var service = new FacebookService(httpClient);
         service.Initialize("EAATest123456789|ValidPageAccessToken");
@@ -938,21 +979,18 @@ public class FacebookServiceTests
         Assert.NotNull(result);
         Assert.Equal("my-page-id", result.Id);
         Assert.Equal("Unnamed Page", result.Name);
+
+        Assert.NotNull(capture.Request);
+        Assert.Equal(HttpMethod.Get, capture.Request.Method);
+        Assert.Equal("/v21.0/my-page-id", capture.Request.RequestUri!.AbsolutePath);
     }
 
     [Fact]
     public async Task Should_ReturnNull_When_FetchPageApiReturnsEmptyContent()
     {
         var (handlerMock, httpClient) = CreateMockHttpClient();
-        handlerMock.Protected()
-            .Setup<Task<HttpResponseMessage>>("SendAsync",
-                ItExpr.IsAny<HttpRequestMessage>(),
-                ItExpr.IsAny<CancellationToken>())
-            .ReturnsAsync(new HttpResponseMessage
-            {
-                StatusCode = HttpStatusCode.OK,
-                Content = new StringContent("")
-            });
+        var capture = new RequestCapture();
+        SetupSendAsync(handlerMock, capture, HttpStatusCode.OK, "");
 
         var service = new FacebookService(httpClient);
         service.Initialize("EAATest123456789|ValidPageAccessToken");
@@ -960,29 +998,26 @@ public class FacebookServiceTests
         var result = await service.FetchPageAsync("123456789", TestContext.Current.CancellationToken);
 
         Assert.Null(result);
+
+        Assert.NotNull(capture.Request);
+        Assert.Equal(HttpMethod.Get, capture.Request.Method);
+        Assert.Equal("/v21.0/123456789", capture.Request.RequestUri!.AbsolutePath);
     }
 
     [Fact]
     public async Task Should_ThrowConnectorException_When_FetchPageApiReturnsError()
     {
         var (handlerMock, httpClient) = CreateMockHttpClient();
-        handlerMock.Protected()
-            .Setup<Task<HttpResponseMessage>>("SendAsync",
-                ItExpr.IsAny<HttpRequestMessage>(),
-                ItExpr.IsAny<CancellationToken>())
-            .ReturnsAsync(new HttpResponseMessage
+        var capture = new RequestCapture();
+        SetupSendAsync(handlerMock, capture, HttpStatusCode.BadRequest, """
             {
-                StatusCode = HttpStatusCode.BadRequest,
-                Content = new StringContent("""
-                    {
-                        "error": {
-                            "message": "(#100) Invalid parameter",
-                            "code": 100,
-                            "error_subcode": 1234
-                        }
-                    }
-                    """)
-            });
+                "error": {
+                    "message": "(#100) Invalid parameter",
+                    "code": 100,
+                    "error_subcode": 1234
+                }
+            }
+            """);
 
         var service = new FacebookService(httpClient);
         service.Initialize("EAATest123456789|ValidPageAccessToken");
@@ -992,29 +1027,26 @@ public class FacebookServiceTests
 
         Assert.Equal(FacebookErrorCodes.GraphApiError, ex.ErrorCode);
         Assert.Equal(FacebookErrorCodes.ErrorDomain, ex.ErrorDomain);
+
+        Assert.NotNull(capture.Request);
+        Assert.Equal(HttpMethod.Get, capture.Request.Method);
+        Assert.Equal("/v21.0/123456789", capture.Request.RequestUri!.AbsolutePath);
     }
 
     [Fact]
     public async Task Should_ThrowConnectorExceptionWithInvalidAccessToken_When_FetchPageApiReturnsTokenError()
     {
         var (handlerMock, httpClient) = CreateMockHttpClient();
-        handlerMock.Protected()
-            .Setup<Task<HttpResponseMessage>>("SendAsync",
-                ItExpr.IsAny<HttpRequestMessage>(),
-                ItExpr.IsAny<CancellationToken>())
-            .ReturnsAsync(new HttpResponseMessage
+        var capture = new RequestCapture();
+        SetupSendAsync(handlerMock, capture, HttpStatusCode.Unauthorized, """
             {
-                StatusCode = HttpStatusCode.Unauthorized,
-                Content = new StringContent("""
-                    {
-                        "error": {
-                            "message": "Error validating access token",
-                            "code": 190,
-                            "error_subcode": 467
-                        }
-                    }
-                    """)
-            });
+                "error": {
+                    "message": "Error validating access token",
+                    "code": 190,
+                    "error_subcode": 467
+                }
+            }
+            """);
 
         var service = new FacebookService(httpClient);
         service.Initialize("EAATest123456789|ValidPageAccessToken");
@@ -1023,21 +1055,18 @@ public class FacebookServiceTests
             service.FetchPageAsync("123456789", TestContext.Current.CancellationToken));
 
         Assert.Equal(FacebookErrorCodes.InvalidAccessToken, ex.ErrorCode);
+
+        Assert.NotNull(capture.Request);
+        Assert.Equal(HttpMethod.Get, capture.Request.Method);
+        Assert.Equal("/v21.0/123456789", capture.Request.RequestUri!.AbsolutePath);
     }
 
     [Fact]
     public async Task Should_ThrowConnectorException_When_FetchPageApiReturnsMalformedJson()
     {
         var (handlerMock, httpClient) = CreateMockHttpClient();
-        handlerMock.Protected()
-            .Setup<Task<HttpResponseMessage>>("SendAsync",
-                ItExpr.IsAny<HttpRequestMessage>(),
-                ItExpr.IsAny<CancellationToken>())
-            .ReturnsAsync(new HttpResponseMessage
-            {
-                StatusCode = HttpStatusCode.OK,
-                Content = new StringContent("not json at all")
-            });
+        var capture = new RequestCapture();
+        SetupSendAsync(handlerMock, capture, HttpStatusCode.OK, "not json at all");
 
         var service = new FacebookService(httpClient);
         service.Initialize("EAATest123456789|ValidPageAccessToken");
@@ -1049,6 +1078,10 @@ public class FacebookServiceTests
         Assert.Equal(FacebookErrorCodes.ErrorDomain, ex.ErrorDomain);
         Assert.NotNull(ex.InnerException);
         Assert.IsType<JsonException>(ex.InnerException);
+
+        Assert.NotNull(capture.Request);
+        Assert.Equal(HttpMethod.Get, capture.Request.Method);
+        Assert.Equal("/v21.0/123456789", capture.Request.RequestUri!.AbsolutePath);
     }
 
     #endregion

--- a/test/Deveel.Messaging.Connector.Firebase.XUnit/Unit/FirebaseMessageBuilderExtensionsTests.cs
+++ b/test/Deveel.Messaging.Connector.Firebase.XUnit/Unit/FirebaseMessageBuilderExtensionsTests.cs
@@ -1,0 +1,63 @@
+namespace Deveel.Messaging
+{
+    [Trait("Category", "Unit")]
+    [Trait("Feature", "FirebaseMessageBuilder")]
+    public class FirebaseMessageBuilderExtensionsTests
+    {
+        [Fact]
+        public void Should_SetTitle_When_WithTitle()
+        {
+            var builder = new MessageBuilder();
+            var result = builder.WithTitle("Test Title");
+            Assert.Same(builder, result);
+        }
+
+        [Fact]
+        public void Should_SetImageUrl_When_WithImageUrl()
+        {
+            var builder = new MessageBuilder();
+            var result = builder.WithImageUrl("https://example.com/image.png");
+            Assert.Same(builder, result);
+        }
+
+        [Fact]
+        public void Should_SetCustomData_When_WithCustomData()
+        {
+            var builder = new MessageBuilder();
+            var result = builder.WithCustomData("{\"key\":\"value\"}");
+            Assert.Same(builder, result);
+        }
+
+        [Fact]
+        public void Should_SetPriority_When_WithPriority()
+        {
+            var builder = new MessageBuilder();
+            var result = builder.WithPriority("high");
+            Assert.Same(builder, result);
+        }
+
+        [Fact]
+        public void Should_SetTimeToLive_When_WithTimeToLive()
+        {
+            var builder = new MessageBuilder();
+            var result = builder.WithTimeToLive(3600);
+            Assert.Same(builder, result);
+        }
+
+        [Fact]
+        public void Should_SetBadge_When_WithBadge()
+        {
+            var builder = new MessageBuilder();
+            var result = builder.WithBadge(1);
+            Assert.Same(builder, result);
+        }
+
+        [Fact]
+        public void Should_SetSound_When_WithSound()
+        {
+            var builder = new MessageBuilder();
+            var result = builder.WithSound("default");
+            Assert.Same(builder, result);
+        }
+    }
+}

--- a/test/Deveel.Messaging.Connector.Firebase.XUnit/Unit/FirebaseServiceAccountAuthenticationProviderTests.cs
+++ b/test/Deveel.Messaging.Connector.Firebase.XUnit/Unit/FirebaseServiceAccountAuthenticationProviderTests.cs
@@ -1,0 +1,171 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Deveel.Messaging
+{
+    [Trait("Category", "Unit")]
+    [Trait("Feature", "FirebaseServiceAccountAuthentication")]
+    public class FirebaseServiceAccountAuthenticationProviderTests
+    {
+        [Fact]
+        public void Should_HandleCertificateScheme_When_CanHandle()
+        {
+            var provider = new FirebaseServiceAccountAuthenticationProvider(NullLogger<FirebaseServiceAccountAuthenticationProvider>.Instance);
+            var config = new AuthenticationConfiguration(AuthenticationScheme.Certificate, "Cert");
+
+            var result = provider.CanHandle(config);
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void Should_HandleCustomScheme_When_FieldContainsServiceAccount()
+        {
+            var provider = new FirebaseServiceAccountAuthenticationProvider(NullLogger<FirebaseServiceAccountAuthenticationProvider>.Instance);
+            var config = new AuthenticationConfiguration(AuthenticationScheme.Custom, "Custom")
+                .WithField("ServiceAccountKey", DataType.String, f => f.AuthenticationRole = "principal");
+
+            var result = provider.CanHandle(config);
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void Should_NotHandleBearerScheme_When_CanHandle()
+        {
+            var provider = new FirebaseServiceAccountAuthenticationProvider(NullLogger<FirebaseServiceAccountAuthenticationProvider>.Instance);
+            var config = new AuthenticationConfiguration(AuthenticationScheme.Bearer, "Bearer");
+
+            var result = provider.CanHandle(config);
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task Should_ReturnSuccess_When_ServiceAccountKeyParameterProvided()
+        {
+            var provider = new FirebaseServiceAccountAuthenticationProvider(NullLogger<FirebaseServiceAccountAuthenticationProvider>.Instance);
+            var settings = new ConnectionSettings()
+                .SetParameter("ServiceAccountKey", "{\"type\": \"service_account\"}");
+            var config = new AuthenticationConfiguration(AuthenticationScheme.Certificate, "Firebase SA");
+
+            var result = await provider.ObtainCredentialAsync(settings, config, TestContext.Current.CancellationToken);
+
+            Assert.True(result.IsSuccessful);
+            Assert.NotNull(result.Credential);
+            Assert.Equal(AuthenticationScheme.Certificate, result.Credential.Scheme);
+            Assert.Equal("ServiceAccount", result.Credential.Properties["CredentialType"]);
+            Assert.Equal("Firebase", result.Credential.Properties["Provider"]);
+        }
+
+        [Fact]
+        public async Task Should_ReturnSuccess_When_ServiceAccountJsonParameterProvided()
+        {
+            var provider = new FirebaseServiceAccountAuthenticationProvider(NullLogger<FirebaseServiceAccountAuthenticationProvider>.Instance);
+            var settings = new ConnectionSettings()
+                .SetParameter("ServiceAccountJson", "{\"type\": \"service_account\"}");
+            var config = new AuthenticationConfiguration(AuthenticationScheme.Certificate, "Firebase SA");
+
+            var result = await provider.ObtainCredentialAsync(settings, config, TestContext.Current.CancellationToken);
+
+            Assert.True(result.IsSuccessful);
+        }
+
+        [Fact]
+        public async Task Should_ReturnSuccess_When_CertificateParameterProvided()
+        {
+            var provider = new FirebaseServiceAccountAuthenticationProvider(NullLogger<FirebaseServiceAccountAuthenticationProvider>.Instance);
+            var settings = new ConnectionSettings()
+                .SetParameter("Certificate", "{\"type\": \"service_account\"}");
+            var config = new AuthenticationConfiguration(AuthenticationScheme.Certificate, "Firebase SA");
+
+            var result = await provider.ObtainCredentialAsync(settings, config, TestContext.Current.CancellationToken);
+
+            Assert.True(result.IsSuccessful);
+        }
+
+        [Fact]
+        public async Task Should_ReturnFailure_When_MissingServiceAccountKey()
+        {
+            var provider = new FirebaseServiceAccountAuthenticationProvider(NullLogger<FirebaseServiceAccountAuthenticationProvider>.Instance);
+            var settings = new ConnectionSettings();
+            var config = new AuthenticationConfiguration(AuthenticationScheme.Certificate, "Firebase SA");
+
+            var result = await provider.ObtainCredentialAsync(settings, config, TestContext.Current.CancellationToken);
+
+            Assert.False(result.IsSuccessful);
+            Assert.Equal("MISSING_SERVICE_ACCOUNT_KEY", result.ErrorCode);
+        }
+
+        [Fact]
+        public async Task Should_ReturnFailure_When_ServiceAccountKeyIsNotValidJson()
+        {
+            var provider = new FirebaseServiceAccountAuthenticationProvider(NullLogger<FirebaseServiceAccountAuthenticationProvider>.Instance);
+            var settings = new ConnectionSettings()
+                .SetParameter("ServiceAccountKey", "not-json-at-all");
+            var config = new AuthenticationConfiguration(AuthenticationScheme.Certificate, "Firebase SA");
+
+            var result = await provider.ObtainCredentialAsync(settings, config, TestContext.Current.CancellationToken);
+
+            Assert.False(result.IsSuccessful);
+            Assert.Equal("INVALID_SERVICE_ACCOUNT_JSON", result.ErrorCode);
+        }
+
+        [Fact]
+        public async Task Should_IncludeProjectId_When_Provided()
+        {
+            var provider = new FirebaseServiceAccountAuthenticationProvider(NullLogger<FirebaseServiceAccountAuthenticationProvider>.Instance);
+            var settings = new ConnectionSettings()
+                .SetParameter("ServiceAccountKey", "{\"type\": \"service_account\"}")
+                .SetParameter("ProjectId", "my-project-123");
+            var config = new AuthenticationConfiguration(AuthenticationScheme.Certificate, "Firebase SA");
+
+            var result = await provider.ObtainCredentialAsync(settings, config, TestContext.Current.CancellationToken);
+
+            Assert.True(result.IsSuccessful);
+            Assert.Equal("my-project-123", result.Credential!.Properties["ProjectId"]);
+        }
+
+        [Fact]
+        public async Task Should_ReturnExisting_When_RefreshCredentialAsyncValid()
+        {
+            var provider = new FirebaseServiceAccountAuthenticationProvider(NullLogger<FirebaseServiceAccountAuthenticationProvider>.Instance);
+            var existing = AuthenticationCredential.ForCertificate("{\"type\": \"service_account\"}");
+
+            var result = await provider.RefreshCredentialAsync(existing, new ConnectionSettings(), new AuthenticationConfiguration(AuthenticationScheme.Certificate, "Firebase SA"), TestContext.Current.CancellationToken);
+
+            Assert.True(result.IsSuccessful);
+            Assert.Same(existing, result.Credential);
+        }
+
+        [Fact]
+        public async Task Should_Reobtain_When_RefreshCredentialAsyncInvalidScheme()
+        {
+            var provider = new FirebaseServiceAccountAuthenticationProvider(NullLogger<FirebaseServiceAccountAuthenticationProvider>.Instance);
+            var settings = new ConnectionSettings()
+                .SetParameter("ServiceAccountKey", "{\"type\": \"service_account\"}");
+            var config = new AuthenticationConfiguration(AuthenticationScheme.Certificate, "Firebase SA");
+            var existing = new AuthenticationCredential(AuthenticationScheme.Bearer, "some-token");
+
+            var result = await provider.RefreshCredentialAsync(existing, settings, config, TestContext.Current.CancellationToken);
+
+            Assert.True(result.IsSuccessful);
+            Assert.NotSame(existing, result.Credential);
+        }
+
+        [Fact]
+        public async Task Should_Reobtain_When_RefreshCredentialAsyncDifferentScheme()
+        {
+            var provider = new FirebaseServiceAccountAuthenticationProvider(NullLogger<FirebaseServiceAccountAuthenticationProvider>.Instance);
+            var settings = new ConnectionSettings()
+                .SetParameter("ServiceAccountKey", "{\"type\": \"service_account\"}");
+            var config = new AuthenticationConfiguration(AuthenticationScheme.Certificate, "Firebase SA");
+            var existing = AuthenticationCredential.ForBearerToken("some-token");
+
+            var result = await provider.RefreshCredentialAsync(existing, settings, config, TestContext.Current.CancellationToken);
+
+            Assert.True(result.IsSuccessful);
+            Assert.NotSame(existing, result.Credential);
+        }
+    }
+}

--- a/test/Deveel.Messaging.Connector.Firebase.XUnit/Unit/FirebaseServiceMappingTests.cs
+++ b/test/Deveel.Messaging.Connector.Firebase.XUnit/Unit/FirebaseServiceMappingTests.cs
@@ -1,0 +1,25 @@
+using FirebaseAdmin.Messaging;
+
+namespace Deveel.Messaging;
+
+[Trait("Category", "Unit")]
+[Trait("Layer", "Infrastructure")]
+[Trait("Feature", "FirebaseService")]
+public class FirebaseServiceMappingTests
+{
+    [Theory]
+    [InlineData(null, MessagingErrorCodes.SendMessageFailed)]
+    [InlineData(MessagingErrorCode.InvalidArgument, FirebaseErrorCodes.InvalidArgument)]
+    [InlineData(MessagingErrorCode.Unregistered, FirebaseErrorCodes.UnregisteredToken)]
+    [InlineData(MessagingErrorCode.SenderIdMismatch, FirebaseErrorCodes.SenderIdMismatch)]
+    [InlineData(MessagingErrorCode.QuotaExceeded, MessagingErrorCodes.RateLimitExceeded)]
+    [InlineData(MessagingErrorCode.ThirdPartyAuthError, FirebaseErrorCodes.ThirdPartyAuthError)]
+    [InlineData(MessagingErrorCode.Unavailable, FirebaseErrorCodes.ServiceUnavailable)]
+    [InlineData(MessagingErrorCode.Internal, FirebaseErrorCodes.InternalError)]
+    [InlineData((MessagingErrorCode)999, MessagingErrorCodes.SendMessageFailed)]
+    public void Should_MapCorrectly_When_FirebaseErrorCodeProvided(MessagingErrorCode? code, string expected)
+    {
+        var result = FirebaseService.MapFirebaseErrorCode(code);
+        Assert.Equal(expected, result);
+    }
+}

--- a/test/Deveel.Messaging.Connector.Firebase.XUnit/Unit/FirebaseServiceMockedTests.cs
+++ b/test/Deveel.Messaging.Connector.Firebase.XUnit/Unit/FirebaseServiceMockedTests.cs
@@ -1,0 +1,169 @@
+using FirebaseAdmin.Messaging;
+using Moq;
+using System.Reflection;
+using Xunit;
+
+namespace Deveel.Messaging
+{
+    [Trait("Category", "Unit")]
+    [Trait("Layer", "Infrastructure")]
+    [Trait("Feature", "FirebaseService")]
+    public class FirebaseServiceMockedTests
+    {
+        private static FirebaseService CreateService(IFirebaseMessagingClient client)
+        {
+            var ctor = typeof(FirebaseService).GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic)
+                .First(c => c.GetParameters().Length == 1);
+            return (FirebaseService)ctor.Invoke(new object[] { client });
+        }
+
+        private static FirebaseAdmin.Messaging.Message CreateMessage(string token = "test-token")
+            => new FirebaseAdmin.Messaging.Message
+            {
+                Token = token,
+                Notification = new Notification
+                {
+                    Title = "Test",
+                    Body = "Test body"
+                }
+            };
+
+        [Fact]
+        public async Task Should_SendMessage_When_SendAsyncSucceeds()
+        {
+            var mockClient = new Mock<IFirebaseMessagingClient>();
+            var message = CreateMessage();
+            mockClient.Setup(x => x.SendAsync(message, false, It.IsAny<CancellationToken>()))
+                .ReturnsAsync("msg-123");
+
+            var service = CreateService(mockClient.Object);
+
+            var result = await service.SendAsync(message, false, TestContext.Current.CancellationToken);
+
+            Assert.Equal("msg-123", result);
+            mockClient.Verify(x => x.SendAsync(message, false, It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Should_ThrowConnectorException_When_SendAsyncThrowsException()
+        {
+            var mockClient = new Mock<IFirebaseMessagingClient>();
+            var message = CreateMessage();
+            mockClient.Setup(x => x.SendAsync(message, false, It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new InvalidOperationException("network error"));
+
+            var service = CreateService(mockClient.Object);
+
+            var ex = await Assert.ThrowsAsync<ConnectorException>(() =>
+                service.SendAsync(message, false, TestContext.Current.CancellationToken));
+
+            Assert.Equal(MessagingErrorCodes.SendMessageFailed, ex.ErrorCode);
+            Assert.Equal(FirebaseErrorCodes.ErrorDomain, ex.ErrorDomain);
+        }
+
+        [Fact]
+        public async Task Should_ThrowInvalidOperation_When_SendAsyncNotInitialized()
+        {
+            var service = new FirebaseService();
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                service.SendAsync(CreateMessage(), false, TestContext.Current.CancellationToken));
+        }
+
+        [Fact]
+        public async Task Should_ThrowConnectorException_When_SendEachAsyncThrowsException()
+        {
+            var mockClient = new Mock<IFirebaseMessagingClient>();
+            var messages = new[] { CreateMessage() };
+            mockClient.Setup(x => x.SendEachAsync(messages, false, It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new InvalidOperationException("error"));
+
+            var service = CreateService(mockClient.Object);
+
+            var ex = await Assert.ThrowsAsync<ConnectorException>(() =>
+                service.SendEachAsync(messages, false, TestContext.Current.CancellationToken));
+
+            Assert.Equal(MessagingErrorCodes.SendMessageFailed, ex.ErrorCode);
+        }
+
+        [Fact]
+        public async Task Should_ThrowConnectorException_When_SendMulticastAsyncThrowsException()
+        {
+            var mockClient = new Mock<IFirebaseMessagingClient>();
+            var message = new MulticastMessage { Tokens = new[] { "token1" } };
+            mockClient.Setup(x => x.SendMulticastAsync(message, false, It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new InvalidOperationException("error"));
+
+            var service = CreateService(mockClient.Object);
+
+            var ex = await Assert.ThrowsAsync<ConnectorException>(() =>
+                service.SendMulticastAsync(message, false, TestContext.Current.CancellationToken));
+
+            Assert.Equal(MessagingErrorCodes.SendMessageFailed, ex.ErrorCode);
+        }
+
+        [Fact]
+        public async Task Should_ReturnTrue_When_TestConnectionAsyncSendsSuccessfully()
+        {
+            var mockClient = new Mock<IFirebaseMessagingClient>();
+            mockClient.Setup(x => x.SendAsync(It.IsAny<FirebaseAdmin.Messaging.Message>(), true, It.IsAny<CancellationToken>()))
+                .ReturnsAsync("test-msg-id");
+
+            var service = CreateService(mockClient.Object);
+
+            var result = await service.TestConnectionAsync(TestContext.Current.CancellationToken);
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task Should_ReturnFalse_When_TestConnectionAsyncNotInitialized()
+        {
+            var service = new FirebaseService();
+
+            var result = await service.TestConnectionAsync(TestContext.Current.CancellationToken);
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void Should_BeInitialized_When_MockClientProvided()
+        {
+            var mockClient = new Mock<IFirebaseMessagingClient>();
+            var service = CreateService(mockClient.Object);
+
+            Assert.True(service.IsInitialized);
+            Assert.Null(service.App);
+        }
+
+        [Fact]
+        public async Task Should_ThrowArgumentNullException_When_SendAsyncNullMessage()
+        {
+            var mockClient = new Mock<IFirebaseMessagingClient>();
+            var service = CreateService(mockClient.Object);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() =>
+                service.SendAsync(null!, false, TestContext.Current.CancellationToken));
+        }
+
+        [Fact]
+        public async Task Should_ThrowArgumentNullException_When_SendEachAsyncNullMessages()
+        {
+            var mockClient = new Mock<IFirebaseMessagingClient>();
+            var service = CreateService(mockClient.Object);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() =>
+                service.SendEachAsync(null!, false, TestContext.Current.CancellationToken));
+        }
+
+        [Fact]
+        public async Task Should_ThrowArgumentNullException_When_SendMulticastAsyncNullMessage()
+        {
+            var mockClient = new Mock<IFirebaseMessagingClient>();
+            var service = CreateService(mockClient.Object);
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() =>
+                service.SendMulticastAsync(null!, false, TestContext.Current.CancellationToken));
+        }
+    }
+}

--- a/test/Deveel.Messaging.Connector.Sendgrid.XUnit/Unit/SendGridMessageBuilderExtensionsTests.cs
+++ b/test/Deveel.Messaging.Connector.Sendgrid.XUnit/Unit/SendGridMessageBuilderExtensionsTests.cs
@@ -1,0 +1,47 @@
+namespace Deveel.Messaging
+{
+    [Trait("Category", "Unit")]
+    [Trait("Feature", "SendGridMessageBuilder")]
+    public class SendGridMessageBuilderExtensionsTests
+    {
+        [Fact]
+        public void Should_SetTemplateId_When_WithTemplateId()
+        {
+            var builder = new MessageBuilder();
+            var result = builder.WithTemplateId("d-abc123");
+            Assert.Same(builder, result);
+        }
+
+        [Fact]
+        public void Should_SetCategories_When_WithCategories()
+        {
+            var builder = new MessageBuilder();
+            var result = builder.WithCategories("[\"category1\"]");
+            Assert.Same(builder, result);
+        }
+
+        [Fact]
+        public void Should_SetCustomArgs_When_WithCustomArgs()
+        {
+            var builder = new MessageBuilder();
+            var result = builder.WithCustomArgs("{\"arg1\":\"val1\"}");
+            Assert.Same(builder, result);
+        }
+
+        [Fact]
+        public void Should_SetSendAt_When_WithSendAt()
+        {
+            var builder = new MessageBuilder();
+            var result = builder.WithSendAt(DateTime.UtcNow.AddHours(1));
+            Assert.Same(builder, result);
+        }
+
+        [Fact]
+        public void Should_SetPriority_When_WithPriority()
+        {
+            var builder = new MessageBuilder();
+            var result = builder.WithPriority("high");
+            Assert.Same(builder, result);
+        }
+    }
+}

--- a/test/Deveel.Messaging.Connector.Sendgrid.XUnit/Unit/SendGridMessageBuilderTests.cs
+++ b/test/Deveel.Messaging.Connector.Sendgrid.XUnit/Unit/SendGridMessageBuilderTests.cs
@@ -1,0 +1,625 @@
+using System.Reflection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using SendGrid.Helpers.Mail;
+
+namespace Deveel.Messaging;
+
+[Trait("Category", "Unit")]
+[Trait("Layer", "Infrastructure")]
+[Trait("Feature", "SendGridMessageBuilder")]
+public class SendGridMessageBuilderTests
+{
+    private static readonly Type BuilderType = typeof(SendGridService).Assembly
+        .GetType("Deveel.Messaging.SendGridMessageBuilder")
+        ?? throw new InvalidOperationException("Could not find SendGridMessageBuilder type");
+
+    private static readonly ConstructorInfo BuilderCtor = BuilderType
+        .GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+        .First();
+
+    private static readonly MethodInfo SetMessageContentAsyncMethod = BuilderType
+        .GetMethod("SetMessageContentAsync", BindingFlags.Public | BindingFlags.Instance)!;
+
+    private static readonly MethodInfo ApplyMessageSettingsMethod = BuilderType
+        .GetMethod("ApplyMessageSettings", BindingFlags.Public | BindingFlags.Instance)!;
+
+    private static readonly MethodInfo ApplyConnectorSettingsMethod = BuilderType
+        .GetMethod("ApplyConnectorSettings", BindingFlags.Public | BindingFlags.Instance)!;
+
+    private static object CreateBuilder(
+        bool sandboxMode = false,
+        bool trackingSettings = false,
+        string? defaultReplyTo = null,
+        ILogger? logger = null)
+    {
+        return BuilderCtor.Invoke(new object?[] { sandboxMode, trackingSettings, defaultReplyTo, logger });
+    }
+
+    private static async Task InvokeSetMessageContentAsync(object builder, SendGridMessage message, IMessage msg)
+    {
+        await (Task)SetMessageContentAsyncMethod.Invoke(builder, new object[] { message, msg })!;
+    }
+
+    private static void InvokeApplyMessageSettings(object builder, SendGridMessage message, IMessage msg, Dictionary<string, object?> properties)
+    {
+        ApplyMessageSettingsMethod.Invoke(builder, new object[] { message, msg, properties });
+    }
+
+    private static void InvokeApplyConnectorSettings(object builder, SendGridMessage message)
+    {
+        ApplyConnectorSettingsMethod.Invoke(builder, new object[] { message });
+    }
+
+    #region SetMessageContentAsync
+
+    [Fact]
+    public async Task Should_SkipContent_When_MessageContentIsNull()
+    {
+        var builder = CreateBuilder();
+        var message = new SendGridMessage();
+        var msg = new Message
+        {
+            Id = "msg-1",
+            Content = null,
+            Sender = new Endpoint(EndpointType.EmailAddress, "from@test.com"),
+            Receiver = new Endpoint(EndpointType.EmailAddress, "to@test.com")
+        };
+
+        await InvokeSetMessageContentAsync(builder, message, msg);
+    }
+
+    [Fact]
+    public async Task Should_SetPlainText_When_ContentIsPlainText()
+    {
+        var builder = CreateBuilder();
+        var message = new SendGridMessage();
+        var content = new TextContent("Hello World");
+        var msg = new Message
+        {
+            Id = "msg-1",
+            Content = content,
+            Sender = new Endpoint(EndpointType.EmailAddress, "from@test.com"),
+            Receiver = new Endpoint(EndpointType.EmailAddress, "to@test.com")
+        };
+
+        await InvokeSetMessageContentAsync(builder, message, msg);
+
+        Assert.Equal("Hello World", message.PlainTextContent);
+    }
+
+    [Fact]
+    public async Task Should_SetHtmlContent_When_ContentIsHtml()
+    {
+        var builder = CreateBuilder();
+        var message = new SendGridMessage();
+        var content = new HtmlContent("<h1>Hello</h1>");
+        var msg = new Message
+        {
+            Id = "msg-1",
+            Content = content,
+            Sender = new Endpoint(EndpointType.EmailAddress, "from@test.com"),
+            Receiver = new Endpoint(EndpointType.EmailAddress, "to@test.com")
+        };
+
+        await InvokeSetMessageContentAsync(builder, message, msg);
+
+        Assert.Equal("<h1>Hello</h1>", message.HtmlContent);
+    }
+
+    [Fact]
+    public async Task Should_SetMultipartContent()
+    {
+        var builder = CreateBuilder();
+        var message = new SendGridMessage();
+        var parts = new List<MessageContentPart>
+        {
+            new TextContentPart("Plain text"),
+            new HtmlContentPart("<b>HTML</b>")
+        };
+        var content = new MultipartContent(parts);
+        var msg = new Message
+        {
+            Id = "msg-1",
+            Content = content,
+            Sender = new Endpoint(EndpointType.EmailAddress, "from@test.com"),
+            Receiver = new Endpoint(EndpointType.EmailAddress, "to@test.com")
+        };
+
+        await InvokeSetMessageContentAsync(builder, message, msg);
+
+        Assert.Equal("Plain text", message.PlainTextContent);
+        Assert.Equal("<b>HTML</b>", message.HtmlContent);
+    }
+
+    [Fact]
+    public async Task Should_SetTemplateId_When_ContentIsTemplate()
+    {
+        var builder = CreateBuilder();
+        var message = new SendGridMessage();
+        var content = new TemplateContent("d-template123");
+        var msg = new Message
+        {
+            Id = "msg-1",
+            Content = content,
+            Sender = new Endpoint(EndpointType.EmailAddress, "from@test.com"),
+            Receiver = new Endpoint(EndpointType.EmailAddress, "to@test.com")
+        };
+
+        await InvokeSetMessageContentAsync(builder, message, msg);
+
+        Assert.Equal("d-template123", message.TemplateId);
+    }
+
+    [Fact]
+    public async Task Should_SetTemplateData_When_ContentIsTemplateWithParameters()
+    {
+        var builder = CreateBuilder();
+        var sendGridMessage = new SendGridMessage();
+        var parameters = new Dictionary<string, object?>
+        {
+            ["name"] = "John",
+            ["city"] = "NYC"
+        };
+        var content = new TemplateContent("d-template456", parameters);
+        var msg = new Message
+        {
+            Id = "msg-1",
+            Content = content,
+            Sender = new Endpoint(EndpointType.EmailAddress, "from@test.com"),
+            Receiver = new Endpoint(EndpointType.EmailAddress, "to@test.com")
+        };
+
+        await InvokeSetMessageContentAsync(builder, sendGridMessage, msg);
+
+        Assert.Equal("d-template456", sendGridMessage.TemplateId);
+    }
+
+    [Fact]
+    public async Task Should_SetPlainText_When_ContentTypeIsUnknownButIsTextContent()
+    {
+        var builder = CreateBuilder();
+        var message = new SendGridMessage();
+        var content = new TextContent("Fallback text");
+        var msg = new Message
+        {
+            Id = "msg-1",
+            Content = content,
+            Sender = new Endpoint(EndpointType.EmailAddress, "from@test.com"),
+            Receiver = new Endpoint(EndpointType.EmailAddress, "to@test.com")
+        };
+
+        await InvokeSetMessageContentAsync(builder, message, msg);
+
+        Assert.Equal("Fallback text", message.PlainTextContent);
+    }
+
+    #endregion
+
+    #region ApplyMessageSettings
+
+    private static Dictionary<string, string> GetHeaders(SendGridMessage message)
+    {
+        if (message.Personalizations?.Count > 0)
+            return message.Personalizations[0].Headers ?? new Dictionary<string, string>();
+        return new Dictionary<string, string>();
+    }
+
+    [Fact]
+    public void Should_SetHighPriorityHeader()
+    {
+        var builder = CreateBuilder();
+        var message = new SendGridMessage();
+        var properties = new Dictionary<string, object?>
+        {
+            ["Priority"] = "high"
+        };
+
+        InvokeApplyMessageSettings(builder, message, CreateDummyMessage(), properties);
+
+        var headers = GetHeaders(message);
+        Assert.Equal("1", headers["X-Priority"]);
+    }
+
+    [Fact]
+    public void Should_SetNormalPriorityHeader()
+    {
+        var builder = CreateBuilder();
+        var message = new SendGridMessage();
+        var properties = new Dictionary<string, object?>
+        {
+            ["Priority"] = "normal"
+        };
+
+        InvokeApplyMessageSettings(builder, message, CreateDummyMessage(), properties);
+
+        var headers = GetHeaders(message);
+        Assert.Equal("3", headers["X-Priority"]);
+    }
+
+    [Fact]
+    public void Should_SetLowPriorityHeader()
+    {
+        var builder = CreateBuilder();
+        var message = new SendGridMessage();
+        var properties = new Dictionary<string, object?>
+        {
+            ["Priority"] = "low"
+        };
+
+        InvokeApplyMessageSettings(builder, message, CreateDummyMessage(), properties);
+
+        var headers = GetHeaders(message);
+        Assert.Equal("5", headers["X-Priority"]);
+    }
+
+    [Fact]
+    public void Should_DefaultToNormal_When_UnknownPriority()
+    {
+        var builder = CreateBuilder();
+        var message = new SendGridMessage();
+        var properties = new Dictionary<string, object?>
+        {
+            ["Priority"] = "urgent"
+        };
+
+        InvokeApplyMessageSettings(builder, message, CreateDummyMessage(), properties);
+
+        var headers = GetHeaders(message);
+        Assert.Equal("3", headers["X-Priority"]);
+    }
+
+    [Fact]
+    public void Should_SkipPriority_When_ValueIsNull()
+    {
+        var builder = CreateBuilder();
+        var message = new SendGridMessage();
+        var properties = new Dictionary<string, object?>
+        {
+            ["Priority"] = null
+        };
+
+        InvokeApplyMessageSettings(builder, message, CreateDummyMessage(), properties);
+
+        var headers = GetHeaders(message);
+        Assert.Empty(headers);
+    }
+
+    [Fact]
+    public void Should_SetCategories()
+    {
+        var builder = CreateBuilder();
+        var message = new SendGridMessage();
+        var properties = new Dictionary<string, object?>
+        {
+            ["Categories"] = "newsletter,marketing,welcome"
+        };
+
+        InvokeApplyMessageSettings(builder, message, CreateDummyMessage(), properties);
+
+        Assert.NotNull(message.Categories);
+        Assert.Equal(3, message.Categories.Count);
+        Assert.Contains("newsletter", message.Categories);
+        Assert.Contains("marketing", message.Categories);
+        Assert.Contains("welcome", message.Categories);
+    }
+
+    [Fact]
+    public void Should_SkipCategories_When_ValueIsEmpty()
+    {
+        var builder = CreateBuilder();
+        var message = new SendGridMessage();
+        var properties = new Dictionary<string, object?>
+        {
+            ["Categories"] = ""
+        };
+
+        InvokeApplyMessageSettings(builder, message, CreateDummyMessage(), properties);
+
+        Assert.Null(message.Categories);
+    }
+
+    [Fact]
+    public void Should_SkipCategories_When_KeyNotPresent()
+    {
+        var builder = CreateBuilder();
+        var message = new SendGridMessage();
+        var properties = new Dictionary<string, object?>();
+
+        InvokeApplyMessageSettings(builder, message, CreateDummyMessage(), properties);
+
+        Assert.Null(message.Categories);
+    }
+
+    [Fact]
+    public void Should_SetCustomArgs()
+    {
+        var builder = CreateBuilder();
+        var message = new SendGridMessage();
+        var properties = new Dictionary<string, object?>
+        {
+            ["CustomArgs"] = "{\"userId\":\"123\",\"campaign\":\"abc\"}"
+        };
+
+        InvokeApplyMessageSettings(builder, message, CreateDummyMessage(), properties);
+
+        Assert.NotNull(message.CustomArgs);
+        Assert.Equal("123", message.CustomArgs["userId"]);
+        Assert.Equal("abc", message.CustomArgs["campaign"]);
+    }
+
+    [Fact]
+    public void Should_HandleInvalidCustomArgsJson()
+    {
+        var logger = new Mock<ILogger>();
+        var builder = CreateBuilder(logger: logger.Object);
+        var message = new SendGridMessage();
+        var properties = new Dictionary<string, object?>
+        {
+            ["CustomArgs"] = "not-valid-json{{{"
+        };
+
+        InvokeApplyMessageSettings(builder, message, CreateDummyMessage(), properties);
+
+        Assert.Null(message.CustomArgs);
+    }
+
+    [Fact]
+    public void Should_SkipCustomArgs_When_ValueIsNull()
+    {
+        var builder = CreateBuilder();
+        var message = new SendGridMessage();
+        var properties = new Dictionary<string, object?>
+        {
+            ["CustomArgs"] = null
+        };
+
+        InvokeApplyMessageSettings(builder, message, CreateDummyMessage(), properties);
+
+        Assert.Null(message.CustomArgs);
+    }
+
+    [Fact]
+    public void Should_SetSendAt_When_DateTimeValue()
+    {
+        var builder = CreateBuilder();
+        var message = new SendGridMessage();
+        var sendAt = new DateTime(2026, 6, 1, 12, 0, 0, DateTimeKind.Utc);
+        var properties = new Dictionary<string, object?>
+        {
+            ["SendAt"] = sendAt
+        };
+
+        InvokeApplyMessageSettings(builder, message, CreateDummyMessage(), properties);
+
+        Assert.NotNull(message.SendAt);
+    }
+
+    [Fact]
+    public void Should_SetSendAt_When_StringValue()
+    {
+        var builder = CreateBuilder();
+        var message = new SendGridMessage();
+        var properties = new Dictionary<string, object?>
+        {
+            ["SendAt"] = "2026-06-01T12:00:00Z"
+        };
+
+        InvokeApplyMessageSettings(builder, message, CreateDummyMessage(), properties);
+
+        Assert.NotNull(message.SendAt);
+    }
+
+    [Fact]
+    public void Should_SkipSendAt_When_ValueIsInvalid()
+    {
+        var builder = CreateBuilder();
+        var message = new SendGridMessage();
+        var properties = new Dictionary<string, object?>
+        {
+            ["SendAt"] = 12345
+        };
+
+        InvokeApplyMessageSettings(builder, message, CreateDummyMessage(), properties);
+
+        Assert.Null(message.SendAt);
+    }
+
+    [Fact]
+    public void Should_SetBatchId()
+    {
+        var builder = CreateBuilder();
+        var message = new SendGridMessage();
+        var properties = new Dictionary<string, object?>
+        {
+            ["BatchId"] = "batch-123"
+        };
+
+        InvokeApplyMessageSettings(builder, message, CreateDummyMessage(), properties);
+
+        Assert.Equal("batch-123", message.BatchId);
+    }
+
+    [Fact]
+    public void Should_SkipBatchId_When_ValueIsEmpty()
+    {
+        var builder = CreateBuilder();
+        var message = new SendGridMessage();
+        var properties = new Dictionary<string, object?>
+        {
+            ["BatchId"] = ""
+        };
+
+        InvokeApplyMessageSettings(builder, message, CreateDummyMessage(), properties);
+
+        Assert.Null(message.BatchId);
+    }
+
+    [Fact]
+    public void Should_SetAsmGroupId()
+    {
+        var builder = CreateBuilder();
+        var message = new SendGridMessage();
+        var properties = new Dictionary<string, object?>
+        {
+            ["AsmGroupId"] = "42"
+        };
+
+        InvokeApplyMessageSettings(builder, message, CreateDummyMessage(), properties);
+
+        Assert.NotNull(message.Asm);
+        Assert.Equal(42, message.Asm.GroupId);
+    }
+
+    [Fact]
+    public void Should_SkipAsmGroupId_When_ValueIsNotNumeric()
+    {
+        var builder = CreateBuilder();
+        var message = new SendGridMessage();
+        var properties = new Dictionary<string, object?>
+        {
+            ["AsmGroupId"] = "abc"
+        };
+
+        InvokeApplyMessageSettings(builder, message, CreateDummyMessage(), properties);
+
+        Assert.Null(message.Asm);
+    }
+
+    [Fact]
+    public void Should_SetIpPoolName()
+    {
+        var builder = CreateBuilder();
+        var message = new SendGridMessage();
+        var properties = new Dictionary<string, object?>
+        {
+            ["IpPoolName"] = "pool-1"
+        };
+
+        InvokeApplyMessageSettings(builder, message, CreateDummyMessage(), properties);
+
+        Assert.Equal("pool-1", message.IpPoolName);
+    }
+
+    [Fact]
+    public void Should_SkipIpPoolName_When_ValueIsEmpty()
+    {
+        var builder = CreateBuilder();
+        var message = new SendGridMessage();
+        var properties = new Dictionary<string, object?>
+        {
+            ["IpPoolName"] = ""
+        };
+
+        InvokeApplyMessageSettings(builder, message, CreateDummyMessage(), properties);
+
+        Assert.Null(message.IpPoolName);
+    }
+
+    [Fact]
+    public void Should_SetReplyTo_When_DefaultReplyToConfigured()
+    {
+        var builder = CreateBuilder(defaultReplyTo: "replies@test.com");
+        var message = new SendGridMessage();
+        var properties = new Dictionary<string, object?>();
+
+        InvokeApplyMessageSettings(builder, message, CreateDummyMessage(), properties);
+
+        Assert.NotNull(message.ReplyTo);
+        Assert.Equal("replies@test.com", message.ReplyTo.Email);
+    }
+
+    [Fact]
+    public void Should_SkipReplyTo_When_DefaultReplyToNotConfigured()
+    {
+        var builder = CreateBuilder();
+        var message = new SendGridMessage();
+        var properties = new Dictionary<string, object?>();
+
+        InvokeApplyMessageSettings(builder, message, CreateDummyMessage(), properties);
+
+        Assert.Null(message.ReplyTo);
+    }
+
+    #endregion
+
+    #region ApplyConnectorSettings
+
+    [Fact]
+    public void Should_EnableSandboxMode_When_Configured()
+    {
+        var builder = CreateBuilder(sandboxMode: true);
+        var message = new SendGridMessage();
+
+        InvokeApplyConnectorSettings(builder, message);
+
+        Assert.NotNull(message.MailSettings);
+        Assert.NotNull(message.MailSettings.SandboxMode);
+        Assert.True(message.MailSettings.SandboxMode.Enable);
+    }
+
+    [Fact]
+    public void Should_EnableTracking_When_Configured()
+    {
+        var builder = CreateBuilder(trackingSettings: true);
+        var message = new SendGridMessage();
+
+        InvokeApplyConnectorSettings(builder, message);
+
+        Assert.NotNull(message.TrackingSettings);
+        Assert.NotNull(message.TrackingSettings.ClickTracking);
+        Assert.True(message.TrackingSettings.ClickTracking.Enable);
+        Assert.NotNull(message.TrackingSettings.OpenTracking);
+        Assert.True(message.TrackingSettings.OpenTracking.Enable);
+    }
+
+    [Fact]
+    public void Should_EnableBoth_When_SandboxAndTrackingConfigured()
+    {
+        var builder = CreateBuilder(sandboxMode: true, trackingSettings: true);
+        var message = new SendGridMessage();
+
+        InvokeApplyConnectorSettings(builder, message);
+
+        Assert.NotNull(message.MailSettings);
+        Assert.True(message.MailSettings.SandboxMode.Enable);
+        Assert.NotNull(message.TrackingSettings);
+        Assert.True(message.TrackingSettings.ClickTracking.Enable);
+        Assert.True(message.TrackingSettings.OpenTracking.Enable);
+    }
+
+    [Fact]
+    public void Should_NotSetMailSettings_When_SandboxModeNotConfigured()
+    {
+        var builder = CreateBuilder(sandboxMode: false);
+        var message = new SendGridMessage();
+
+        InvokeApplyConnectorSettings(builder, message);
+
+        Assert.Null(message.MailSettings);
+    }
+
+    [Fact]
+    public void Should_NotSetTrackingSettings_When_TrackingNotConfigured()
+    {
+        var builder = CreateBuilder(trackingSettings: false);
+        var message = new SendGridMessage();
+
+        InvokeApplyConnectorSettings(builder, message);
+
+        Assert.Null(message.TrackingSettings);
+    }
+
+    #endregion
+
+    private static IMessage CreateDummyMessage()
+    {
+        return new Message
+        {
+            Id = "test-msg",
+            Sender = new Endpoint(EndpointType.EmailAddress, "from@test.com"),
+            Receiver = new Endpoint(EndpointType.EmailAddress, "to@test.com"),
+            Content = new TextContent("Test")
+        };
+    }
+}

--- a/test/Deveel.Messaging.Connector.Telegram.XUnit/Unit/TelegramBotConnectorTests.cs
+++ b/test/Deveel.Messaging.Connector.Telegram.XUnit/Unit/TelegramBotConnectorTests.cs
@@ -547,7 +547,324 @@ namespace Deveel.Messaging
 
 		#endregion
 
-		#region Helper Methods
+		#region Additional Content Type Tests
+
+	[Fact]
+	public async Task Should_SendLocationFromJson_When_SendMessageAsyncWithJsonLocationContent()
+	{
+		var connector = await CreateInitializedConnectorAsync();
+		var json = """{"latitude":40.7128,"longitude":-74.0060,"livePeriod":3600,"heading":45,"proximityAlertRadius":500}""";
+		var message = new Message
+		{
+			Id = "test-json-loc",
+			Receiver = new Endpoint(EndpointType.Id, "123456789"),
+			Content = new JsonContent(json)
+		};
+		var result = await connector.SendMessageAsync(message, TestContext.Current.CancellationToken);
+		Assert.True(result.IsSuccess());
+	}
+
+	[Fact]
+	public async Task Should_SendButtonContent_When_SendMessageAsyncWithButtonContent()
+	{
+		var connector = await CreateInitializedConnectorAsync();
+		var message = new Message
+		{
+			Id = "test-button",
+			Receiver = new Endpoint(EndpointType.Id, "123456789"),
+			Content = new ButtonContent("Click me", ButtonType.Postback, "payload")
+		};
+		var result = await connector.SendMessageAsync(message, TestContext.Current.CancellationToken);
+		Assert.True(result.IsSuccess());
+	}
+
+	[Fact]
+	public async Task Should_SendQuickReply_When_SendMessageAsyncWithQuickReplyContent()
+	{
+		var connector = await CreateInitializedConnectorAsync();
+		var message = new Message
+		{
+			Id = "test-qr",
+			Receiver = new Endpoint(EndpointType.Id, "123456789"),
+			Content = new QuickReplyContent("Option 1")
+		};
+		var result = await connector.SendMessageAsync(message, TestContext.Current.CancellationToken);
+		Assert.True(result.IsSuccess());
+	}
+
+	[Fact]
+	public async Task Should_Fail_When_SendMessageAsyncWithCarouselContent()
+	{
+		var connector = await CreateInitializedConnectorAsync();
+		var message = new Message
+		{
+			Id = "test-carousel",
+			Receiver = new Endpoint(EndpointType.Id, "123456789"),
+			Content = new CarouselContent(new List<ICarouselCard>())
+		};
+		var result = await connector.SendMessageAsync(message, TestContext.Current.CancellationToken);
+		Assert.False(result.IsSuccess());
+	}
+
+	#endregion
+
+	#region Webhook Setup Failure Tests
+
+	[Fact]
+	public async Task Should_FailInitialization_When_WebhookSetupThrows()
+	{
+		var schema = TelegramChannelSchemas.WebhookBot;
+		var connectionSettings = TelegramMockFactory.CreateWebhookConnectionSettings();
+		var mockService = TelegramMockFactory.CreateMockTelegramService();
+		mockService.Setup(x => x.SetWebhookAsync(
+			It.IsAny<string>(), It.IsAny<InputFile?>(), It.IsAny<string?>(),
+			It.IsAny<int?>(), It.IsAny<IEnumerable<UpdateType>?>(),
+			It.IsAny<bool?>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new InvalidOperationException("webhook failed"));
+		var connector = new TelegramBotConnector(schema, connectionSettings, mockService.Object);
+		var result = await connector.InitializeAsync(TestContext.Current.CancellationToken);
+		Assert.False(result.IsSuccess());
+	}
+
+	#endregion
+
+	#region Validation Edge Case Tests
+
+	[Fact]
+	public async Task Should_ReturnValidationError_When_ValidateWithInvalidMediaUrl()
+	{
+		var connector = await CreateInitializedConnectorAsync();
+		var message = new Message
+		{
+			Id = "test-bad-url",
+			Receiver = new Endpoint(EndpointType.Id, "123456789"),
+			Content = new MediaContent(MediaType.Image, "img.jpg", "not-a-valid-url")
+		};
+		var results = new List<ValidationResult>();
+		await foreach (var r in connector.ValidateMessageAsync(message, TestContext.Current.CancellationToken))
+			if (r != null && !string.IsNullOrEmpty(r.ErrorMessage))
+				results.Add(r);
+		Assert.Contains(results, r => r.MemberNames.Contains("Content"));
+	}
+
+	[Fact]
+	public async Task Should_ReturnValidationError_When_ValidateWithTooLongCaption()
+	{
+		var connector = await CreateInitializedConnectorAsync();
+		var longCaption = new string('x', TelegramConnectorConstants.MaxCaptionLength + 1);
+		var message = new Message
+		{
+			Id = "test-long-cap",
+			Receiver = new Endpoint(EndpointType.Id, "123456789"),
+			Content = new MediaContent(MediaType.Image, "img.jpg", "https://example.com/img.jpg"),
+			Properties = new Dictionary<string, MessageProperty>
+			{
+				{ "Caption", new MessageProperty("Caption", longCaption) }
+			}
+		};
+		var results = new List<ValidationResult>();
+		await foreach (var r in connector.ValidateMessageAsync(message, TestContext.Current.CancellationToken))
+			if (r != null && !string.IsNullOrEmpty(r.ErrorMessage))
+				results.Add(r);
+		Assert.NotEmpty(results);
+	}
+
+	[Fact]
+	public async Task Should_ReturnValidationError_When_ValidateWithInvalidInlineKeyboardJson()
+	{
+		var connector = await CreateInitializedConnectorAsync();
+		var message = new Message
+		{
+			Id = "test-bad-keyboard",
+			Receiver = new Endpoint(EndpointType.Id, "123456789"),
+			Content = new TextContent("test"),
+			Properties = new Dictionary<string, MessageProperty>
+			{
+				{ "InlineKeyboard", new MessageProperty("InlineKeyboard", "not valid json") }
+			}
+		};
+		var results = new List<ValidationResult>();
+		await foreach (var r in connector.ValidateMessageAsync(message, TestContext.Current.CancellationToken))
+			if (r != null && !string.IsNullOrEmpty(r.ErrorMessage))
+				results.Add(r);
+		Assert.NotEmpty(results);
+	}
+
+	[Fact]
+	public async Task Should_ReturnNoError_When_ValidateWithEmptyTextContent()
+	{
+		var connector = await CreateInitializedConnectorAsync();
+		var message = new Message
+		{
+			Id = "test-empty-text",
+			Receiver = new Endpoint(EndpointType.Id, "123456789"),
+			Content = new TextContent("")
+		};
+		var results = new List<ValidationResult>();
+		await foreach (var r in connector.ValidateMessageAsync(message, TestContext.Current.CancellationToken))
+			if (r != null && !string.IsNullOrEmpty(r.ErrorMessage))
+				results.Add(r);
+		Assert.Empty(results);
+	}
+
+	#endregion
+
+	#region Status With Webhook Tests
+
+	[Fact]
+	public async Task Should_IncludeWebhookError_When_GetStatusAsyncWithWebhookFailure()
+	{
+		var schema = TelegramChannelSchemas.WebhookBot;
+		var connectionSettings = TelegramMockFactory.CreateWebhookConnectionSettings();
+		var mockService = TelegramMockFactory.CreateMockTelegramService();
+		mockService.Setup(x => x.GetWebhookInfoAsync(It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new InvalidOperationException("webhook info error"));
+		var connector = new TelegramBotConnector(schema, connectionSettings, mockService.Object);
+		await connector.InitializeAsync(TestContext.Current.CancellationToken);
+		var result = await connector.GetStatusAsync(TestContext.Current.CancellationToken);
+		Assert.True(result.IsSuccess());
+		Assert.True(result.Value.AdditionalData.ContainsKey("WebhookError"));
+	}
+
+	#endregion
+
+	#region Connection Test Failure Tests
+
+	[Fact]
+	public async Task Should_Fail_When_TestConnectionAsyncWithNullBotInfo()
+	{
+		var schema = TelegramChannelSchemas.TelegramBot;
+		var connectionSettings = TelegramMockFactory.CreateTestConnectionSettings();
+		var mockService = TelegramMockFactory.CreateMockTelegramService();
+		mockService.Setup(x => x.GetMeAsync(It.IsAny<CancellationToken>()))
+			.ReturnsAsync((User)null!);
+		var connector = new TelegramBotConnector(schema, connectionSettings, mockService.Object);
+		await connector.InitializeAsync(TestContext.Current.CancellationToken);
+		var result = await connector.TestConnectionAsync(TestContext.Current.CancellationToken);
+		Assert.False(result.IsSuccess());
+	}
+
+	#endregion
+
+	#region Health Check With Webhook Tests
+
+	[Fact]
+	public async Task Should_IncludeWebhookIssues_When_GetHealthAsyncWithWebhookErrors()
+	{
+		var schema = TelegramChannelSchemas.WebhookBot;
+		var connectionSettings = TelegramMockFactory.CreateWebhookConnectionSettings();
+		var mockService = TelegramMockFactory.CreateMockTelegramService();
+		var webhookInfo = new WebhookInfo
+		{
+			Url = "https://example.com/webhook",
+			LastErrorMessage = "connection failed",
+			PendingUpdateCount = 0
+		};
+		mockService.Setup(x => x.GetWebhookInfoAsync(It.IsAny<CancellationToken>()))
+			.ReturnsAsync(webhookInfo);
+		var connector = new TelegramBotConnector(schema, connectionSettings, mockService.Object);
+		await connector.InitializeAsync(TestContext.Current.CancellationToken);
+		var result = await connector.GetHealthAsync(TestContext.Current.CancellationToken);
+		Assert.True(result.IsSuccess());
+		Assert.Contains(result.Value.Issues, i => i.Contains("Webhook error"));
+	}
+
+	[Fact]
+	public async Task Should_IncludePendingUpdateIssue_When_GetHealthAsyncWithHighPendingUpdates()
+	{
+		var schema = TelegramChannelSchemas.WebhookBot;
+		var connectionSettings = TelegramMockFactory.CreateWebhookConnectionSettings();
+		var mockService = TelegramMockFactory.CreateMockTelegramService();
+		var webhookInfo = new WebhookInfo
+		{
+			Url = "https://example.com/webhook",
+			PendingUpdateCount = 200,
+			LastErrorMessage = null
+		};
+		mockService.Setup(x => x.GetWebhookInfoAsync(It.IsAny<CancellationToken>()))
+			.ReturnsAsync(webhookInfo);
+		var connector = new TelegramBotConnector(schema, connectionSettings, mockService.Object);
+		await connector.InitializeAsync(TestContext.Current.CancellationToken);
+		var result = await connector.GetHealthAsync(TestContext.Current.CancellationToken);
+		Assert.True(result.IsSuccess());
+		Assert.Contains(result.Value.Issues, i => i.Contains("pending update count"));
+	}
+
+	[Fact]
+	public async Task Should_HandleWebhookCheckFailure_When_GetHealthAsyncWithWebhookException()
+	{
+		var schema = TelegramChannelSchemas.WebhookBot;
+		var connectionSettings = TelegramMockFactory.CreateWebhookConnectionSettings();
+		var mockService = TelegramMockFactory.CreateMockTelegramService();
+		mockService.Setup(x => x.GetWebhookInfoAsync(It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new InvalidOperationException("webhook check failed"));
+		var connector = new TelegramBotConnector(schema, connectionSettings, mockService.Object);
+		await connector.InitializeAsync(TestContext.Current.CancellationToken);
+		var result = await connector.GetHealthAsync(TestContext.Current.CancellationToken);
+		Assert.True(result.IsSuccess());
+		Assert.Contains(result.Value.Issues, i => i.Contains("Webhook check failed"));
+	}
+
+	[Fact]
+	public async Task Should_MarkUnhealthy_When_GetHealthAsyncWithConnectionFailure()
+	{
+		var schema = TelegramChannelSchemas.WebhookBot;
+		var connectionSettings = TelegramMockFactory.CreateWebhookConnectionSettings();
+		var mockService = TelegramMockFactory.CreateMockTelegramService();
+		var connector = new TelegramBotConnector(schema, connectionSettings, mockService.Object);
+
+		var initResult = await connector.InitializeAsync(TestContext.Current.CancellationToken);
+		Assert.True(initResult.IsSuccess(), $"Init failed: {initResult.Error?.Message}");
+
+		mockService.Setup(x => x.GetMeAsync(It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new InvalidOperationException("health check connection failed"));
+
+		var result = await connector.GetHealthAsync(TestContext.Current.CancellationToken);
+		Assert.True(result.IsSuccess());
+		Assert.False(result.Value.IsHealthy);
+		Assert.Contains(result.Value.Issues, i => i.Contains("Health check failed"));
+	}
+
+	#endregion
+
+	#region Shutdown Webhook Failure Tests
+
+	[Fact]
+	public async Task Should_HandleWebhookRemovalFailure_When_ShutdownAsyncWithWebhook()
+	{
+		var schema = TelegramChannelSchemas.WebhookBot;
+		var connectionSettings = TelegramMockFactory.CreateWebhookConnectionSettings();
+		var mockService = TelegramMockFactory.CreateMockTelegramService();
+		mockService.Setup(x => x.DeleteWebhookAsync(
+			It.IsAny<bool?>(), It.IsAny<CancellationToken>()))
+			.ThrowsAsync(new InvalidOperationException("delete failed"));
+		var connector = new TelegramBotConnector(schema, connectionSettings, mockService.Object);
+		await connector.InitializeAsync(TestContext.Current.CancellationToken);
+		await connector.ShutdownAsync(TestContext.Current.CancellationToken);
+		Assert.Equal(ConnectorState.Shutdown, connector.State);
+	}
+
+	#endregion
+
+	#region Send Media With Data Tests
+
+	[Fact]
+	public async Task Should_SendMediaFromData_When_SendMessageAsyncWithMediaData()
+	{
+		var connector = await CreateInitializedConnectorAsync();
+		var message = new Message
+		{
+			Id = "test-media-data",
+			Receiver = new Endpoint(EndpointType.Id, "123456789"),
+			Content = new MediaContent(MediaType.Image, "test.jpg", new byte[] { 0x01, 0x02, 0x03 })
+		};
+		var result = await connector.SendMessageAsync(message, TestContext.Current.CancellationToken);
+		Assert.True(result.IsSuccess());
+	}
+
+	#endregion
+
+	#region Helper Methods
 
 		private async Task<TelegramBotConnector> CreateInitializedConnectorAsync()
 		{

--- a/test/Deveel.Messaging.Connector.Telegram.XUnit/Unit/TelegramBotRegistrationTests.cs
+++ b/test/Deveel.Messaging.Connector.Telegram.XUnit/Unit/TelegramBotRegistrationTests.cs
@@ -82,5 +82,17 @@ namespace Deveel.Messaging
                 d.ServiceType == typeof(IChannelConnector) &&
                 d.ServiceKey?.Equals("bot") == true);
         }
+
+        [Fact]
+        public void Should_RegisterNamedConnector_When_NamedConnectionStringShortcutIsUsed()
+        {
+            var services = CreateServices();
+            services.AddMessaging()
+                .AddTelegramBot("bot", "BotToken=test-token");
+
+            Assert.Contains(services, d =>
+                d.ServiceType == typeof(IChannelConnector) &&
+                d.ServiceKey?.Equals("bot") == true);
+        }
     }
 }

--- a/test/Deveel.Messaging.Connector.Telegram.XUnit/Unit/TelegramInteractiveMappingTests.cs
+++ b/test/Deveel.Messaging.Connector.Telegram.XUnit/Unit/TelegramInteractiveMappingTests.cs
@@ -4,6 +4,7 @@
 //
 
 using Deveel.Messaging.Testing;
+using Telegram.Bot.Types.ReplyMarkups;
 
 namespace Deveel.Messaging;
 
@@ -12,12 +13,33 @@ namespace Deveel.Messaging;
 [Trait("Feature", "TelegramInteractiveMapping")]
 public class TelegramInteractiveMappingTests
 {
+    private static Type _builderType = typeof(TelegramService).Assembly.GetTypes().First(t => t.Name == "TelegramMessageBuilder");
+
+    private static object? InvokeStatic(string methodName, object[] args)
+    {
+        try
+        {
+            var method = _builderType.GetMethod(methodName, System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
+            return method!.Invoke(null, args);
+        }
+        catch (System.Reflection.TargetInvocationException ex)
+        {
+            throw ex.InnerException!;
+        }
+    }
+
+    private static InlineKeyboardMarkup CreateInlineKeyboardMarkup(IEnumerable<IButtonContent> buttons)
+        => (InlineKeyboardMarkup)InvokeStatic("CreateInlineKeyboardMarkup", new object[] { buttons })!;
+
+    private static ReplyKeyboardMarkup CreateReplyKeyboardMarkup(IEnumerable<IQuickReplyContent> quickReplies)
+        => (ReplyKeyboardMarkup)InvokeStatic("CreateReplyKeyboardMarkup", new object[] { quickReplies })!;
+
     [Fact]
     public void Should_MapButtonContent_When_CreateInlineKeyboardMarkup()
     {
         var buttons = InteractiveContentBuilder.CreateButtons(2);
 
-        var markup = TelegramMessageBuilder.CreateInlineKeyboardMarkup(buttons);
+        var markup = CreateInlineKeyboardMarkup(buttons);
 
         TelegramInteractiveMappingAssertions.AssertMapsToInlineKeyboard(buttons, markup);
     }
@@ -28,7 +50,7 @@ public class TelegramInteractiveMappingTests
         var button = new ButtonContent("Call", ButtonType.PhoneNumber, "+1234567890");
 
         Assert.Throws<NotSupportedException>(() =>
-            TelegramMessageBuilder.CreateInlineKeyboardMarkup(new[] { button }));
+            CreateInlineKeyboardMarkup(new[] { button }));
     }
 
     [Fact]
@@ -37,7 +59,7 @@ public class TelegramInteractiveMappingTests
         var button = new ButtonContent("Visit", ButtonType.Url, null);
 
         Assert.Throws<ArgumentException>(() =>
-            TelegramMessageBuilder.CreateInlineKeyboardMarkup(new[] { button }));
+            CreateInlineKeyboardMarkup(new[] { button }));
     }
 
     [Fact]
@@ -46,7 +68,7 @@ public class TelegramInteractiveMappingTests
         var button = new ButtonContent("Visit", ButtonType.Url, "");
 
         Assert.Throws<ArgumentException>(() =>
-            TelegramMessageBuilder.CreateInlineKeyboardMarkup(new[] { button }));
+            CreateInlineKeyboardMarkup(new[] { button }));
     }
 
     [Fact]
@@ -54,7 +76,7 @@ public class TelegramInteractiveMappingTests
     {
         var quickReplies = InteractiveContentBuilder.CreateQuickReplies(3);
 
-        var markup = TelegramMessageBuilder.CreateReplyKeyboardMarkup(quickReplies);
+        var markup = CreateReplyKeyboardMarkup(quickReplies);
 
         TelegramInteractiveMappingAssertions.AssertMapsToReplyKeyboard(quickReplies, markup);
     }

--- a/test/Deveel.Messaging.Connector.Telegram.XUnit/Unit/TelegramMessageBuilderExtensionsTests.cs
+++ b/test/Deveel.Messaging.Connector.Telegram.XUnit/Unit/TelegramMessageBuilderExtensionsTests.cs
@@ -1,0 +1,47 @@
+namespace Deveel.Messaging
+{
+    [Trait("Category", "Unit")]
+    [Trait("Feature", "TelegramMessageBuilder")]
+    public class TelegramMessageBuilderExtensionsTests
+    {
+        [Fact]
+        public void Should_SetParseMode_When_WithParseMode()
+        {
+            var builder = new MessageBuilder();
+            var result = builder.WithParseMode("HTML");
+            Assert.Same(builder, result);
+        }
+
+        [Fact]
+        public void Should_DisableWebPagePreview_When_WithDisableWebPagePreview()
+        {
+            var builder = new MessageBuilder();
+            var result = builder.WithDisableWebPagePreview();
+            Assert.Same(builder, result);
+        }
+
+        [Fact]
+        public void Should_DisableNotification_When_WithDisableNotification()
+        {
+            var builder = new MessageBuilder();
+            var result = builder.WithDisableNotification();
+            Assert.Same(builder, result);
+        }
+
+        [Fact]
+        public void Should_SetReplyToMessageId_When_WithReplyToMessageId()
+        {
+            var builder = new MessageBuilder();
+            var result = builder.WithReplyToMessageId(42);
+            Assert.Same(builder, result);
+        }
+
+        [Fact]
+        public void Should_SetCaption_When_WithCaption()
+        {
+            var builder = new MessageBuilder();
+            var result = builder.WithCaption("test caption");
+            Assert.Same(builder, result);
+        }
+    }
+}

--- a/test/Deveel.Messaging.Connector.Telegram.XUnit/Unit/TelegramMessageBuilderTests.cs
+++ b/test/Deveel.Messaging.Connector.Telegram.XUnit/Unit/TelegramMessageBuilderTests.cs
@@ -1,0 +1,212 @@
+using System.Text.Json;
+using Telegram.Bot.Types.ReplyMarkups;
+
+namespace Deveel.Messaging
+{
+    [Trait("Category", "Unit")]
+    [Trait("Feature", "TelegramMessageBuilder")]
+    public class TelegramMessageBuilderTests
+    {
+        [Fact]
+        public void Should_ReturnNull_When_ExtractChatIdWithNonIdEndpoint()
+        {
+            var endpoint = new Endpoint(EndpointType.EmailAddress, "test@example.com");
+            Assert.Null(TelegramMessageBuilder.ExtractChatId(endpoint));
+        }
+
+        [Fact]
+        public void Should_ReturnNull_When_ExtractChatIdWithNullEndpoint()
+        {
+            Assert.Null(TelegramMessageBuilder.ExtractChatId(null));
+        }
+
+        [Fact]
+        public void Should_ReturnNull_When_ExtractChatIdWithEmptyAddress()
+        {
+            var endpoint = new Endpoint(EndpointType.Id, "");
+            Assert.Null(TelegramMessageBuilder.ExtractChatId(endpoint));
+        }
+
+        [Fact]
+        public void Should_ReturnNumericChatId_When_ExtractChatIdWithNumericAddress()
+        {
+            var endpoint = new Endpoint(EndpointType.Id, "123456789");
+            var chatId = TelegramMessageBuilder.ExtractChatId(endpoint);
+            Assert.NotNull(chatId);
+            Assert.Equal(123456789, chatId.Identifier);
+        }
+
+        [Fact]
+        public void Should_ReturnStringChatId_When_ExtractChatIdWithUsername()
+        {
+            var endpoint = new Endpoint(EndpointType.Id, "@testuser");
+            var chatId = TelegramMessageBuilder.ExtractChatId(endpoint);
+            Assert.NotNull(chatId);
+            Assert.Equal("@testuser", chatId.Username);
+        }
+
+        [Fact]
+        public void Should_ReturnNull_When_GetMessageIntPropertyWithNonParsableValue()
+        {
+            var message = new Message
+            {
+                Id = "test",
+                Properties = new Dictionary<string, MessageProperty>
+                {
+                    { "Count", new MessageProperty("Count", "not-a-number") }
+                }
+            };
+            Assert.Null(TelegramMessageBuilder.GetMessageIntProperty(message, "Count"));
+        }
+
+        [Fact]
+        public void Should_ReturnNull_When_GetMessagePropertyWithMissingProperty()
+        {
+            var message = new Message { Id = "test" };
+            Assert.Null(TelegramMessageBuilder.GetMessageProperty(message, "Missing"));
+        }
+
+        [Fact]
+        public void Should_ReturnParseModeMarkdown_When_GetMessageParseModeWithUnrecognizedMode()
+        {
+            var message = new Message { Id = "test" };
+            var result = TelegramMessageBuilder.GetMessageParseMode(message, "unknown");
+            Assert.Equal(Telegram.Bot.Types.Enums.ParseMode.Markdown, result);
+        }
+
+        [Fact]
+        public void Should_ReturnNull_When_GetMessageParseModeWithNone()
+        {
+            var message = new Message
+            {
+                Id = "test",
+                Properties = new Dictionary<string, MessageProperty>
+                {
+                    { "ParseMode", new MessageProperty("ParseMode", "None") }
+                }
+            };
+            Assert.Null(TelegramMessageBuilder.GetMessageParseMode(message, null));
+        }
+
+        [Fact]
+        public void Should_ReturnNull_When_CreateReplyMarkupWithInvalidInlineKeyboardJson()
+        {
+            var message = new Message
+            {
+                Id = "test",
+                Properties = new Dictionary<string, MessageProperty>
+                {
+                    { "InlineKeyboard", new MessageProperty("InlineKeyboard", "not valid json") }
+                }
+            };
+            Assert.Null(TelegramMessageBuilder.CreateReplyMarkup(message));
+        }
+
+        [Fact]
+        public void Should_ReturnNull_When_CreateReplyMarkupWithNoKeyboard()
+        {
+            var message = new Message { Id = "test" };
+            Assert.Null(TelegramMessageBuilder.CreateReplyMarkup(message));
+        }
+
+        [Fact]
+        public void Should_Throw_When_CreateInlineKeyboardMarkupWithPhoneNumberButton()
+        {
+            var button = new ButtonContent("Call", ButtonType.PhoneNumber, "+1234567890");
+            Assert.Throws<NotSupportedException>(() =>
+                TelegramMessageBuilder.CreateInlineKeyboardMarkup(new[] { button }));
+        }
+
+        [Fact]
+        public void Should_Throw_When_CreateInputFileWithNoUrlOrData()
+        {
+            var media = new MediaContent(MediaType.Image, "test.jpg", (byte[])null!);
+            Assert.Throws<ArgumentException>(() =>
+                TelegramMessageBuilder.CreateInputFile(media));
+        }
+
+        [Fact]
+        public void Should_CreateInputFileFromData_When_MediaHasData()
+        {
+            var media = new MediaContent(MediaType.Image, "test.jpg", new byte[] { 0x01, 0x02 });
+            var inputFile = TelegramMessageBuilder.CreateInputFile(media);
+            Assert.NotNull(inputFile);
+        }
+
+        [Fact]
+        public void Should_ReturnFalse_When_IsLocationMessageWithInvalidJson()
+        {
+            var jsonContent = new JsonContent("not valid json");
+            Assert.False(TelegramMessageBuilder.IsLocationMessage(jsonContent));
+        }
+
+        [Fact]
+        public void Should_ReturnFalse_When_IsLocationMessageWithoutCoordinates()
+        {
+            var jsonContent = new JsonContent("""{"name": "test"}""");
+            Assert.False(TelegramMessageBuilder.IsLocationMessage(jsonContent));
+        }
+
+        [Fact]
+        public void Should_ReturnTrue_When_IsLocationMessageWithCoordinates()
+        {
+            var jsonContent = new JsonContent("""{"latitude": 40.71, "longitude": -74.00}""");
+            Assert.True(TelegramMessageBuilder.IsLocationMessage(jsonContent));
+        }
+
+        [Fact]
+        public void Should_ReturnDefault_When_GetMessageBoolPropertyWithNonParsableValue()
+        {
+            var message = new Message
+            {
+                Id = "test",
+                Properties = new Dictionary<string, MessageProperty>
+                {
+                    { "Flag", new MessageProperty("Flag", "not-a-bool") }
+                }
+            };
+            Assert.False(TelegramMessageBuilder.GetMessageBoolProperty(message, "Flag"));
+        }
+
+        [Fact]
+        public void Should_ReturnTrue_When_GetMessageBoolPropertyWithTrueValue()
+        {
+            var message = new Message
+            {
+                Id = "test",
+                Properties = new Dictionary<string, MessageProperty>
+                {
+                    { "Flag", new MessageProperty("Flag", "true") }
+                }
+            };
+            Assert.True(TelegramMessageBuilder.GetMessageBoolProperty(message, "Flag"));
+        }
+
+        [Fact]
+        public void Should_CreateReplyKeyboardFromQuickReplies_When_CreateReplyKeyboardMarkup()
+        {
+            var quickReplies = new List<IQuickReplyContent>
+            {
+                new QuickReplyContent("Yes"),
+                new QuickReplyContent("No")
+            };
+            var markup = TelegramMessageBuilder.CreateReplyKeyboardMarkup(quickReplies);
+            Assert.NotNull(markup);
+            Assert.True(markup.OneTimeKeyboard);
+            Assert.True(markup.ResizeKeyboard);
+        }
+
+        [Fact]
+        public void Should_CreateInlineKeyboardFromButtons_When_CreateInlineKeyboardMarkup()
+        {
+            var buttons = new List<IButtonContent>
+            {
+                new ButtonContent("Click", ButtonType.Postback, "payload"),
+                new ButtonContent("Visit", ButtonType.Url, "https://example.com")
+            };
+            var markup = TelegramMessageBuilder.CreateInlineKeyboardMarkup(buttons);
+            Assert.NotNull(markup);
+            Assert.Equal(2, markup.InlineKeyboard.Count());
+        }
+    }
+}

--- a/test/Deveel.Messaging.Connector.Telegram.XUnit/Unit/TelegramMessageBuilderTests.cs
+++ b/test/Deveel.Messaging.Connector.Telegram.XUnit/Unit/TelegramMessageBuilderTests.cs
@@ -1,4 +1,6 @@
 using System.Text.Json;
+using Telegram.Bot.Types;
+using Telegram.Bot.Types.Enums;
 using Telegram.Bot.Types.ReplyMarkups;
 
 namespace Deveel.Messaging
@@ -7,31 +9,76 @@ namespace Deveel.Messaging
     [Trait("Feature", "TelegramMessageBuilder")]
     public class TelegramMessageBuilderTests
     {
+        private static Type _builderType = typeof(TelegramService).Assembly.GetTypes().First(t => t.Name == "TelegramMessageBuilder");
+
+        private static object? InvokeStatic(string methodName, object[] args)
+        {
+            try
+            {
+                var method = _builderType.GetMethod(methodName, System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
+                return method!.Invoke(null, args);
+            }
+            catch (System.Reflection.TargetInvocationException ex)
+            {
+                throw ex.InnerException!;
+            }
+        }
+
+        private static ChatId? ExtractChatId(Endpoint? endpoint)
+            => (ChatId?)InvokeStatic("ExtractChatId", new object?[] { endpoint });
+
+        private static int? GetMessageIntProperty(Message message, string propertyName)
+            => (int?)InvokeStatic("GetMessageIntProperty", new object[] { message, propertyName });
+
+        private static MessageProperty? GetMessageProperty(Message message, string propertyName)
+            => (MessageProperty?)InvokeStatic("GetMessageProperty", new object[] { message, propertyName });
+
+        private static ParseMode? GetMessageParseMode(Message message, string? defaultParseMode)
+            => (ParseMode?)InvokeStatic("GetMessageParseMode", new object?[] { message, defaultParseMode });
+
+        private static IReplyMarkup? CreateReplyMarkup(Message message)
+            => (IReplyMarkup?)InvokeStatic("CreateReplyMarkup", new object[] { message });
+
+        private static InlineKeyboardMarkup CreateInlineKeyboardMarkup(IEnumerable<IButtonContent> buttons)
+            => (InlineKeyboardMarkup)InvokeStatic("CreateInlineKeyboardMarkup", new object[] { buttons })!;
+
+        private static InputFile? CreateInputFile(MediaContent media)
+            => (InputFile?)InvokeStatic("CreateInputFile", new object[] { media });
+
+        private static bool IsLocationMessage(JsonContent jsonContent)
+            => (bool)InvokeStatic("IsLocationMessage", new object[] { jsonContent })!;
+
+        private static bool? GetMessageBoolProperty(Message message, string propertyName)
+            => (bool?)InvokeStatic("GetMessageBoolProperty", new object[] { message, propertyName, false });
+
+        private static ReplyKeyboardMarkup CreateReplyKeyboardMarkup(IEnumerable<IQuickReplyContent> quickReplies)
+            => (ReplyKeyboardMarkup)InvokeStatic("CreateReplyKeyboardMarkup", new object[] { quickReplies })!;
+
         [Fact]
         public void Should_ReturnNull_When_ExtractChatIdWithNonIdEndpoint()
         {
             var endpoint = new Endpoint(EndpointType.EmailAddress, "test@example.com");
-            Assert.Null(TelegramMessageBuilder.ExtractChatId(endpoint));
+            Assert.Null(ExtractChatId(endpoint));
         }
 
         [Fact]
         public void Should_ReturnNull_When_ExtractChatIdWithNullEndpoint()
         {
-            Assert.Null(TelegramMessageBuilder.ExtractChatId(null));
+            Assert.Null(ExtractChatId(null));
         }
 
         [Fact]
         public void Should_ReturnNull_When_ExtractChatIdWithEmptyAddress()
         {
             var endpoint = new Endpoint(EndpointType.Id, "");
-            Assert.Null(TelegramMessageBuilder.ExtractChatId(endpoint));
+            Assert.Null(ExtractChatId(endpoint));
         }
 
         [Fact]
         public void Should_ReturnNumericChatId_When_ExtractChatIdWithNumericAddress()
         {
             var endpoint = new Endpoint(EndpointType.Id, "123456789");
-            var chatId = TelegramMessageBuilder.ExtractChatId(endpoint);
+            var chatId = ExtractChatId(endpoint);
             Assert.NotNull(chatId);
             Assert.Equal(123456789, chatId.Identifier);
         }
@@ -40,7 +87,7 @@ namespace Deveel.Messaging
         public void Should_ReturnStringChatId_When_ExtractChatIdWithUsername()
         {
             var endpoint = new Endpoint(EndpointType.Id, "@testuser");
-            var chatId = TelegramMessageBuilder.ExtractChatId(endpoint);
+            var chatId = ExtractChatId(endpoint);
             Assert.NotNull(chatId);
             Assert.Equal("@testuser", chatId.Username);
         }
@@ -56,21 +103,21 @@ namespace Deveel.Messaging
                     { "Count", new MessageProperty("Count", "not-a-number") }
                 }
             };
-            Assert.Null(TelegramMessageBuilder.GetMessageIntProperty(message, "Count"));
+            Assert.Null(GetMessageIntProperty(message, "Count"));
         }
 
         [Fact]
         public void Should_ReturnNull_When_GetMessagePropertyWithMissingProperty()
         {
             var message = new Message { Id = "test" };
-            Assert.Null(TelegramMessageBuilder.GetMessageProperty(message, "Missing"));
+            Assert.Null(GetMessageProperty(message, "Missing"));
         }
 
         [Fact]
         public void Should_ReturnParseModeMarkdown_When_GetMessageParseModeWithUnrecognizedMode()
         {
             var message = new Message { Id = "test" };
-            var result = TelegramMessageBuilder.GetMessageParseMode(message, "unknown");
+            var result = GetMessageParseMode(message, "unknown");
             Assert.Equal(Telegram.Bot.Types.Enums.ParseMode.Markdown, result);
         }
 
@@ -85,7 +132,7 @@ namespace Deveel.Messaging
                     { "ParseMode", new MessageProperty("ParseMode", "None") }
                 }
             };
-            Assert.Null(TelegramMessageBuilder.GetMessageParseMode(message, null));
+            Assert.Null(GetMessageParseMode(message, null));
         }
 
         [Fact]
@@ -99,14 +146,14 @@ namespace Deveel.Messaging
                     { "InlineKeyboard", new MessageProperty("InlineKeyboard", "not valid json") }
                 }
             };
-            Assert.Null(TelegramMessageBuilder.CreateReplyMarkup(message));
+            Assert.Null(CreateReplyMarkup(message));
         }
 
         [Fact]
         public void Should_ReturnNull_When_CreateReplyMarkupWithNoKeyboard()
         {
             var message = new Message { Id = "test" };
-            Assert.Null(TelegramMessageBuilder.CreateReplyMarkup(message));
+            Assert.Null(CreateReplyMarkup(message));
         }
 
         [Fact]
@@ -114,7 +161,7 @@ namespace Deveel.Messaging
         {
             var button = new ButtonContent("Call", ButtonType.PhoneNumber, "+1234567890");
             Assert.Throws<NotSupportedException>(() =>
-                TelegramMessageBuilder.CreateInlineKeyboardMarkup(new[] { button }));
+                CreateInlineKeyboardMarkup(new[] { button }));
         }
 
         [Fact]
@@ -122,14 +169,14 @@ namespace Deveel.Messaging
         {
             var media = new MediaContent(MediaType.Image, "test.jpg", (byte[])null!);
             Assert.Throws<ArgumentException>(() =>
-                TelegramMessageBuilder.CreateInputFile(media));
+                CreateInputFile(media));
         }
 
         [Fact]
         public void Should_CreateInputFileFromData_When_MediaHasData()
         {
             var media = new MediaContent(MediaType.Image, "test.jpg", new byte[] { 0x01, 0x02 });
-            var inputFile = TelegramMessageBuilder.CreateInputFile(media);
+            var inputFile = CreateInputFile(media);
             Assert.NotNull(inputFile);
         }
 
@@ -137,21 +184,21 @@ namespace Deveel.Messaging
         public void Should_ReturnFalse_When_IsLocationMessageWithInvalidJson()
         {
             var jsonContent = new JsonContent("not valid json");
-            Assert.False(TelegramMessageBuilder.IsLocationMessage(jsonContent));
+            Assert.False(IsLocationMessage(jsonContent));
         }
 
         [Fact]
         public void Should_ReturnFalse_When_IsLocationMessageWithoutCoordinates()
         {
             var jsonContent = new JsonContent("""{"name": "test"}""");
-            Assert.False(TelegramMessageBuilder.IsLocationMessage(jsonContent));
+            Assert.False(IsLocationMessage(jsonContent));
         }
 
         [Fact]
         public void Should_ReturnTrue_When_IsLocationMessageWithCoordinates()
         {
             var jsonContent = new JsonContent("""{"latitude": 40.71, "longitude": -74.00}""");
-            Assert.True(TelegramMessageBuilder.IsLocationMessage(jsonContent));
+            Assert.True(IsLocationMessage(jsonContent));
         }
 
         [Fact]
@@ -165,7 +212,7 @@ namespace Deveel.Messaging
                     { "Flag", new MessageProperty("Flag", "not-a-bool") }
                 }
             };
-            Assert.False(TelegramMessageBuilder.GetMessageBoolProperty(message, "Flag"));
+            Assert.False(GetMessageBoolProperty(message, "Flag"));
         }
 
         [Fact]
@@ -179,7 +226,7 @@ namespace Deveel.Messaging
                     { "Flag", new MessageProperty("Flag", "true") }
                 }
             };
-            Assert.True(TelegramMessageBuilder.GetMessageBoolProperty(message, "Flag"));
+            Assert.True(GetMessageBoolProperty(message, "Flag"));
         }
 
         [Fact]
@@ -190,7 +237,7 @@ namespace Deveel.Messaging
                 new QuickReplyContent("Yes"),
                 new QuickReplyContent("No")
             };
-            var markup = TelegramMessageBuilder.CreateReplyKeyboardMarkup(quickReplies);
+            var markup = CreateReplyKeyboardMarkup(quickReplies);
             Assert.NotNull(markup);
             Assert.True(markup.OneTimeKeyboard);
             Assert.True(markup.ResizeKeyboard);
@@ -204,7 +251,7 @@ namespace Deveel.Messaging
                 new ButtonContent("Click", ButtonType.Postback, "payload"),
                 new ButtonContent("Visit", ButtonType.Url, "https://example.com")
             };
-            var markup = TelegramMessageBuilder.CreateInlineKeyboardMarkup(buttons);
+            var markup = CreateInlineKeyboardMarkup(buttons);
             Assert.NotNull(markup);
             Assert.Equal(2, markup.InlineKeyboard.Count());
         }

--- a/test/Deveel.Messaging.Connector.Telegram.XUnit/Unit/TelegramMessageParserTests.cs
+++ b/test/Deveel.Messaging.Connector.Telegram.XUnit/Unit/TelegramMessageParserTests.cs
@@ -1,0 +1,182 @@
+using System.Text.Json;
+
+namespace Deveel.Messaging
+{
+    [Trait("Category", "Unit")]
+    [Trait("Feature", "TelegramMessageParser")]
+    public class TelegramMessageParserTests
+    {
+        [Fact]
+        public void Should_ReturnEmpty_When_ParseWebhookJsonWithNoMessageOrEditedMessage()
+        {
+            var source = MessageSource.Json("""{"update_id": 123}""");
+            var messages = TelegramMessageParser.ParseWebhookJson(source);
+            Assert.Empty(messages);
+        }
+
+        [Fact]
+        public void Should_ParseTextMessage_When_ParseWebhookJsonWithTextMessage()
+        {
+            var source = MessageSource.Json("""
+            {
+                "update_id": 1,
+                "message": {
+                    "message_id": 100,
+                    "from": {"id": 111, "is_bot": false, "first_name": "User"},
+                    "chat": {"id": 222, "type": "private"},
+                    "date": 1640995200,
+                    "text": "Hello"
+                }
+            }
+            """);
+            var messages = TelegramMessageParser.ParseWebhookJson(source);
+            Assert.Single(messages);
+            var msg = messages[0];
+            Assert.Equal("100", msg.Id);
+            Assert.IsType<TextContent>(msg.Content);
+            Assert.Equal("Hello", ((TextContent)msg.Content).Text);
+        }
+
+        [Fact]
+        public void Should_ParseEditedMessage_When_ParseWebhookJsonWithEditedMessage()
+        {
+            var source = MessageSource.Json("""
+            {
+                "update_id": 2,
+                "edited_message": {
+                    "message_id": 200,
+                    "from": {"id": 111, "is_bot": false, "first_name": "User"},
+                    "chat": {"id": 222, "type": "private"},
+                    "date": 1640995200,
+                    "text": "Edited"
+                }
+            }
+            """);
+            var messages = TelegramMessageParser.ParseWebhookJson(source);
+            Assert.Single(messages);
+        }
+
+        [Fact]
+        public void Should_ReturnEmpty_When_ParseWebhookJsonWithMalformedData()
+        {
+            var source = MessageSource.Json("{ invalid json }");
+            Assert.Throws<JsonException>(() => TelegramMessageParser.ParseWebhookJson(source));
+        }
+
+        [Fact]
+        public void Should_ReturnNull_When_ParseMessageWithoutMessageId()
+        {
+            var json = """{"from": {"id": 1}, "chat": {"id": 2}}""";
+            var element = System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.JsonElement>(json);
+            Assert.Null(TelegramMessageParser.ParseMessage(element));
+        }
+
+        [Fact]
+        public void Should_ReturnNull_When_ParseMessageWithoutFromOrChat()
+        {
+            var json = """{"message_id": 1, "from": {"id": 1}}""";
+            var element = System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.JsonElement>(json);
+            Assert.Null(TelegramMessageParser.ParseMessage(element));
+        }
+
+        [Fact]
+        public void Should_ParseVideoMessage_When_ParseWebhookJsonWithVideo()
+        {
+            var source = MessageSource.Json("""
+            {
+                "update_id": 3,
+                "message": {
+                    "message_id": 300,
+                    "from": {"id": 111, "is_bot": false, "first_name": "User"},
+                    "chat": {"id": 222, "type": "private"},
+                    "date": 1640995200,
+                    "video": {"file_id": "video123", "file_size": 1024, "width": 640, "height": 480}
+                }
+            }
+            """);
+            var messages = TelegramMessageParser.ParseWebhookJson(source);
+            Assert.Single(messages);
+            Assert.IsType<MediaContent>(messages[0].Content);
+            Assert.Equal(MediaType.Video, ((MediaContent)messages[0].Content).MediaType);
+        }
+
+        [Fact]
+        public void Should_ParseAudioMessage_When_ParseWebhookJsonWithAudio()
+        {
+            var source = MessageSource.Json("""
+            {
+                "update_id": 4,
+                "message": {
+                    "message_id": 400,
+                    "from": {"id": 111, "is_bot": false, "first_name": "User"},
+                    "chat": {"id": 222, "type": "private"},
+                    "date": 1640995200,
+                    "audio": {"file_id": "audio123", "file_size": 2048, "duration": 120}
+                }
+            }
+            """);
+            var messages = TelegramMessageParser.ParseWebhookJson(source);
+            Assert.Single(messages);
+            Assert.IsType<MediaContent>(messages[0].Content);
+            Assert.Equal(MediaType.Audio, ((MediaContent)messages[0].Content).MediaType);
+        }
+
+        [Fact]
+        public void Should_ParseDocumentMessage_When_ParseWebhookJsonWithDocument()
+        {
+            var source = MessageSource.Json("""
+            {
+                "update_id": 5,
+                "message": {
+                    "message_id": 500,
+                    "from": {"id": 111, "is_bot": false, "first_name": "User"},
+                    "chat": {"id": 222, "type": "private"},
+                    "date": 1640995200,
+                    "document": {"file_id": "doc123", "file_size": 4096}
+                }
+            }
+            """);
+            var messages = TelegramMessageParser.ParseWebhookJson(source);
+            Assert.Single(messages);
+            Assert.IsType<MediaContent>(messages[0].Content);
+            Assert.Equal(MediaType.Document, ((MediaContent)messages[0].Content).MediaType);
+        }
+
+        [Fact]
+        public void Should_ParseReplyMessage_When_ParseWebhookJsonWithReplyToMessage()
+        {
+            var source = MessageSource.Json("""
+            {
+                "update_id": 6,
+                "message": {
+                    "message_id": 600,
+                    "from": {"id": 111, "is_bot": false, "first_name": "User"},
+                    "chat": {"id": 222, "type": "private"},
+                    "date": 1640995200,
+                    "text": "A reply",
+                    "reply_to_message": {
+                        "message_id": 1,
+                        "from": {"id": 333, "is_bot": true, "first_name": "Bot"},
+                        "chat": {"id": 222, "type": "private"},
+                        "date": 1640995100,
+                        "text": "Original"
+                    }
+                }
+            }
+            """);
+            var messages = TelegramMessageParser.ParseWebhookJson(source);
+            Assert.Single(messages);
+            Assert.True(messages[0].Properties?.ContainsKey("ReplyToMessageId"));
+        }
+
+        [Fact]
+        public void Should_ReturnTextContent_When_ParseMessageWithUnknownContent()
+        {
+            var json = """{"message_id": 1, "from": {"id": 1}, "chat": {"id": 2}, "date": 1640995200}""";
+            var element = System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.JsonElement>(json);
+            var message = TelegramMessageParser.ParseMessage(element);
+            Assert.NotNull(message);
+            Assert.IsType<TextContent>(message.Content);
+        }
+    }
+}

--- a/test/Deveel.Messaging.Connector.Telegram.XUnit/Unit/TelegramMessageParserTests.cs
+++ b/test/Deveel.Messaging.Connector.Telegram.XUnit/Unit/TelegramMessageParserTests.cs
@@ -6,11 +6,37 @@ namespace Deveel.Messaging
     [Trait("Feature", "TelegramMessageParser")]
     public class TelegramMessageParserTests
     {
+        private static Type _parserType = typeof(TelegramService).Assembly.GetTypes().First(t => t.Name == "TelegramMessageParser");
+
+        private static object? InvokeStatic(string methodName, object[] args)
+        {
+            try
+            {
+                var method = _parserType.GetMethod(methodName, System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
+                return method!.Invoke(null, args);
+            }
+            catch (System.Reflection.TargetInvocationException ex)
+            {
+                throw ex.InnerException!;
+            }
+        }
+
+        private static List<Message> ParseWebhookJson(MessageSource source)
+        {
+            var result = InvokeStatic("ParseWebhookJson", new object[] { source });
+            return ((System.Collections.IEnumerable)result!).OfType<Message>().ToList();
+        }
+
+        private static Message? ParseMessage(JsonElement element)
+        {
+            return (Message?)InvokeStatic("ParseMessage", new object[] { element });
+        }
+
         [Fact]
         public void Should_ReturnEmpty_When_ParseWebhookJsonWithNoMessageOrEditedMessage()
         {
             var source = MessageSource.Json("""{"update_id": 123}""");
-            var messages = TelegramMessageParser.ParseWebhookJson(source);
+            var messages = ParseWebhookJson(source);
             Assert.Empty(messages);
         }
 
@@ -29,7 +55,7 @@ namespace Deveel.Messaging
                 }
             }
             """);
-            var messages = TelegramMessageParser.ParseWebhookJson(source);
+            var messages = ParseWebhookJson(source);
             Assert.Single(messages);
             var msg = messages[0];
             Assert.Equal("100", msg.Id);
@@ -52,7 +78,7 @@ namespace Deveel.Messaging
                 }
             }
             """);
-            var messages = TelegramMessageParser.ParseWebhookJson(source);
+            var messages = ParseWebhookJson(source);
             Assert.Single(messages);
         }
 
@@ -60,7 +86,7 @@ namespace Deveel.Messaging
         public void Should_ReturnEmpty_When_ParseWebhookJsonWithMalformedData()
         {
             var source = MessageSource.Json("{ invalid json }");
-            Assert.Throws<JsonException>(() => TelegramMessageParser.ParseWebhookJson(source));
+            Assert.Throws<JsonException>(() => ParseWebhookJson(source));
         }
 
         [Fact]
@@ -68,7 +94,7 @@ namespace Deveel.Messaging
         {
             var json = """{"from": {"id": 1}, "chat": {"id": 2}}""";
             var element = System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.JsonElement>(json);
-            Assert.Null(TelegramMessageParser.ParseMessage(element));
+            Assert.Null(ParseMessage(element));
         }
 
         [Fact]
@@ -76,7 +102,7 @@ namespace Deveel.Messaging
         {
             var json = """{"message_id": 1, "from": {"id": 1}}""";
             var element = System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.JsonElement>(json);
-            Assert.Null(TelegramMessageParser.ParseMessage(element));
+            Assert.Null(ParseMessage(element));
         }
 
         [Fact]
@@ -94,7 +120,7 @@ namespace Deveel.Messaging
                 }
             }
             """);
-            var messages = TelegramMessageParser.ParseWebhookJson(source);
+            var messages = ParseWebhookJson(source);
             Assert.Single(messages);
             Assert.IsType<MediaContent>(messages[0].Content);
             Assert.Equal(MediaType.Video, ((MediaContent)messages[0].Content).MediaType);
@@ -115,7 +141,7 @@ namespace Deveel.Messaging
                 }
             }
             """);
-            var messages = TelegramMessageParser.ParseWebhookJson(source);
+            var messages = ParseWebhookJson(source);
             Assert.Single(messages);
             Assert.IsType<MediaContent>(messages[0].Content);
             Assert.Equal(MediaType.Audio, ((MediaContent)messages[0].Content).MediaType);
@@ -136,7 +162,7 @@ namespace Deveel.Messaging
                 }
             }
             """);
-            var messages = TelegramMessageParser.ParseWebhookJson(source);
+            var messages = ParseWebhookJson(source);
             Assert.Single(messages);
             Assert.IsType<MediaContent>(messages[0].Content);
             Assert.Equal(MediaType.Document, ((MediaContent)messages[0].Content).MediaType);
@@ -164,7 +190,7 @@ namespace Deveel.Messaging
                 }
             }
             """);
-            var messages = TelegramMessageParser.ParseWebhookJson(source);
+            var messages = ParseWebhookJson(source);
             Assert.Single(messages);
             Assert.True(messages[0].Properties?.ContainsKey("ReplyToMessageId"));
         }
@@ -174,7 +200,7 @@ namespace Deveel.Messaging
         {
             var json = """{"message_id": 1, "from": {"id": 1}, "chat": {"id": 2}, "date": 1640995200}""";
             var element = System.Text.Json.JsonSerializer.Deserialize<System.Text.Json.JsonElement>(json);
-            var message = TelegramMessageParser.ParseMessage(element);
+            var message = ParseMessage(element);
             Assert.NotNull(message);
             Assert.IsType<TextContent>(message.Content);
         }

--- a/test/Deveel.Messaging.Connector.Telegram.XUnit/Unit/TelegramServiceTests.cs
+++ b/test/Deveel.Messaging.Connector.Telegram.XUnit/Unit/TelegramServiceTests.cs
@@ -22,6 +22,13 @@ namespace Deveel.Messaging
 	{
 		private const string ValidToken = "123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZ123456789";
 
+		private static bool IsValidBotToken(string token)
+		{
+			var method = typeof(TelegramService).GetMethod("IsValidBotToken",
+				System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+			return (bool)method!.Invoke(null, new object[] { token })!;
+		}
+
 		#region Constructor Tests
 
 		[Fact]
@@ -1521,37 +1528,37 @@ namespace Deveel.Messaging
 		[InlineData(null)]
 		public void Should_ReturnFalse_When_IsValidBotTokenWithNullOrWhitespace(string? token)
 		{
-			Assert.False(TelegramService.IsValidBotToken(token!));
+			Assert.False(IsValidBotToken(token!));
 		}
 
 		[Fact]
 		public void Should_ReturnFalse_When_IsValidBotTokenWithoutColon()
 		{
-			Assert.False(TelegramService.IsValidBotToken("invalidtoken"));
+			Assert.False(IsValidBotToken("invalidtoken"));
 		}
 
 		[Fact]
 		public void Should_ReturnFalse_When_IsValidBotTokenWithNonNumericPrefix()
 		{
-			Assert.False(TelegramService.IsValidBotToken("abc:defghijklmnopqrstuvwxyz1234567890ab"));
+			Assert.False(IsValidBotToken("abc:defghijklmnopqrstuvwxyz1234567890ab"));
 		}
 
 		[Fact]
 		public void Should_ReturnFalse_When_IsValidBotTokenWithWrongLengthToken()
 		{
-			Assert.False(TelegramService.IsValidBotToken("12345:tooshort"));
+			Assert.False(IsValidBotToken("12345:tooshort"));
 		}
 
 		[Fact]
 		public void Should_ReturnFalse_When_IsValidBotTokenWithInvalidCharacters()
 		{
-			Assert.False(TelegramService.IsValidBotToken("12345:ABCDEFGHIJKLMNOPQRSTUVWXYZ12345!@#$%"));
+			Assert.False(IsValidBotToken("12345:ABCDEFGHIJKLMNOPQRSTUVWXYZ12345!@#$%"));
 		}
 
 		[Fact]
 		public void Should_ReturnTrue_When_IsValidBotTokenWithValidToken()
 		{
-			Assert.True(TelegramService.IsValidBotToken("123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi"));
+			Assert.True(IsValidBotToken("123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi"));
 		}
 
 		[Fact]

--- a/test/Deveel.Messaging.Connector.Telegram.XUnit/Unit/TelegramServiceTests.cs
+++ b/test/Deveel.Messaging.Connector.Telegram.XUnit/Unit/TelegramServiceTests.cs
@@ -5,6 +5,7 @@
 
 using Moq;
 using Telegram.Bot;
+using Telegram.Bot.Exceptions;
 using Telegram.Bot.Requests;
 using Telegram.Bot.Types;
 using Telegram.Bot.Types.ReplyMarkups;
@@ -117,6 +118,20 @@ namespace Deveel.Messaging
 
 			// Assert
 			Assert.True(true);
+		}
+
+		[Theory]
+		[InlineData("123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567!")]
+		[InlineData("123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567@")]
+		[InlineData("123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567#")]
+		public void Should_ThrowArgumentException_When_InitializeWithTokenContainingInvalidCharacters(string token)
+		{
+			// Arrange
+			var service = new TelegramService();
+
+			// Act
+			// Assert
+			Assert.Throws<ArgumentException>(() => service.Initialize(token));
 		}
 
 		#endregion
@@ -322,6 +337,49 @@ namespace Deveel.Messaging
 			Assert.NotNull(result);
 			mockBotClient.Verify(x => x.SendRequest<Telegram.Bot.Types.Message>(
 				It.Is<SendMessageRequest>(req => req.ParseMode == Telegram.Bot.Types.Enums.ParseMode.Markdown),
+				It.IsAny<CancellationToken>()), Times.Once);
+		}
+
+		[Fact]
+		public async Task Should_CallBotClientWithAllParameters_When_SendTextMessageAsyncWithAllParameters()
+		{
+			// Arrange
+			var mockBotClient = new Mock<ITelegramBotClient>();
+			var expectedMessage = TelegramMockFactory.CreateTestTelegramMessage();
+			var service = new TelegramService(mockBotClient.Object);
+			var replyMarkup = new InlineKeyboardMarkup(InlineKeyboardButton.WithCallbackData("Test", "test"));
+
+			mockBotClient.Setup(x => x.SendRequest<Telegram.Bot.Types.Message>(
+				It.IsAny<SendMessageRequest>(),
+				It.IsAny<CancellationToken>()))
+				.ReturnsAsync(expectedMessage);
+
+			service.Initialize(ValidToken);
+
+			// Act
+			var result = await service.SendTextMessageAsync(
+				123456,
+				"Test message with **bold** text",
+				parseMode: Telegram.Bot.Types.Enums.ParseMode.Markdown,
+				disableWebPagePreview: true,
+				disableNotification: true,
+				replyToMessageId: 999,
+				replyMarkup: replyMarkup,
+				cancellationToken: TestContext.Current.CancellationToken);
+
+			// Assert
+			Assert.NotNull(result);
+			mockBotClient.Verify(x => x.SendRequest<Telegram.Bot.Types.Message>(
+				It.Is<SendMessageRequest>(req =>
+					req.ChatId.Identifier == 123456 &&
+					req.Text == "Test message with **bold** text" &&
+					req.ParseMode == Telegram.Bot.Types.Enums.ParseMode.Markdown &&
+					req.LinkPreviewOptions != null &&
+					req.LinkPreviewOptions.IsDisabled == true &&
+					req.DisableNotification == true &&
+					req.ReplyParameters != null &&
+					req.ReplyParameters.MessageId == 999 &&
+					req.ReplyMarkup == replyMarkup),
 				It.IsAny<CancellationToken>()), Times.Once);
 		}
 
@@ -1168,6 +1226,29 @@ namespace Deveel.Messaging
 		}
 
 		[Fact]
+		public async Task Should_CallBotClient_When_DeleteWebhookAsyncWithDefaultParameters()
+		{
+			// Arrange
+			var mockBotClient = new Mock<ITelegramBotClient>();
+			var service = new TelegramService(mockBotClient.Object);
+
+			mockBotClient.Setup(x => x.SendRequest<bool>(
+				It.IsAny<DeleteWebhookRequest>(),
+				It.IsAny<CancellationToken>()))
+				.ReturnsAsync(true);
+
+			service.Initialize(ValidToken);
+
+			// Act
+			await service.DeleteWebhookAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+			// Assert
+			mockBotClient.Verify(x => x.SendRequest<bool>(
+				It.Is<DeleteWebhookRequest>(req => req.DropPendingUpdates == false),
+				It.IsAny<CancellationToken>()), Times.Once);
+		}
+
+		[Fact]
 		public async Task Should_CallBotClientWithParameter_When_DeleteWebhookAsyncWithDropPendingUpdates()
 		{
 			// Arrange
@@ -1257,6 +1338,160 @@ namespace Deveel.Messaging
 
 		#endregion
 
+		#region Api Error Mapping Tests
+
+		[Theory]
+		[InlineData(400, MessagingErrorCodes.InvalidCredentials)]
+		[InlineData(401, TelegramErrorCodes.Unauthorized)]
+		[InlineData(403, TelegramErrorCodes.BotBlocked)]
+		[InlineData(404, TelegramErrorCodes.ChatNotFound)]
+		[InlineData(429, MessagingErrorCodes.UnsupportedContentType)]
+		[InlineData(500, TelegramErrorCodes.Unauthorized)]
+		public async Task Should_MapTelegramErrorCode_When_GetMeAsyncThrowsApiException(int errorCode, string expectedErrorCode)
+		{
+			// Arrange
+			var mockBotClient = new Mock<ITelegramBotClient>();
+			var service = new TelegramService(mockBotClient.Object);
+
+			mockBotClient.Setup(x => x.SendRequest<User>(
+				It.IsAny<GetMeRequest>(),
+				It.IsAny<CancellationToken>()))
+				.ThrowsAsync(new ApiRequestException($"Error {errorCode}", errorCode));
+
+			service.Initialize(ValidToken);
+
+			// Act
+			var exception = await Assert.ThrowsAsync<ConnectorException>(
+				() => service.GetMeAsync(TestContext.Current.CancellationToken));
+
+			// Assert
+			Assert.Equal(expectedErrorCode, exception.ErrorCode);
+			Assert.Equal(TelegramErrorCodes.ErrorDomain, exception.ErrorDomain);
+		}
+
+		[Theory]
+		[InlineData(400, TelegramErrorCodes.InvalidChatId)]
+		[InlineData(403, TelegramErrorCodes.BotBlocked)]
+		[InlineData(404, TelegramErrorCodes.ChatNotFound)]
+		[InlineData(429, MessagingErrorCodes.UnsupportedContentType)]
+		[InlineData(500, MessagingErrorCodes.UnsupportedContentType)]
+		public async Task Should_MapTelegramSendErrorCode_When_SendTextMessageAsyncThrowsApiException(int errorCode, string expectedErrorCode)
+		{
+			// Arrange
+			var mockBotClient = new Mock<ITelegramBotClient>();
+			var service = new TelegramService(mockBotClient.Object);
+
+			mockBotClient.Setup(x => x.SendRequest<Telegram.Bot.Types.Message>(
+				It.IsAny<SendMessageRequest>(),
+				It.IsAny<CancellationToken>()))
+				.ThrowsAsync(new ApiRequestException($"Error {errorCode}", errorCode));
+
+			service.Initialize(ValidToken);
+
+			// Act
+			var exception = await Assert.ThrowsAsync<ConnectorException>(
+				() => service.SendTextMessageAsync(123456, "test", cancellationToken: TestContext.Current.CancellationToken));
+
+			// Assert
+			Assert.Equal(expectedErrorCode, exception.ErrorCode);
+			Assert.Equal(TelegramErrorCodes.ErrorDomain, exception.ErrorDomain);
+		}
+
+		[Fact]
+		public async Task Should_ThrowConnectorException_When_SendPhotoAsyncThrowsApiException()
+		{
+			// Arrange
+			var mockBotClient = new Mock<ITelegramBotClient>();
+			var service = new TelegramService(mockBotClient.Object);
+			var photoFile = InputFile.FromUri("https://example.com/photo.jpg");
+
+			mockBotClient.Setup(x => x.SendRequest<Telegram.Bot.Types.Message>(
+				It.IsAny<SendPhotoRequest>(),
+				It.IsAny<CancellationToken>()))
+				.ThrowsAsync(new ApiRequestException("Forbidden", 403));
+
+			service.Initialize(ValidToken);
+
+			// Act
+			var exception = await Assert.ThrowsAsync<ConnectorException>(
+				() => service.SendPhotoAsync(123456, photoFile, cancellationToken: TestContext.Current.CancellationToken));
+
+			// Assert
+			Assert.Equal(TelegramErrorCodes.BotBlocked, exception.ErrorCode);
+			Assert.Equal(TelegramErrorCodes.ErrorDomain, exception.ErrorDomain);
+		}
+
+		[Fact]
+		public async Task Should_ThrowConnectorException_When_SetWebhookAsyncThrowsApiException()
+		{
+			// Arrange
+			var mockBotClient = new Mock<ITelegramBotClient>();
+			var service = new TelegramService(mockBotClient.Object);
+
+			mockBotClient.Setup(x => x.SendRequest<bool>(
+				It.IsAny<SetWebhookRequest>(),
+				It.IsAny<CancellationToken>()))
+				.ThrowsAsync(new ApiRequestException("Bad Request", 400));
+
+			service.Initialize(ValidToken);
+
+			// Act
+			var exception = await Assert.ThrowsAsync<ConnectorException>(
+				() => service.SetWebhookAsync("https://example.com/webhook", cancellationToken: TestContext.Current.CancellationToken));
+
+			// Assert
+			Assert.Equal(MessagingErrorCodes.UnsupportedContentType, exception.ErrorCode);
+			Assert.Equal(TelegramErrorCodes.ErrorDomain, exception.ErrorDomain);
+		}
+
+		[Fact]
+		public async Task Should_ThrowConnectorException_When_GetWebhookInfoAsyncThrowsApiException()
+		{
+			// Arrange
+			var mockBotClient = new Mock<ITelegramBotClient>();
+			var service = new TelegramService(mockBotClient.Object);
+
+			mockBotClient.Setup(x => x.SendRequest<WebhookInfo>(
+				It.IsAny<GetWebhookInfoRequest>(),
+				It.IsAny<CancellationToken>()))
+				.ThrowsAsync(new ApiRequestException("Not Found", 404));
+
+			service.Initialize(ValidToken);
+
+			// Act
+			var exception = await Assert.ThrowsAsync<ConnectorException>(
+				() => service.GetWebhookInfoAsync(TestContext.Current.CancellationToken));
+
+			// Assert
+			Assert.Equal(MessagingErrorCodes.UnsupportedContentType, exception.ErrorCode);
+			Assert.Equal(TelegramErrorCodes.ErrorDomain, exception.ErrorDomain);
+		}
+
+		[Fact]
+		public async Task Should_ThrowConnectorException_When_GetUpdatesAsyncThrowsApiException()
+		{
+			// Arrange
+			var mockBotClient = new Mock<ITelegramBotClient>();
+			var service = new TelegramService(mockBotClient.Object);
+
+			mockBotClient.Setup(x => x.SendRequest<Update[]>(
+				It.IsAny<GetUpdatesRequest>(),
+				It.IsAny<CancellationToken>()))
+				.ThrowsAsync(new ApiRequestException("Conflict", 409));
+
+			service.Initialize(ValidToken);
+
+			// Act
+			var exception = await Assert.ThrowsAsync<ConnectorException>(
+				() => service.GetUpdatesAsync(cancellationToken: TestContext.Current.CancellationToken));
+
+			// Assert
+			Assert.Equal(MessagingErrorCodes.UnsupportedContentType, exception.ErrorCode);
+			Assert.Equal(TelegramErrorCodes.ErrorDomain, exception.ErrorDomain);
+		}
+
+		#endregion
+
 		#region Additional Coverage Tests
 
 		[Fact]
@@ -1280,6 +1515,66 @@ namespace Deveel.Messaging
 			Assert.Contains("not been initialized", exception.InnerException!.Message);
 		}
 
+		[Theory]
+		[InlineData("")]
+		[InlineData(" ")]
+		[InlineData(null)]
+		public void Should_ReturnFalse_When_IsValidBotTokenWithNullOrWhitespace(string? token)
+		{
+			Assert.False(TelegramService.IsValidBotToken(token!));
+		}
+
+		[Fact]
+		public void Should_ReturnFalse_When_IsValidBotTokenWithoutColon()
+		{
+			Assert.False(TelegramService.IsValidBotToken("invalidtoken"));
+		}
+
+		[Fact]
+		public void Should_ReturnFalse_When_IsValidBotTokenWithNonNumericPrefix()
+		{
+			Assert.False(TelegramService.IsValidBotToken("abc:defghijklmnopqrstuvwxyz1234567890ab"));
+		}
+
+		[Fact]
+		public void Should_ReturnFalse_When_IsValidBotTokenWithWrongLengthToken()
+		{
+			Assert.False(TelegramService.IsValidBotToken("12345:tooshort"));
+		}
+
+		[Fact]
+		public void Should_ReturnFalse_When_IsValidBotTokenWithInvalidCharacters()
+		{
+			Assert.False(TelegramService.IsValidBotToken("12345:ABCDEFGHIJKLMNOPQRSTUVWXYZ12345!@#$%"));
+		}
+
+		[Fact]
+		public void Should_ReturnTrue_When_IsValidBotTokenWithValidToken()
+		{
+			Assert.True(TelegramService.IsValidBotToken("123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi"));
+		}
+
+		[Fact]
+		public async Task Should_ThrowConnectorException_When_DeleteWebhookAsyncThrowsApiException()
+		{
+			var mockBotClient = new Mock<ITelegramBotClient>();
+			var service = new TelegramService(mockBotClient.Object);
+
+			mockBotClient.Setup(x => x.SendRequest<bool>(
+				It.IsAny<DeleteWebhookRequest>(),
+				It.IsAny<CancellationToken>()))
+				.ThrowsAsync(new ApiRequestException("Bad Request", 400));
+
+			service.Initialize(ValidToken);
+
+			var exception = await Assert.ThrowsAsync<ConnectorException>(
+				() => service.DeleteWebhookAsync(cancellationToken: TestContext.Current.CancellationToken));
+
+			Assert.Equal(MessagingErrorCodes.UnsupportedContentType, exception.ErrorCode);
+			Assert.Equal(TelegramErrorCodes.ErrorDomain, exception.ErrorDomain);
+		}
+
 		#endregion
 	}
 }
+

--- a/test/Deveel.Messaging.Connector.Twilio.XUnit/Unit/TwilioMessageBuilderExtensionsTests.cs
+++ b/test/Deveel.Messaging.Connector.Twilio.XUnit/Unit/TwilioMessageBuilderExtensionsTests.cs
@@ -1,0 +1,39 @@
+namespace Deveel.Messaging
+{
+    [Trait("Category", "Unit")]
+    [Trait("Feature", "TwilioMessageBuilder")]
+    public class TwilioMessageBuilderExtensionsTests
+    {
+        [Fact]
+        public void Should_SetMessagingServiceSid_When_WithMessagingServiceSid()
+        {
+            var builder = new MessageBuilder();
+            var result = builder.WithMessagingServiceSid("MG123abc");
+            Assert.Same(builder, result);
+        }
+
+        [Fact]
+        public void Should_SetStatusCallback_When_WithStatusCallback()
+        {
+            var builder = new MessageBuilder();
+            var result = builder.WithStatusCallback(new Uri("https://example.com/callback"));
+            Assert.Same(builder, result);
+        }
+
+        [Fact]
+        public void Should_SetValidityPeriod_When_WithValidityPeriod()
+        {
+            var builder = new MessageBuilder();
+            var result = builder.WithValidityPeriod(3600);
+            Assert.Same(builder, result);
+        }
+
+        [Fact]
+        public void Should_SetMaxPrice_When_WithMaxPrice()
+        {
+            var builder = new MessageBuilder();
+            var result = builder.WithMaxPrice(0.01m);
+            Assert.Same(builder, result);
+        }
+    }
+}

--- a/test/Deveel.Messaging.Connector.Twilio.XUnit/Unit/TwilioServiceMappingTests.cs
+++ b/test/Deveel.Messaging.Connector.Twilio.XUnit/Unit/TwilioServiceMappingTests.cs
@@ -1,0 +1,21 @@
+namespace Deveel.Messaging;
+
+[Trait("Category", "Unit")]
+[Trait("Layer", "Infrastructure")]
+[Trait("Feature", "TwilioService")]
+public class TwilioServiceMappingTests
+{
+    [Theory]
+    [InlineData(21211, MessagingErrorCodes.InvalidRecipient)]
+    [InlineData(21610, MessagingErrorCodes.InvalidRecipient)]
+    [InlineData(21614, TwilioErrorCodes.InvalidSender)]
+    [InlineData(21408, TwilioErrorCodes.InvalidSender)]
+    [InlineData(20001, TwilioErrorCodes.InvalidMessage)]
+    [InlineData(99999, MessagingErrorCodes.SendMessageFailed)]
+    [InlineData(null, MessagingErrorCodes.SendMessageFailed)]
+    public void Should_MapCorrectly_When_TwilioErrorCodeProvided(int? twilioCode, string expected)
+    {
+        var result = TwilioService.MapTwilioErrorCode(twilioCode);
+        Assert.Equal(expected, result);
+    }
+}

--- a/test/Deveel.Messaging.Connector.Twilio.XUnit/Unit/TwilioServiceMockedTests.cs
+++ b/test/Deveel.Messaging.Connector.Twilio.XUnit/Unit/TwilioServiceMockedTests.cs
@@ -1,0 +1,131 @@
+using Moq;
+using System.Reflection;
+using Twilio.Exceptions;
+using Twilio.Rest.Api.V2010.Account;
+using Xunit;
+
+namespace Deveel.Messaging
+{
+    [Trait("Category", "Unit")]
+    [Trait("Layer", "Infrastructure")]
+    [Trait("Feature", "TwilioService")]
+    public class TwilioServiceMockedTests
+    {
+        private static TwilioService CreateService(ITwilioApiClient client)
+        {
+            var ctor = typeof(TwilioService).GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic)
+                .First(c => c.GetParameters().Length == 1);
+            return (TwilioService)ctor.Invoke(new object[] { client });
+        }
+
+        [Fact]
+        public void Should_Initialize_When_InitializeCalled()
+        {
+            var mockClient = new Mock<ITwilioApiClient>();
+            var service = CreateService(mockClient.Object);
+
+            service.Initialize("AC123", "token");
+
+            mockClient.Verify(x => x.Initialize("AC123", "token"), Times.Once);
+        }
+
+        [Fact]
+        public async Task Should_FetchAccount_When_FetchAccountAsyncSucceeds()
+        {
+            var mockClient = new Mock<ITwilioApiClient>();
+            mockClient.Setup(x => x.FetchAccountAsync("AC123"))
+                .ReturnsAsync((Twilio.Rest.Api.V2010.AccountResource?)null);
+
+            var service = CreateService(mockClient.Object);
+
+            var result = await service.FetchAccountAsync("AC123", TestContext.Current.CancellationToken);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task Should_ThrowConnectorException_When_FetchAccountAsyncThrowsApiException()
+        {
+            var mockClient = new Mock<ITwilioApiClient>();
+            mockClient.Setup(x => x.FetchAccountAsync("AC123"))
+                .ThrowsAsync(new ApiException(20001, 400, "Account error", null, null, null));
+
+            var service = CreateService(mockClient.Object);
+
+            var ex = await Assert.ThrowsAsync<ConnectorException>(() =>
+                service.FetchAccountAsync("AC123", TestContext.Current.CancellationToken));
+
+            Assert.Equal(MessagingErrorCodes.ConnectionFailed, ex.ErrorCode);
+            Assert.Equal(TwilioErrorCodes.ErrorDomain, ex.ErrorDomain);
+        }
+
+        [Fact]
+        public async Task Should_CreateMessage_When_CreateMessageAsyncSucceeds()
+        {
+            var mockClient = new Mock<ITwilioApiClient>();
+            var options = new CreateMessageOptions("+1234567890")
+            {
+                Body = "Test message"
+            };
+            var mockResult = TwilioMockFactory.CreateMockMessageResource("SM123", MessageResource.StatusEnum.Queued);
+            mockClient.Setup(x => x.CreateMessageAsync(options))
+                .ReturnsAsync(mockResult);
+
+            var service = CreateService(mockClient.Object);
+
+            var result = await service.CreateMessageAsync(options, TestContext.Current.CancellationToken);
+
+            Assert.NotNull(result);
+            Assert.Equal("SM123", result.Sid);
+        }
+
+        [Fact]
+        public async Task Should_ThrowConnectorException_When_CreateMessageAsyncThrowsApiException()
+        {
+            var mockClient = new Mock<ITwilioApiClient>();
+            var options = new CreateMessageOptions("+1234567890");
+            mockClient.Setup(x => x.CreateMessageAsync(options))
+                .ThrowsAsync(new ApiException(21211, 400, "Invalid number", null, null, null));
+
+            var service = CreateService(mockClient.Object);
+
+            var ex = await Assert.ThrowsAsync<ConnectorException>(() =>
+                service.CreateMessageAsync(options, TestContext.Current.CancellationToken));
+
+            Assert.Equal(MessagingErrorCodes.InvalidRecipient, ex.ErrorCode);
+            Assert.Equal(TwilioErrorCodes.ErrorDomain, ex.ErrorDomain);
+        }
+
+        [Fact]
+        public async Task Should_FetchMessage_When_FetchMessageAsyncSucceeds()
+        {
+            var mockClient = new Mock<ITwilioApiClient>();
+            var mockResult = TwilioMockFactory.CreateMockMessageResource("SM123", MessageResource.StatusEnum.Sent);
+            mockClient.Setup(x => x.FetchMessageAsync("SM123"))
+                .ReturnsAsync(mockResult);
+
+            var service = CreateService(mockClient.Object);
+
+            var result = await service.FetchMessageAsync("SM123", TestContext.Current.CancellationToken);
+
+            Assert.NotNull(result);
+            Assert.Equal("SM123", result.Sid);
+        }
+
+        [Fact]
+        public async Task Should_ThrowConnectorException_When_FetchMessageAsyncThrowsApiException()
+        {
+            var mockClient = new Mock<ITwilioApiClient>();
+            mockClient.Setup(x => x.FetchMessageAsync("SM123"))
+                .ThrowsAsync(new ApiException(20429, 429, "Rate limited", null, null, null));
+
+            var service = CreateService(mockClient.Object);
+
+            var ex = await Assert.ThrowsAsync<ConnectorException>(() =>
+                service.FetchMessageAsync("SM123", TestContext.Current.CancellationToken));
+
+            Assert.Equal(TwilioErrorCodes.StatusQueryFailed, ex.ErrorCode);
+            Assert.Equal(TwilioErrorCodes.ErrorDomain, ex.ErrorDomain);
+        }
+    }
+}

--- a/test/Deveel.Messaging.Connectors.XUnit/Unit/AuthenticationProviderTests.cs
+++ b/test/Deveel.Messaging.Connectors.XUnit/Unit/AuthenticationProviderTests.cs
@@ -1,0 +1,309 @@
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Deveel.Messaging
+{
+    [Trait("Category", "Unit")]
+    [Trait("Feature", "AuthenticationProvider")]
+    public class AuthenticationProviderTests
+    {
+        private class TestAuthenticationProvider : AuthenticationProviderBase
+        {
+            public TestAuthenticationProvider()
+                : base(AuthenticationScheme.ApiKey, "Test API Key")
+            {
+            }
+
+            public override Task<AuthenticationResult> ObtainCredentialAsync(
+                ConnectionSettings connectionSettings,
+                AuthenticationConfiguration configuration,
+                CancellationToken cancellationToken = default)
+            {
+                return Task.FromResult(Success(AuthenticationCredential.ForApiKey("test-key")));
+            }
+
+            public AuthenticationResult CallFailure(string msg, string? code = null)
+                => Failure(msg, code);
+
+            public AuthenticationResult CallSuccess(AuthenticationCredential c)
+                => Success(c);
+        }
+
+        [Fact]
+        public void Should_SetSchemeAndDisplayName_When_Constructed()
+        {
+            var provider = new TestAuthenticationProvider();
+            Assert.Equal(AuthenticationScheme.ApiKey, provider.Scheme);
+            Assert.Equal("Test API Key", provider.DisplayName);
+        }
+
+        private class NullSchemeProvider : AuthenticationProviderBase
+        {
+            public NullSchemeProvider() : base(null!, "Test") { }
+            public override Task<AuthenticationResult> ObtainCredentialAsync(ConnectionSettings connectionSettings, AuthenticationConfiguration configuration, CancellationToken cancellationToken = default)
+                => throw new NotImplementedException();
+        }
+
+        [Fact]
+        public void Should_ThrowArgumentNullException_When_SchemeIsNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => new NullSchemeProvider());
+        }
+
+        private class NullDisplayNameProvider : AuthenticationProviderBase
+        {
+            public NullDisplayNameProvider() : base(AuthenticationScheme.ApiKey, null!) { }
+            public override Task<AuthenticationResult> ObtainCredentialAsync(ConnectionSettings connectionSettings, AuthenticationConfiguration configuration, CancellationToken cancellationToken = default)
+                => throw new NotImplementedException();
+        }
+
+        [Fact]
+        public void Should_ThrowArgumentNullException_When_DisplayNameIsNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => new NullDisplayNameProvider());
+        }
+
+        [Fact]
+        public void Should_ReturnTrue_When_CanHandleMatchingScheme()
+        {
+            var provider = new TestAuthenticationProvider();
+            var config = new AuthenticationConfiguration(AuthenticationScheme.ApiKey, "API Key");
+            Assert.True(provider.CanHandle(config));
+        }
+
+        [Fact]
+        public void Should_ReturnFalse_When_CanHandleNonMatchingScheme()
+        {
+            var provider = new TestAuthenticationProvider();
+            var config = new AuthenticationConfiguration(AuthenticationScheme.Bearer, "Bearer");
+            Assert.False(provider.CanHandle(config));
+        }
+
+        [Fact]
+        public void Should_ThrowArgumentNullException_When_CanHandleWithNullConfig()
+        {
+            var provider = new TestAuthenticationProvider();
+            Assert.Throws<ArgumentNullException>(() => provider.CanHandle(null!));
+        }
+
+        [Fact]
+        public async Task Should_FallbackToObtainCredential_When_RefreshCredentialCalled()
+        {
+            var provider = new TestAuthenticationProvider();
+            var settings = new ConnectionSettings();
+            var config = new AuthenticationConfiguration(AuthenticationScheme.ApiKey, "API Key");
+            var credential = AuthenticationCredential.ForApiKey("old-key");
+
+            var result = await provider.RefreshCredentialAsync(credential, settings, config);
+
+            Assert.True(result.IsSuccessful);
+            Assert.Equal("test-key", result.Credential?.Value);
+        }
+
+        [Fact]
+        public void Should_CreateFailureResult()
+        {
+            var provider = new TestAuthenticationProvider();
+            var result = provider.CallFailure("Something went wrong", "ERR_001");
+
+            Assert.False(result.IsSuccessful);
+            Assert.Equal("Something went wrong", result.ErrorMessage);
+            Assert.Equal("ERR_001", result.ErrorCode);
+        }
+
+        [Fact]
+        public void Should_CreateFailureResult_WithoutErrorCode()
+        {
+            var provider = new TestAuthenticationProvider();
+            var result = provider.CallFailure("Failed");
+
+            Assert.False(result.IsSuccessful);
+            Assert.Null(result.ErrorCode);
+        }
+
+        [Fact]
+        public void Should_CreateSuccessResult()
+        {
+            var provider = new TestAuthenticationProvider();
+            var credential = AuthenticationCredential.ForApiKey("my-key");
+            var result = provider.CallSuccess(credential);
+
+            Assert.True(result.IsSuccessful);
+            Assert.Same(credential, result.Credential);
+        }
+
+        [Fact]
+        public async Task Should_ObtainApiKey_When_ConnectionHasKey()
+        {
+            var provider = new ApiKeyAuthenticationProvider(NullLogger<ApiKeyAuthenticationProvider>.Instance);
+            var settings = new ConnectionSettings();
+            settings.SetParameter("ApiKey", "my-api-key");
+            var config = new AuthenticationConfiguration(AuthenticationScheme.ApiKey, "API Key")
+                .WithField("ApiKey", DataType.String, f => f.AuthenticationRole = "principal");
+
+            var result = await provider.ObtainCredentialAsync(settings, config);
+
+            Assert.True(result.IsSuccessful);
+            Assert.Equal("my-api-key", result.Credential?.Value);
+        }
+
+        [Fact]
+        public async Task Should_ObtainApiKey_UsingFirstMatchingField()
+        {
+            var provider = new ApiKeyAuthenticationProvider();
+            var settings = new ConnectionSettings();
+            settings.SetParameter("Key", "found-key");
+            var config = new AuthenticationConfiguration(AuthenticationScheme.ApiKey, "API Key")
+                .WithField("ApiKey", DataType.String, f => f.AuthenticationRole = "principal")
+                .WithField("Key", DataType.String, f => f.AuthenticationRole = "principal");
+
+            var result = await provider.ObtainCredentialAsync(settings, config);
+
+            Assert.True(result.IsSuccessful);
+            Assert.Equal("found-key", result.Credential?.Value);
+        }
+
+        [Fact]
+        public async Task Should_Fail_When_NoApiKeyFound()
+        {
+            var provider = new ApiKeyAuthenticationProvider();
+            var settings = new ConnectionSettings();
+            var config = new AuthenticationConfiguration(AuthenticationScheme.ApiKey, "API Key")
+                .WithField("ApiKey", DataType.String, f => f.AuthenticationRole = "principal");
+
+            var result = await provider.ObtainCredentialAsync(settings, config);
+
+            Assert.False(result.IsSuccessful);
+            Assert.Contains("ApiKey", result.ErrorMessage);
+        }
+
+        [Fact]
+        public async Task Should_ObtainBasicCredentials()
+        {
+            var provider = new BasicAuthenticationProvider(NullLogger<BasicAuthenticationProvider>.Instance);
+            var settings = new ConnectionSettings();
+            settings.SetParameter("Username", "admin");
+            settings.SetParameter("Password", "secret");
+            var config = new AuthenticationConfiguration(AuthenticationScheme.Basic, "Basic")
+                .WithField("Username", DataType.String, f => f.AuthenticationRole = "principal")
+                .WithField("Password", DataType.String, f => f.AuthenticationRole = "credential");
+
+            var result = await provider.ObtainCredentialAsync(settings, config);
+
+            Assert.True(result.IsSuccessful);
+            Assert.NotNull(result.Credential);
+        }
+
+        [Fact]
+        public async Task Should_FailBasicAuth_When_UsernameMissing()
+        {
+            var provider = new BasicAuthenticationProvider();
+            var settings = new ConnectionSettings();
+            settings.SetParameter("Password", "secret");
+            var config = new AuthenticationConfiguration(AuthenticationScheme.Basic, "Basic")
+                .WithField("Username", DataType.String, f => f.AuthenticationRole = "principal")
+                .WithField("Password", DataType.String, f => f.AuthenticationRole = "credential");
+
+            var result = await provider.ObtainCredentialAsync(settings, config);
+
+            Assert.False(result.IsSuccessful);
+        }
+
+        [Fact]
+        public async Task Should_FailBasicAuth_When_PasswordMissing()
+        {
+            var provider = new BasicAuthenticationProvider();
+            var settings = new ConnectionSettings();
+            settings.SetParameter("Username", "admin");
+            var config = new AuthenticationConfiguration(AuthenticationScheme.Basic, "Basic")
+                .WithField("Username", DataType.String, f => f.AuthenticationRole = "principal")
+                .WithField("Password", DataType.String, f => f.AuthenticationRole = "credential");
+
+            var result = await provider.ObtainCredentialAsync(settings, config);
+
+            Assert.False(result.IsSuccessful);
+        }
+
+        [Fact]
+        public async Task Should_ObtainBasicCredentials_WithMultipleFieldCombinations()
+        {
+            var provider = new BasicAuthenticationProvider();
+            var settings = new ConnectionSettings();
+            settings.SetParameter("AccountSid", "sid123");
+            settings.SetParameter("Password", "secret");
+            var config = new AuthenticationConfiguration(AuthenticationScheme.Basic, "Basic")
+                .WithField("Username", DataType.String, f => f.AuthenticationRole = "principal")
+                .WithField("AccountSid", DataType.String, f => f.AuthenticationRole = "principal")
+                .WithField("Password", DataType.String, f => f.AuthenticationRole = "credential")
+                .WithField("AuthToken", DataType.String, f => f.AuthenticationRole = "credential");
+
+            var result = await provider.ObtainCredentialAsync(settings, config);
+
+            Assert.True(result.IsSuccessful);
+            Assert.NotNull(result.Credential);
+            Assert.Equal("Password", result.Credential.Properties["PassField"]);
+        }
+
+        [Fact]
+        public async Task Should_ObtainBearerToken()
+        {
+            var provider = new BearerTokenAuthenticationProvider(NullLogger<BearerTokenAuthenticationProvider>.Instance);
+            var settings = new ConnectionSettings();
+            settings.SetParameter("AccessToken", "my-token");
+            var config = new AuthenticationConfiguration(AuthenticationScheme.Bearer, "Bearer")
+                .WithField("AccessToken", DataType.String, f => f.AuthenticationRole = "principal");
+
+            var result = await provider.ObtainCredentialAsync(settings, config);
+
+            Assert.True(result.IsSuccessful);
+            Assert.Equal("my-token", result.Credential?.Value);
+            Assert.Equal("Bearer", result.Credential?.Properties["TokenType"]);
+        }
+
+        [Fact]
+        public async Task Should_ObtainBearerToken_WithCustomTokenType()
+        {
+            var provider = new BearerTokenAuthenticationProvider();
+            var settings = new ConnectionSettings();
+            settings.SetParameter("Token", "my-token");
+            settings.SetParameter("TokenType", "JWT");
+            var config = new AuthenticationConfiguration(AuthenticationScheme.Bearer, "Bearer")
+                .WithField("Token", DataType.String, f => f.AuthenticationRole = "principal");
+
+            var result = await provider.ObtainCredentialAsync(settings, config);
+
+            Assert.True(result.IsSuccessful);
+            Assert.Equal("JWT", result.Credential?.Properties["TokenType"]);
+        }
+
+        [Fact]
+        public async Task Should_ObtainBearerToken_WithExpiration()
+        {
+            var provider = new BearerTokenAuthenticationProvider();
+            var expiresAt = DateTime.UtcNow.AddHours(1);
+            var settings = new ConnectionSettings();
+            settings.SetParameter("BearerToken", "my-token");
+            settings.SetParameter("ExpiresAt", expiresAt.ToString("O"));
+            var config = new AuthenticationConfiguration(AuthenticationScheme.Bearer, "Bearer")
+                .WithField("BearerToken", DataType.String, f => f.AuthenticationRole = "principal");
+
+            var result = await provider.ObtainCredentialAsync(settings, config);
+
+            Assert.True(result.IsSuccessful);
+            Assert.NotNull(result.Credential?.ExpiresAt);
+        }
+
+        [Fact]
+        public async Task Should_FailBearerToken_When_NoTokenFound()
+        {
+            var provider = new BearerTokenAuthenticationProvider();
+            var settings = new ConnectionSettings();
+            var config = new AuthenticationConfiguration(AuthenticationScheme.Bearer, "Bearer")
+                .WithField("Token", DataType.String, f => f.AuthenticationRole = "principal");
+
+            var result = await provider.ObtainCredentialAsync(settings, config);
+
+            Assert.False(result.IsSuccessful);
+            Assert.Contains("Token", result.ErrorMessage);
+        }
+    }
+}

--- a/test/Deveel.Messaging.Connectors.XUnit/Unit/AuthenticationProviderTests.cs
+++ b/test/Deveel.Messaging.Connectors.XUnit/Unit/AuthenticationProviderTests.cs
@@ -40,7 +40,7 @@ namespace Deveel.Messaging
         {
             public NullSchemeProvider() : base(null!, "Test") { }
             public override Task<AuthenticationResult> ObtainCredentialAsync(ConnectionSettings connectionSettings, AuthenticationConfiguration configuration, CancellationToken cancellationToken = default)
-                => throw new NotImplementedException();
+                => throw new NotSupportedException();
         }
 
         [Fact]
@@ -53,7 +53,7 @@ namespace Deveel.Messaging
         {
             public NullDisplayNameProvider() : base(AuthenticationScheme.ApiKey, null!) { }
             public override Task<AuthenticationResult> ObtainCredentialAsync(ConnectionSettings connectionSettings, AuthenticationConfiguration configuration, CancellationToken cancellationToken = default)
-                => throw new NotImplementedException();
+                => throw new NotSupportedException();
         }
 
         [Fact]

--- a/test/Deveel.Messaging.Connectors.XUnit/Unit/ChannelConnectorBuilderTests.cs
+++ b/test/Deveel.Messaging.Connectors.XUnit/Unit/ChannelConnectorBuilderTests.cs
@@ -615,14 +615,14 @@ namespace Deveel.Messaging.XUnit
 
 			public ValueTask<OperationResult<bool>>         InitializeAsync(CancellationToken ct)         => new ValueTask<OperationResult<bool>>(OperationResult<bool>.Success(true));
 			public ValueTask<OperationResult<bool>>         TestConnectionAsync(CancellationToken ct)     => new ValueTask<OperationResult<bool>>(OperationResult<bool>.Success(true));
-			public ValueTask<OperationResult<SendResult>>   SendMessageAsync(IMessage m, CancellationToken ct) => throw new NotImplementedException();
-			public ValueTask<OperationResult<BatchSendResult>> SendBatchAsync(IMessageBatch b, CancellationToken ct) => throw new NotImplementedException();
-			public ValueTask<OperationResult<StatusInfo>>   GetStatusAsync(CancellationToken ct)          => throw new NotImplementedException();
-			public ValueTask<OperationResult<StatusUpdatesResult>> GetMessageStatusAsync(string id, CancellationToken ct) => throw new NotImplementedException();
-			public IAsyncEnumerable<ValidationResult>  ValidateMessageAsync(IMessage m, CancellationToken ct)        => throw new NotImplementedException();
-			public ValueTask<OperationResult<StatusUpdateResult>> ReceiveMessageStatusAsync(MessageSource s, CancellationToken ct) => throw new NotImplementedException();
-			public ValueTask<OperationResult<ReceiveResult>> ReceiveMessagesAsync(MessageSource s, CancellationToken ct) => throw new NotImplementedException();
-			public ValueTask<OperationResult<ConnectorHealth>> GetHealthAsync(CancellationToken ct)       => throw new NotImplementedException();
+			public ValueTask<OperationResult<SendResult>>   SendMessageAsync(IMessage m, CancellationToken ct) => throw new NotSupportedException();
+			public ValueTask<OperationResult<BatchSendResult>> SendBatchAsync(IMessageBatch b, CancellationToken ct) => throw new NotSupportedException();
+			public ValueTask<OperationResult<StatusInfo>>   GetStatusAsync(CancellationToken ct)          => throw new NotSupportedException();
+			public ValueTask<OperationResult<StatusUpdatesResult>> GetMessageStatusAsync(string id, CancellationToken ct) => throw new NotSupportedException();
+			public IAsyncEnumerable<ValidationResult>  ValidateMessageAsync(IMessage m, CancellationToken ct)        => throw new NotSupportedException();
+			public ValueTask<OperationResult<StatusUpdateResult>> ReceiveMessageStatusAsync(MessageSource s, CancellationToken ct) => throw new NotSupportedException();
+			public ValueTask<OperationResult<ReceiveResult>> ReceiveMessagesAsync(MessageSource s, CancellationToken ct) => throw new NotSupportedException();
+			public ValueTask<OperationResult<ConnectorHealth>> GetHealthAsync(CancellationToken ct)       => throw new NotSupportedException();
 			public ValueTask ShutdownAsync(CancellationToken ct) => default;
 		}
 

--- a/test/Deveel.Messaging.Connectors.XUnit/Unit/ChannelConnectorFactoryTests.cs
+++ b/test/Deveel.Messaging.Connectors.XUnit/Unit/ChannelConnectorFactoryTests.cs
@@ -231,10 +231,10 @@ namespace Deveel.Messaging.XUnit
                 => ValueTask.CompletedTask;
 
             protected override Task<SendResult> SendMessageCoreAsync(IMessage message, CancellationToken cancellationToken)
-                => throw new NotImplementedException();
+                => throw new NotSupportedException();
 
             protected override Task<StatusInfo> GetConnectorStatusAsync(CancellationToken cancellationToken)
-                => throw new NotImplementedException();
+                => throw new NotSupportedException();
         }
 
         private class PoolTestSchemaFactory : IChannelSchemaFactory

--- a/test/Deveel.Messaging.Connectors.XUnit/Unit/ChannelDescriptorExtendedTests.cs
+++ b/test/Deveel.Messaging.Connectors.XUnit/Unit/ChannelDescriptorExtendedTests.cs
@@ -399,28 +399,28 @@ namespace Deveel.Messaging.XUnit
 				=> new ValueTask<OperationResult<bool>>(OperationResult<bool>.Success(true));
 
 			public ValueTask<OperationResult<SendResult>> SendMessageAsync(IMessage message, CancellationToken cancellationToken)
-				=> throw new NotImplementedException();
+				=> throw new NotSupportedException();
 
 			public ValueTask<OperationResult<BatchSendResult>> SendBatchAsync(IMessageBatch batch, CancellationToken cancellationToken)
-				=> throw new NotImplementedException();
+				=> throw new NotSupportedException();
 
 			public ValueTask<OperationResult<StatusInfo>> GetStatusAsync(CancellationToken cancellationToken)
-				=> throw new NotImplementedException();
+				=> throw new NotSupportedException();
 
 			public ValueTask<OperationResult<StatusUpdatesResult>> GetMessageStatusAsync(string messageId, CancellationToken cancellationToken)
-				=> throw new NotImplementedException();
+				=> throw new NotSupportedException();
 
 			public IAsyncEnumerable<ValidationResult> ValidateMessageAsync(IMessage message, CancellationToken cancellationToken)
-				=> throw new NotImplementedException();
+				=> throw new NotSupportedException();
 
 			public ValueTask<OperationResult<StatusUpdateResult>> ReceiveMessageStatusAsync(MessageSource source, CancellationToken cancellationToken)
-				=> throw new NotImplementedException();
+				=> throw new NotSupportedException();
 
 			public ValueTask<OperationResult<ReceiveResult>> ReceiveMessagesAsync(MessageSource source, CancellationToken cancellationToken)
-				=> throw new NotImplementedException();
+				=> throw new NotSupportedException();
 
 			public ValueTask<OperationResult<ConnectorHealth>> GetHealthAsync(CancellationToken cancellationToken)
-				=> throw new NotImplementedException();
+				=> throw new NotSupportedException();
 
 			public ValueTask ShutdownAsync(CancellationToken cancellationToken)
 				=> default;
@@ -438,28 +438,28 @@ namespace Deveel.Messaging.XUnit
 				=> new ValueTask<OperationResult<bool>>(OperationResult<bool>.Success(true));
 
 			public ValueTask<OperationResult<SendResult>> SendMessageAsync(IMessage message, CancellationToken cancellationToken)
-				=> throw new NotImplementedException();
+				=> throw new NotSupportedException();
 
 			public ValueTask<OperationResult<BatchSendResult>> SendBatchAsync(IMessageBatch batch, CancellationToken cancellationToken)
-				=> throw new NotImplementedException();
+				=> throw new NotSupportedException();
 
 			public ValueTask<OperationResult<StatusInfo>> GetStatusAsync(CancellationToken cancellationToken)
-				=> throw new NotImplementedException();
+				=> throw new NotSupportedException();
 
 			public ValueTask<OperationResult<StatusUpdatesResult>> GetMessageStatusAsync(string messageId, CancellationToken cancellationToken)
-				=> throw new NotImplementedException();
+				=> throw new NotSupportedException();
 
 			public IAsyncEnumerable<ValidationResult> ValidateMessageAsync(IMessage message, CancellationToken cancellationToken)
-				=> throw new NotImplementedException();
+				=> throw new NotSupportedException();
 
 			public ValueTask<OperationResult<StatusUpdateResult>> ReceiveMessageStatusAsync(MessageSource source, CancellationToken cancellationToken)
-				=> throw new NotImplementedException();
+				=> throw new NotSupportedException();
 
 			public ValueTask<OperationResult<ReceiveResult>> ReceiveMessagesAsync(MessageSource source, CancellationToken cancellationToken)
-				=> throw new NotImplementedException();
+				=> throw new NotSupportedException();
 
 			public ValueTask<OperationResult<ConnectorHealth>> GetHealthAsync(CancellationToken cancellationToken)
-				=> throw new NotImplementedException();
+				=> throw new NotSupportedException();
 
 			public ValueTask ShutdownAsync(CancellationToken cancellationToken)
 				=> default;

--- a/test/Deveel.Messaging.Connectors.XUnit/Unit/ChannelSchemaBuilderTests.cs
+++ b/test/Deveel.Messaging.Connectors.XUnit/Unit/ChannelSchemaBuilderTests.cs
@@ -1,0 +1,658 @@
+namespace Deveel.Messaging
+{
+    [Trait("Category", "Unit")]
+    [Trait("Feature", "ChannelSchemaBuilder")]
+    public class ChannelSchemaBuilderTests
+    {
+        [Fact]
+        public void Should_SetProperties_When_Constructed()
+        {
+            var builder = new ChannelSchemaBuilder("TestProvider", "TestType", "1.0");
+            var schema = builder.Build();
+
+            Assert.NotNull(schema);
+            Assert.Equal("TestProvider", schema.ChannelProvider);
+            Assert.Equal("TestType", schema.ChannelType);
+            Assert.Equal("1.0", schema.Version);
+        }
+
+        [Fact]
+        public void Should_ThrowArgumentNullException_When_ChannelProviderIsNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => new ChannelSchemaBuilder(null!, "Type", "1.0"));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(" ")]
+        public void Should_ThrowArgumentException_When_ChannelProviderIsEmptyOrWhitespace(string provider)
+        {
+            Assert.Throws<ArgumentException>(() => new ChannelSchemaBuilder(provider, "Type", "1.0"));
+        }
+
+        [Fact]
+        public void Should_ThrowArgumentNullException_When_ChannelTypeIsNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => new ChannelSchemaBuilder("Provider", null!, "1.0"));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(" ")]
+        public void Should_ThrowArgumentException_When_ChannelTypeIsEmptyOrWhitespace(string type)
+        {
+            Assert.Throws<ArgumentException>(() => new ChannelSchemaBuilder("Provider", type, "1.0"));
+        }
+
+        [Fact]
+        public void Should_ThrowArgumentNullException_When_VersionIsNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => new ChannelSchemaBuilder("Provider", "Type", null!));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(" ")]
+        public void Should_ThrowArgumentException_When_VersionIsEmptyOrWhitespace(string version)
+        {
+            Assert.Throws<ArgumentException>(() => new ChannelSchemaBuilder("Provider", "Type", version));
+        }
+
+        [Fact]
+        public void Should_SetDisplayName()
+        {
+            var schema = new ChannelSchemaBuilder("P", "T", "1.0")
+                .WithDisplayName("My Channel")
+                .Build();
+
+            Assert.Equal("My Channel", schema.DisplayName);
+        }
+
+        [Fact]
+        public void Should_SetCapabilities()
+        {
+            var schema = new ChannelSchemaBuilder("P", "T", "1.0")
+                .WithCapabilities(ChannelCapability.SendMessages | ChannelCapability.ReceiveMessages)
+                .Build();
+
+            Assert.Equal(ChannelCapability.SendMessages | ChannelCapability.ReceiveMessages, schema.Capabilities);
+        }
+
+        [Fact]
+        public void Should_AddCapability()
+        {
+            var schema = new ChannelSchemaBuilder("P", "T", "1.0")
+                .WithCapability(ChannelCapability.ReceiveMessages)
+                .Build();
+
+            Assert.True(schema.Capabilities.HasFlag(ChannelCapability.ReceiveMessages));
+        }
+
+        [Fact]
+        public void Should_RemoveCapability()
+        {
+            var schema = new ChannelSchemaBuilder("P", "T", "1.0")
+                .WithCapability(ChannelCapability.ReceiveMessages)
+                .RemoveCapability(ChannelCapability.ReceiveMessages)
+                .Build();
+
+            Assert.False(schema.Capabilities.HasFlag(ChannelCapability.ReceiveMessages));
+        }
+
+        [Fact]
+        public void Should_RestrictCapabilities()
+        {
+            var schema = new ChannelSchemaBuilder("P", "T", "1.0")
+                .WithCapability(ChannelCapability.ReceiveMessages)
+                .WithCapability(ChannelCapability.BulkMessaging)
+                .RestrictCapabilities(ChannelCapability.SendMessages)
+                .Build();
+
+            Assert.True(schema.Capabilities.HasFlag(ChannelCapability.SendMessages));
+            Assert.False(schema.Capabilities.HasFlag(ChannelCapability.ReceiveMessages));
+        }
+
+        [Fact]
+        public void Should_AddParameter()
+        {
+            var param = new ChannelParameter("ApiKey", DataType.String) { IsRequired = true };
+            var schema = new ChannelSchemaBuilder("P", "T", "1.0")
+                .AddParameter(param)
+                .Build();
+
+            Assert.Single(schema.Parameters);
+            Assert.Equal("ApiKey", schema.Parameters[0].Name);
+            Assert.True(schema.Parameters[0].IsRequired);
+        }
+
+        [Fact]
+        public void Should_AddParameterUsingFactory()
+        {
+            var schema = new ChannelSchemaBuilder("P", "T", "1.0")
+                .AddParameter("ApiKey", DataType.String, p => p.IsRequired = true)
+                .Build();
+
+            Assert.Single(schema.Parameters);
+            Assert.Equal("ApiKey", schema.Parameters[0].Name);
+            Assert.True(schema.Parameters[0].IsRequired);
+        }
+
+        [Fact]
+        public void Should_ThrowArgumentNullException_When_AddingParameterWithNullName()
+        {
+            var builder = new ChannelSchemaBuilder("P", "T", "1.0");
+            Assert.Throws<ArgumentNullException>(() => builder.AddParameter(null!, DataType.String));
+        }
+
+        [Fact]
+        public void Should_AddRequiredParameter()
+        {
+            var schema = new ChannelSchemaBuilder("P", "T", "1.0")
+                .AddRequiredParameter("ApiKey", DataType.String, sensitive: true)
+                .Build();
+
+            Assert.Single(schema.Parameters);
+            Assert.Equal("ApiKey", schema.Parameters[0].Name);
+            Assert.True(schema.Parameters[0].IsRequired);
+            Assert.True(schema.Parameters[0].IsSensitive);
+        }
+
+        [Fact]
+        public void Should_AddRequiredParameterNonSensitive()
+        {
+            var schema = new ChannelSchemaBuilder("P", "T", "1.0")
+                .AddRequiredParameter("Username", DataType.String)
+                .Build();
+
+            Assert.Single(schema.Parameters);
+            Assert.False(schema.Parameters[0].IsSensitive);
+        }
+
+        [Fact]
+        public void Should_RemoveParameter()
+        {
+            var schema = new ChannelSchemaBuilder("P", "T", "1.0")
+                .AddParameter("ApiKey", DataType.String)
+                .RemoveParameter("ApiKey")
+                .Build();
+
+            Assert.Empty(schema.Parameters);
+        }
+
+        [Fact]
+        public void Should_NotThrow_When_RemovingUnknownParameter()
+        {
+            var schema = new ChannelSchemaBuilder("P", "T", "1.0")
+                .RemoveParameter("NonExistent")
+                .Build();
+
+            Assert.Empty(schema.Parameters);
+        }
+
+        [Fact]
+        public void Should_UpdateParameter()
+        {
+            var schema = new ChannelSchemaBuilder("P", "T", "1.0")
+                .AddRequiredParameter("ApiKey", DataType.String)
+                .UpdateParameter("ApiKey", p => p.IsRequired = false)
+                .Build();
+
+            Assert.False(schema.Parameters[0].IsRequired);
+        }
+
+        [Fact]
+        public void Should_ThrowInvalidOperationException_When_UpdatingUnknownParameter()
+        {
+            var builder = new ChannelSchemaBuilder("P", "T", "1.0");
+            Assert.Throws<InvalidOperationException>(() => builder.UpdateParameter("NonExistent", p => { }));
+        }
+
+        [Fact]
+        public void Should_AddMessageProperty()
+        {
+            var prop = new MessagePropertyConfiguration("Subject", DataType.String) { IsRequired = true };
+            var schema = new ChannelSchemaBuilder("P", "T", "1.0")
+                .AddMessageProperty(prop)
+                .Build();
+
+            Assert.Single(schema.MessageProperties);
+            Assert.Equal("Subject", schema.MessageProperties[0].Name);
+            Assert.True(schema.MessageProperties[0].IsRequired);
+        }
+
+        [Fact]
+        public void Should_AddMessagePropertyUsingFactory()
+        {
+            var schema = new ChannelSchemaBuilder("P", "T", "1.0")
+                .AddMessageProperty("Subject", DataType.String, p => p.IsRequired = true)
+                .Build();
+
+            Assert.Single(schema.MessageProperties);
+            Assert.True(schema.MessageProperties[0].IsRequired);
+        }
+
+        [Fact]
+        public void Should_ThrowInvalidOperationException_When_AddingDuplicateMessageProperty()
+        {
+            var builder = new ChannelSchemaBuilder("P", "T", "1.0");
+            builder.AddMessageProperty("Subject", DataType.String);
+            Assert.Throws<InvalidOperationException>(() => builder.AddMessageProperty("Subject", DataType.String));
+        }
+
+        [Fact]
+        public void Should_ThrowArgumentNullException_When_AddingMessagePropertyWithNullName()
+        {
+            var builder = new ChannelSchemaBuilder("P", "T", "1.0");
+            Assert.Throws<ArgumentNullException>(() => builder.AddMessageProperty(null!, DataType.String));
+        }
+
+        [Fact]
+        public void Should_RemoveMessageProperty()
+        {
+            var schema = new ChannelSchemaBuilder("P", "T", "1.0")
+                .AddMessageProperty("Subject", DataType.String)
+                .RemoveMessageProperty("Subject")
+                .Build();
+
+            Assert.Empty(schema.MessageProperties);
+        }
+
+        [Fact]
+        public void Should_NotThrow_When_RemovingUnknownMessageProperty()
+        {
+            var schema = new ChannelSchemaBuilder("P", "T", "1.0")
+                .RemoveMessageProperty("NonExistent")
+                .Build();
+
+            Assert.Empty(schema.MessageProperties);
+        }
+
+        [Fact]
+        public void Should_UpdateMessageProperty()
+        {
+            var schema = new ChannelSchemaBuilder("P", "T", "1.0")
+                .AddMessageProperty("Subject", DataType.String)
+                .UpdateMessageProperty("Subject", p => p.IsRequired = true)
+                .Build();
+
+            Assert.True(schema.MessageProperties[0].IsRequired);
+        }
+
+        [Fact]
+        public void Should_ThrowInvalidOperationException_When_UpdatingUnknownMessageProperty()
+        {
+            var builder = new ChannelSchemaBuilder("P", "T", "1.0");
+            Assert.Throws<InvalidOperationException>(() => builder.UpdateMessageProperty("NonExistent", p => { }));
+        }
+
+        [Fact]
+        public void Should_AddContentType()
+        {
+            var schema = new ChannelSchemaBuilder("P", "T", "1.0")
+                .AddContentType(MessageContentType.PlainText)
+                .Build();
+
+            Assert.Single(schema.ContentTypes);
+            Assert.Equal(MessageContentType.PlainText, schema.ContentTypes[0]);
+        }
+
+        [Fact]
+        public void Should_RemoveContentType()
+        {
+            var schema = new ChannelSchemaBuilder("P", "T", "1.0")
+                .AddContentType(MessageContentType.PlainText)
+                .RemoveContentType(MessageContentType.PlainText)
+                .Build();
+
+            Assert.Empty(schema.ContentTypes);
+        }
+
+        [Fact]
+        public void Should_RestrictContentTypes()
+        {
+            var schema = new ChannelSchemaBuilder("P", "T", "1.0")
+                .AddContentType(MessageContentType.PlainText)
+                .AddContentType(MessageContentType.Html)
+                .RestrictContentTypes(MessageContentType.PlainText)
+                .Build();
+
+            Assert.Single(schema.ContentTypes);
+            Assert.Equal(MessageContentType.PlainText, schema.ContentTypes[0]);
+        }
+
+        [Fact]
+        public void Should_AddAuthenticationScheme()
+        {
+            var schema = new ChannelSchemaBuilder("P", "T", "1.0")
+                .AddAuthenticationScheme(AuthenticationScheme.ApiKey)
+                .Build();
+
+            Assert.Single(schema.AuthenticationConfigurations);
+            Assert.Equal(AuthenticationScheme.ApiKey, schema.AuthenticationConfigurations[0].Scheme);
+        }
+
+        [Fact]
+        public void Should_AddAuthenticationType()
+        {
+            var schema = new ChannelSchemaBuilder("P", "T", "1.0")
+                .AddAuthenticationType(AuthenticationScheme.Bearer)
+                .Build();
+
+            Assert.Single(schema.AuthenticationConfigurations);
+            Assert.Equal(AuthenticationScheme.Bearer, schema.AuthenticationConfigurations[0].Scheme);
+        }
+
+        [Fact]
+        public void Should_AddNoneAuthenticationScheme()
+        {
+            var schema = new ChannelSchemaBuilder("P", "T", "1.0")
+                .AddAuthenticationScheme(AuthenticationScheme.None)
+                .Build();
+
+            Assert.Single(schema.AuthenticationConfigurations);
+            Assert.Equal(AuthenticationScheme.None, schema.AuthenticationConfigurations[0].Scheme);
+            Assert.Equal("No Authentication", schema.AuthenticationConfigurations[0].DisplayName);
+        }
+
+        [Fact]
+        public void Should_AddBasicAuthenticationScheme()
+        {
+            var schema = new ChannelSchemaBuilder("P", "T", "1.0")
+                .AddAuthenticationScheme(AuthenticationScheme.Basic)
+                .Build();
+
+            var config = schema.AuthenticationConfigurations[0];
+            Assert.Equal(AuthenticationScheme.Basic, config.Scheme);
+            Assert.Contains(config.Fields, f => f.FieldName == "Username" && f.AuthenticationRole == "principal");
+            Assert.Contains(config.Fields, f => f.FieldName == "Password" && f.AuthenticationRole == "credential");
+        }
+
+        [Fact]
+        public void Should_AddOAuthClientCredentialsScheme()
+        {
+            var schema = new ChannelSchemaBuilder("P", "T", "1.0")
+                .AddAuthenticationScheme(AuthenticationScheme.OAuthClientCredentials)
+                .Build();
+
+            var config = schema.AuthenticationConfigurations[0];
+            Assert.Equal(AuthenticationScheme.OAuthClientCredentials, config.Scheme);
+            Assert.Contains(config.Fields, f => f.FieldName == "ClientId");
+            Assert.Contains(config.Fields, f => f.FieldName == "ClientSecret");
+        }
+
+        [Fact]
+        public void Should_AddCertificateScheme()
+        {
+            var schema = new ChannelSchemaBuilder("P", "T", "1.0")
+                .AddAuthenticationScheme(AuthenticationScheme.Certificate)
+                .Build();
+
+            var config = schema.AuthenticationConfigurations[0];
+            Assert.Equal(AuthenticationScheme.Certificate, config.Scheme);
+            Assert.Contains(config.Fields, f => f.FieldName == "Certificate");
+        }
+
+        [Fact]
+        public void Should_AddDigestScheme()
+        {
+            var schema = new ChannelSchemaBuilder("P", "T", "1.0")
+                .AddAuthenticationScheme(AuthenticationScheme.Digest)
+                .Build();
+
+            var config = schema.AuthenticationConfigurations[0];
+            Assert.Equal(AuthenticationScheme.Digest, config.Scheme);
+            Assert.Contains(config.Fields, f => f.FieldName == "Username");
+            Assert.Contains(config.Fields, f => f.FieldName == "Password");
+            Assert.Contains(config.Fields, f => f.FieldName == "Realm");
+        }
+
+        [Fact]
+        public void Should_AddAuthenticationConfiguration()
+        {
+            var config = new AuthenticationConfiguration(AuthenticationScheme.ApiKey, "Custom API Key");
+            var schema = new ChannelSchemaBuilder("P", "T", "1.0")
+                .AddAuthenticationConfiguration(config)
+                .Build();
+
+            Assert.Single(schema.AuthenticationConfigurations);
+            Assert.Equal(AuthenticationScheme.ApiKey, schema.AuthenticationConfigurations[0].Scheme);
+        }
+
+        [Fact]
+        public void Should_AddAuthenticationConfigurationWithFactory()
+        {
+            var schema = new ChannelSchemaBuilder("P", "T", "1.0")
+                .AddAuthenticationConfiguration(() =>
+                    new AuthenticationConfiguration(AuthenticationScheme.ApiKey, "Custom API Key"))
+                .Build();
+
+            Assert.Single(schema.AuthenticationConfigurations);
+        }
+
+        [Fact]
+        public void Should_ThrowInvalidOperationException_When_AddingDuplicateAuthenticationScheme()
+        {
+            var builder = new ChannelSchemaBuilder("P", "T", "1.0");
+            builder.AddAuthenticationScheme(AuthenticationScheme.ApiKey);
+            Assert.Throws<InvalidOperationException>(() =>
+                builder.AddAuthenticationConfiguration(
+                    new AuthenticationConfiguration(AuthenticationScheme.ApiKey, "Duplicate")));
+        }
+
+        [Fact]
+        public void Should_ThrowArgumentNullException_When_AddingNullAuthenticationConfiguration()
+        {
+            var builder = new ChannelSchemaBuilder("P", "T", "1.0");
+            Assert.Throws<ArgumentNullException>(() => builder.AddAuthenticationConfiguration((AuthenticationConfiguration)null!));
+        }
+
+        [Fact]
+        public void Should_ThrowArgumentNullException_When_AddingNullAuthenticationConfigurationFactory()
+        {
+            var builder = new ChannelSchemaBuilder("P", "T", "1.0");
+            Assert.Throws<ArgumentNullException>(() => builder.AddAuthenticationConfiguration((Func<AuthenticationConfiguration>)null!));
+        }
+
+        [Fact]
+        public void Should_AddSchemaParameter_When_AuthenticationConfigurationHasPrincipalField()
+        {
+            var config = new AuthenticationConfiguration(AuthenticationScheme.ApiKey, "API Key")
+                .WithField("ApiKey", DataType.String, f => f.AuthenticationRole = "principal");
+
+            var schema = new ChannelSchemaBuilder("P", "T", "1.0")
+                .AddAuthenticationConfiguration(config)
+                .Build();
+
+            Assert.Single(schema.Parameters);
+            Assert.Equal("ApiKey", schema.Parameters[0].Name);
+        }
+
+        [Fact]
+        public void Should_NotAddDuplicateParameter_When_PrincipalFieldAlreadyExists()
+        {
+            var config = new AuthenticationConfiguration(AuthenticationScheme.ApiKey, "API Key")
+                .WithField("ApiKey", DataType.String, f => f.AuthenticationRole = "principal");
+
+            var schema = new ChannelSchemaBuilder("P", "T", "1.0")
+                .AddParameter("ApiKey", DataType.String)
+                .AddAuthenticationConfiguration(config)
+                .Build();
+
+            Assert.Single(schema.Parameters);
+        }
+
+        [Fact]
+        public void Should_RestrictAuthenticationSchemes()
+        {
+            var schema = new ChannelSchemaBuilder("P", "T", "1.0")
+                .AddAuthenticationScheme(AuthenticationScheme.ApiKey)
+                .AddAuthenticationScheme(AuthenticationScheme.Bearer)
+                .RestrictAuthenticationSchemes(AuthenticationScheme.ApiKey)
+                .Build();
+
+            Assert.Single(schema.AuthenticationConfigurations);
+            Assert.Equal(AuthenticationScheme.ApiKey, schema.AuthenticationConfigurations[0].Scheme);
+        }
+
+        [Fact]
+        public void Should_RestrictAuthenticationConfigurations()
+        {
+            var apiKeyConfig = new AuthenticationConfiguration(AuthenticationScheme.ApiKey, "API Key");
+            var schema = new ChannelSchemaBuilder("P", "T", "1.0")
+                .AddAuthenticationScheme(AuthenticationScheme.ApiKey)
+                .AddAuthenticationScheme(AuthenticationScheme.Bearer)
+                .RestrictAuthenticationConfigurations(apiKeyConfig)
+                .Build();
+
+            Assert.Single(schema.AuthenticationConfigurations);
+        }
+
+        [Fact]
+        public void Should_HandlesMessageEndpoint()
+        {
+            var endpoint = new ChannelEndpointConfiguration(EndpointType.EmailAddress) { CanSend = true };
+            var schema = new ChannelSchemaBuilder("P", "T", "1.0")
+                .HandlesMessageEndpoint(endpoint)
+                .Build();
+
+            Assert.Single(schema.Endpoints);
+            Assert.Equal(EndpointType.EmailAddress, schema.Endpoints[0].Type);
+        }
+
+        [Fact]
+        public void Should_HandlesMessageEndpointUsingFactory()
+        {
+            var schema = new ChannelSchemaBuilder("P", "T", "1.0")
+                .HandlesMessageEndpoint(EndpointType.EmailAddress, e => e.CanSend = true)
+                .Build();
+
+            Assert.Single(schema.Endpoints);
+            Assert.True(schema.Endpoints[0].CanSend);
+        }
+
+        [Fact]
+        public void Should_ThrowInvalidOperationException_When_AddingDuplicateEndpoint()
+        {
+            var builder = new ChannelSchemaBuilder("P", "T", "1.0");
+            builder.HandlesMessageEndpoint(EndpointType.EmailAddress);
+            Assert.Throws<InvalidOperationException>(() =>
+                builder.HandlesMessageEndpoint(new ChannelEndpointConfiguration(EndpointType.EmailAddress)));
+        }
+
+        [Fact]
+        public void Should_AllowAnyMessageEndpoint()
+        {
+            var schema = new ChannelSchemaBuilder("P", "T", "1.0")
+                .AllowsAnyMessageEndpoint()
+                .Build();
+
+            Assert.Single(schema.Endpoints);
+            Assert.Equal(EndpointType.Any, schema.Endpoints[0].Type);
+        }
+
+        [Fact]
+        public void Should_ThrowInvalidOperationException_When_AddingDuplicateAnyEndpoint()
+        {
+            var builder = new ChannelSchemaBuilder("P", "T", "1.0");
+            builder.AllowsAnyMessageEndpoint();
+            Assert.Throws<InvalidOperationException>(() => builder.AllowsAnyMessageEndpoint());
+        }
+
+        [Fact]
+        public void Should_RemoveEndpoint()
+        {
+            var schema = new ChannelSchemaBuilder("P", "T", "1.0")
+                .HandlesMessageEndpoint(EndpointType.EmailAddress)
+                .RemoveEndpoint(EndpointType.EmailAddress)
+                .Build();
+
+            Assert.Empty(schema.Endpoints);
+        }
+
+        [Fact]
+        public void Should_NotThrow_When_RemovingUnknownEndpoint()
+        {
+            var schema = new ChannelSchemaBuilder("P", "T", "1.0")
+                .RemoveEndpoint(EndpointType.EmailAddress)
+                .Build();
+
+            Assert.Empty(schema.Endpoints);
+        }
+
+        [Fact]
+        public void Should_UpdateEndpoint()
+        {
+            var schema = new ChannelSchemaBuilder("P", "T", "1.0")
+                .HandlesMessageEndpoint(EndpointType.EmailAddress)
+                .UpdateEndpoint(EndpointType.EmailAddress, e => e.CanSend = true)
+                .Build();
+
+            Assert.True(schema.Endpoints[0].CanSend);
+        }
+
+        [Fact]
+        public void Should_ThrowInvalidOperationException_When_UpdatingUnknownEndpoint()
+        {
+            var builder = new ChannelSchemaBuilder("P", "T", "1.0");
+            Assert.Throws<InvalidOperationException>(() => builder.UpdateEndpoint(EndpointType.PhoneNumber, e => { }));
+        }
+
+        [Fact]
+        public void Should_EnableStrictMode()
+        {
+            var schema = new ChannelSchemaBuilder("P", "T", "1.0")
+                .WithFlexibleMode()
+                .WithStrictMode()
+                .Build();
+
+            Assert.True(schema.IsStrict);
+        }
+
+        [Fact]
+        public void Should_EnableFlexibleMode()
+        {
+            var schema = new ChannelSchemaBuilder("P", "T", "1.0")
+                .WithFlexibleMode()
+                .Build();
+
+            Assert.False(schema.IsStrict);
+        }
+
+        [Fact]
+        public void Should_NotThrow_When_WithIdIsCalled()
+        {
+            var schema = new ChannelSchemaBuilder("P", "T", "1.0")
+                .WithId("test-id")
+                .Build();
+
+            Assert.NotNull(schema);
+        }
+
+        [Fact]
+        public void Should_BuildSchemaFromExistingSchema()
+        {
+            var source = new ChannelSchema("SourceProvider", "SourceType", "2.0");
+            source.DisplayName = "Original Schema";
+
+            var schema = ChannelSchemaBuilder.From(source)
+                .WithDisplayName("Custom Display")
+                .Build();
+
+            Assert.Equal("SourceProvider", schema.ChannelProvider);
+            Assert.Equal("SourceType", schema.ChannelType);
+            Assert.Equal("2.0", schema.Version);
+            Assert.Equal("Custom Display", schema.DisplayName);
+        }
+
+        [Fact]
+        public void Should_BuildFromSource_WithDefaultCopyDisplayName()
+        {
+            var source = new ChannelSchema("P", "T", "1.0");
+            source.DisplayName = "Original";
+
+            var schema = ChannelSchemaBuilder.From(source).Build();
+
+            Assert.Equal("Original (Copy)", schema.DisplayName);
+        }
+    }
+}

--- a/test/Deveel.Messaging.Connectors.XUnit/Unit/ChannelSchemaRegistryTests.cs
+++ b/test/Deveel.Messaging.Connectors.XUnit/Unit/ChannelSchemaRegistryTests.cs
@@ -244,8 +244,8 @@ namespace Deveel.Messaging.XUnit
 				return ValueTask.CompletedTask;
 			}
 			protected override ValueTask TestConnectorConnectionAsync(CancellationToken cancellationToken) => ValueTask.CompletedTask;
-			protected override Task<SendResult> SendMessageCoreAsync(IMessage message, CancellationToken cancellationToken) => throw new NotImplementedException();
-			protected override Task<StatusInfo> GetConnectorStatusAsync(CancellationToken cancellationToken) => throw new NotImplementedException();
+			protected override Task<SendResult> SendMessageCoreAsync(IMessage message, CancellationToken cancellationToken) => throw new NotSupportedException();
+			protected override Task<StatusInfo> GetConnectorStatusAsync(CancellationToken cancellationToken) => throw new NotSupportedException();
 		}
 
 		[ChannelSchema(typeof(AnotherTestSchemaFactory))]
@@ -258,8 +258,8 @@ namespace Deveel.Messaging.XUnit
 				return ValueTask.CompletedTask;
 			}
 			protected override ValueTask TestConnectorConnectionAsync(CancellationToken cancellationToken) => ValueTask.CompletedTask;
-			protected override Task<SendResult> SendMessageCoreAsync(IMessage message, CancellationToken cancellationToken) => throw new NotImplementedException();
-			protected override Task<StatusInfo> GetConnectorStatusAsync(CancellationToken cancellationToken) => throw new NotImplementedException();
+			protected override Task<SendResult> SendMessageCoreAsync(IMessage message, CancellationToken cancellationToken) => throw new NotSupportedException();
+			protected override Task<StatusInfo> GetConnectorStatusAsync(CancellationToken cancellationToken) => throw new NotSupportedException();
 		}
 
 		/// <summary>A connector registered directly in the DI container with a distinct schema.</summary>
@@ -273,14 +273,14 @@ namespace Deveel.Messaging.XUnit
 			public ConnectorState State => ConnectorState.Ready;
 			public ValueTask<OperationResult<bool>> InitializeAsync(CancellationToken ct) => new ValueTask<OperationResult<bool>>(OperationResult<bool>.Success(true));
 			public ValueTask<OperationResult<bool>> TestConnectionAsync(CancellationToken ct) => new ValueTask<OperationResult<bool>>(OperationResult<bool>.Success(true));
-			public ValueTask<OperationResult<SendResult>> SendMessageAsync(IMessage message, CancellationToken ct) => throw new NotImplementedException();
-			public ValueTask<OperationResult<BatchSendResult>> SendBatchAsync(IMessageBatch batch, CancellationToken ct) => throw new NotImplementedException();
-			public ValueTask<OperationResult<StatusInfo>> GetStatusAsync(CancellationToken ct) => throw new NotImplementedException();
-			public ValueTask<OperationResult<StatusUpdatesResult>> GetMessageStatusAsync(string messageId, CancellationToken ct) => throw new NotImplementedException();
-			public IAsyncEnumerable<ValidationResult> ValidateMessageAsync(IMessage message, CancellationToken ct) => throw new NotImplementedException();
-			public ValueTask<OperationResult<StatusUpdateResult>> ReceiveMessageStatusAsync(MessageSource source, CancellationToken ct) => throw new NotImplementedException();
-			public ValueTask<OperationResult<ReceiveResult>> ReceiveMessagesAsync(MessageSource source, CancellationToken ct) => throw new NotImplementedException();
-			public ValueTask<OperationResult<ConnectorHealth>> GetHealthAsync(CancellationToken ct) => throw new NotImplementedException();
+			public ValueTask<OperationResult<SendResult>> SendMessageAsync(IMessage message, CancellationToken ct) => throw new NotSupportedException();
+			public ValueTask<OperationResult<BatchSendResult>> SendBatchAsync(IMessageBatch batch, CancellationToken ct) => throw new NotSupportedException();
+			public ValueTask<OperationResult<StatusInfo>> GetStatusAsync(CancellationToken ct) => throw new NotSupportedException();
+			public ValueTask<OperationResult<StatusUpdatesResult>> GetMessageStatusAsync(string messageId, CancellationToken ct) => throw new NotSupportedException();
+			public IAsyncEnumerable<ValidationResult> ValidateMessageAsync(IMessage message, CancellationToken ct) => throw new NotSupportedException();
+			public ValueTask<OperationResult<StatusUpdateResult>> ReceiveMessageStatusAsync(MessageSource source, CancellationToken ct) => throw new NotSupportedException();
+			public ValueTask<OperationResult<ReceiveResult>> ReceiveMessagesAsync(MessageSource source, CancellationToken ct) => throw new NotSupportedException();
+			public ValueTask<OperationResult<ConnectorHealth>> GetHealthAsync(CancellationToken ct) => throw new NotSupportedException();
 			public ValueTask ShutdownAsync(CancellationToken ct) => default;
 		}
 
@@ -295,14 +295,14 @@ namespace Deveel.Messaging.XUnit
 			public ConnectorState State => ConnectorState.Ready;
 			public ValueTask<OperationResult<bool>> InitializeAsync(CancellationToken ct) => new ValueTask<OperationResult<bool>>(OperationResult<bool>.Success(true));
 			public ValueTask<OperationResult<bool>> TestConnectionAsync(CancellationToken ct) => new ValueTask<OperationResult<bool>>(OperationResult<bool>.Success(true));
-			public ValueTask<OperationResult<SendResult>> SendMessageAsync(IMessage message, CancellationToken ct) => throw new NotImplementedException();
-			public ValueTask<OperationResult<BatchSendResult>> SendBatchAsync(IMessageBatch batch, CancellationToken ct) => throw new NotImplementedException();
-			public ValueTask<OperationResult<StatusInfo>> GetStatusAsync(CancellationToken ct) => throw new NotImplementedException();
-			public ValueTask<OperationResult<StatusUpdatesResult>> GetMessageStatusAsync(string messageId, CancellationToken ct) => throw new NotImplementedException();
-			public IAsyncEnumerable<ValidationResult> ValidateMessageAsync(IMessage message, CancellationToken ct) => throw new NotImplementedException();
-			public ValueTask<OperationResult<StatusUpdateResult>> ReceiveMessageStatusAsync(MessageSource source, CancellationToken ct) => throw new NotImplementedException();
-			public ValueTask<OperationResult<ReceiveResult>> ReceiveMessagesAsync(MessageSource source, CancellationToken ct) => throw new NotImplementedException();
-			public ValueTask<OperationResult<ConnectorHealth>> GetHealthAsync(CancellationToken ct) => throw new NotImplementedException();
+			public ValueTask<OperationResult<SendResult>> SendMessageAsync(IMessage message, CancellationToken ct) => throw new NotSupportedException();
+			public ValueTask<OperationResult<BatchSendResult>> SendBatchAsync(IMessageBatch batch, CancellationToken ct) => throw new NotSupportedException();
+			public ValueTask<OperationResult<StatusInfo>> GetStatusAsync(CancellationToken ct) => throw new NotSupportedException();
+			public ValueTask<OperationResult<StatusUpdatesResult>> GetMessageStatusAsync(string messageId, CancellationToken ct) => throw new NotSupportedException();
+			public IAsyncEnumerable<ValidationResult> ValidateMessageAsync(IMessage message, CancellationToken ct) => throw new NotSupportedException();
+			public ValueTask<OperationResult<StatusUpdateResult>> ReceiveMessageStatusAsync(MessageSource source, CancellationToken ct) => throw new NotSupportedException();
+			public ValueTask<OperationResult<ReceiveResult>> ReceiveMessagesAsync(MessageSource source, CancellationToken ct) => throw new NotSupportedException();
+			public ValueTask<OperationResult<ConnectorHealth>> GetHealthAsync(CancellationToken ct) => throw new NotSupportedException();
 			public ValueTask ShutdownAsync(CancellationToken ct) => default;
 		}
 

--- a/test/Deveel.Messaging.Connectors.XUnit/Unit/ChannelSchemaTests.cs
+++ b/test/Deveel.Messaging.Connectors.XUnit/Unit/ChannelSchemaTests.cs
@@ -1,0 +1,217 @@
+namespace Deveel.Messaging
+{
+    [Trait("Category", "Unit")]
+    [Trait("Feature", "ChannelSchema")]
+    public class ChannelSchemaTests
+    {
+        [Fact]
+        public void Should_SetProperties_When_Constructed()
+        {
+            var schema = new ChannelSchema("TestProvider", "TestType", "1.0");
+
+            Assert.Equal("TestProvider", schema.ChannelProvider);
+            Assert.Equal("TestType", schema.ChannelType);
+            Assert.Equal("1.0", schema.Version);
+            Assert.True(schema.IsStrict);
+            Assert.Equal(ChannelCapability.SendMessages, schema.Capabilities);
+            Assert.Empty(schema.Parameters);
+            Assert.Empty(schema.MessageProperties);
+            Assert.Empty(schema.ContentTypes);
+            Assert.Empty(schema.AuthenticationConfigurations);
+            Assert.Empty(schema.Endpoints);
+        }
+
+        [Fact]
+        public void Should_ThrowArgumentNullException_When_ChannelProviderIsNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => new ChannelSchema(null!, "Type", "1.0"));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(" ")]
+        public void Should_ThrowArgumentException_When_ChannelProviderIsEmptyOrWhitespace(string provider)
+        {
+            Assert.Throws<ArgumentException>(() => new ChannelSchema(provider, "Type", "1.0"));
+        }
+
+        [Fact]
+        public void Should_ThrowArgumentNullException_When_ChannelTypeIsNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => new ChannelSchema("Provider", null!, "1.0"));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(" ")]
+        public void Should_ThrowArgumentException_When_ChannelTypeIsEmptyOrWhitespace(string type)
+        {
+            Assert.Throws<ArgumentException>(() => new ChannelSchema("Provider", type, "1.0"));
+        }
+
+        [Fact]
+        public void Should_ThrowArgumentNullException_When_VersionIsNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => new ChannelSchema("Provider", "Type", null!));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(" ")]
+        public void Should_ThrowArgumentException_When_VersionIsEmptyOrWhitespace(string version)
+        {
+            Assert.Throws<ArgumentException>(() => new ChannelSchema("Provider", "Type", version));
+        }
+
+        [Fact]
+        public void Should_ThrowArgumentNullException_When_CopySourceIsNull()
+        {
+            Assert.Throws<ArgumentNullException>(() => new ChannelSchema(null!, "Derived"));
+        }
+
+        [Fact]
+        public void Should_CopyProperties_When_UsingCopyConstructor()
+        {
+            var source = new ChannelSchema("SourceProvider", "SourceType", "2.0");
+            source.DisplayName = "Original Schema";
+            source.IsStrict = false;
+            source.Capabilities = ChannelCapability.SendMessages | ChannelCapability.ReceiveMessages;
+
+            var copy = new ChannelSchema(source);
+
+            Assert.Equal(source.ChannelProvider, copy.ChannelProvider);
+            Assert.Equal(source.ChannelType, copy.ChannelType);
+            Assert.Equal(source.Version, copy.Version);
+            Assert.Equal(source.IsStrict, copy.IsStrict);
+            Assert.Equal(source.Capabilities, copy.Capabilities);
+        }
+
+        [Fact]
+        public void Should_SetDefaultDisplayName_When_CopyingWithoutDerivedName()
+        {
+            var source = new ChannelSchema("P", "T", "1.0");
+            source.DisplayName = "Original";
+
+            var copy = new ChannelSchema(source);
+
+            Assert.Equal("Original (Copy)", copy.DisplayName);
+        }
+
+        [Fact]
+        public void Should_UseDerivedDisplayName_When_Provided()
+        {
+            var source = new ChannelSchema("P", "T", "1.0");
+
+            var copy = new ChannelSchema(source, "Custom Copy");
+
+            Assert.Equal("Custom Copy", copy.DisplayName);
+        }
+
+        [Fact]
+        public void Should_DeepCopyParameters_When_UsingCopyConstructor()
+        {
+            var source = new ChannelSchema("P", "T", "1.0");
+            var param = new ChannelParameter("ApiKey", DataType.String);
+            var field = typeof(ChannelSchema).GetField("parameters",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            var list = field!.GetValue(source) as System.Collections.IList;
+            list!.Add(param);
+
+            var copy = new ChannelSchema(source);
+
+            Assert.Single(copy.Parameters);
+            Assert.Equal("ApiKey", copy.Parameters[0].Name);
+        }
+
+        [Fact]
+        public void Should_DeepCopyAuthenticationConfigurations_When_UsingCopyConstructor()
+        {
+            var source = new ChannelSchema("P", "T", "1.0");
+            var authConfig = new AuthenticationConfiguration(AuthenticationScheme.ApiKey, "API Key");
+            var field = typeof(ChannelSchema).GetField("authenticationConfigurations",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            var list = field!.GetValue(source) as System.Collections.IList;
+            list!.Add(authConfig);
+
+            var copy = new ChannelSchema(source);
+
+            Assert.Single(copy.AuthenticationConfigurations);
+            Assert.Equal(AuthenticationScheme.ApiKey, copy.AuthenticationConfigurations[0].Scheme);
+        }
+
+        [Fact]
+        public void Should_DeepCopyContentTypes_When_UsingCopyConstructor()
+        {
+            var source = new ChannelSchema("P", "T", "1.0");
+            var contentType = MessageContentType.PlainText;
+            var field = typeof(ChannelSchema).GetField("contentTypes",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            var list = field!.GetValue(source) as System.Collections.IList;
+            list!.Add(contentType);
+
+            var copy = new ChannelSchema(source);
+
+            Assert.Single(copy.ContentTypes);
+            Assert.Equal(MessageContentType.PlainText, copy.ContentTypes[0]);
+        }
+
+        [Fact]
+        public void Should_DeepCopyEndpoints_When_UsingCopyConstructor()
+        {
+            var source = new ChannelSchema("P", "T", "1.0");
+            var endpoint = new ChannelEndpointConfiguration(EndpointType.EmailAddress);
+            var field = typeof(ChannelSchema).GetField("endpoints",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            var list = field!.GetValue(source) as System.Collections.IList;
+            list!.Add(endpoint);
+
+            var copy = new ChannelSchema(source);
+
+            Assert.Single(copy.Endpoints);
+            Assert.Equal(EndpointType.EmailAddress, copy.Endpoints[0].Type);
+        }
+
+        [Fact]
+        public void Should_ReturnDistinctAuthenticationSchemes()
+        {
+            var source = new ChannelSchema("P", "T", "1.0");
+            var authConfig1 = new AuthenticationConfiguration(AuthenticationScheme.ApiKey, "API Key");
+            var authConfig2 = new AuthenticationConfiguration(AuthenticationScheme.Bearer, "Bearer");
+            var field = typeof(ChannelSchema).GetField("authenticationConfigurations",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            var list = field!.GetValue(source) as System.Collections.IList;
+            list!.Add(authConfig1);
+            list!.Add(authConfig2);
+
+            var schemes = source.AuthenticationSchemes.ToList();
+
+            Assert.Equal(2, schemes.Count);
+            Assert.Contains(AuthenticationScheme.ApiKey, schemes);
+            Assert.Contains(AuthenticationScheme.Bearer, schemes);
+        }
+
+        [Fact]
+        public void Should_SetDisplayName_When_PropertyIsSet()
+        {
+            var schema = new ChannelSchema("P", "T", "1.0");
+            schema.DisplayName = "My Channel";
+            Assert.Equal("My Channel", schema.DisplayName);
+        }
+
+        [Fact]
+        public void Should_SetIsStrict_When_PropertyIsSet()
+        {
+            var schema = new ChannelSchema("P", "T", "1.0");
+            schema.IsStrict = false;
+            Assert.False(schema.IsStrict);
+        }
+
+        [Fact]
+        public void Should_SetCapabilities_When_PropertyIsSet()
+        {
+            var schema = new ChannelSchema("P", "T", "1.0");
+            schema.Capabilities = ChannelCapability.ReceiveMessages;
+            Assert.Equal(ChannelCapability.ReceiveMessages, schema.Capabilities);
+        }
+    }
+}

--- a/test/Deveel.Messaging.Connectors.XUnit/Unit/ConnectorDescriptorExtendedTests.cs
+++ b/test/Deveel.Messaging.Connectors.XUnit/Unit/ConnectorDescriptorExtendedTests.cs
@@ -292,28 +292,28 @@ namespace Deveel.Messaging.XUnit
 				=> new ValueTask<OperationResult<bool>>(OperationResult<bool>.Success(true));
 
 			public ValueTask<OperationResult<SendResult>> SendMessageAsync(IMessage message, CancellationToken cancellationToken)
-				=> throw new NotImplementedException();
+				=> throw new NotSupportedException();
 
 			public ValueTask<OperationResult<BatchSendResult>> SendBatchAsync(IMessageBatch batch, CancellationToken cancellationToken)
-				=> throw new NotImplementedException();
+				=> throw new NotSupportedException();
 
 			public ValueTask<OperationResult<StatusInfo>> GetStatusAsync(CancellationToken cancellationToken)
-				=> throw new NotImplementedException();
+				=> throw new NotSupportedException();
 
 			public ValueTask<OperationResult<StatusUpdatesResult>> GetMessageStatusAsync(string messageId, CancellationToken cancellationToken)
-				=> throw new NotImplementedException();
+				=> throw new NotSupportedException();
 
 			public IAsyncEnumerable<ValidationResult> ValidateMessageAsync(IMessage message, CancellationToken cancellationToken)
-				=> throw new NotImplementedException();
+				=> throw new NotSupportedException();
 
 			public ValueTask<OperationResult<StatusUpdateResult>> ReceiveMessageStatusAsync(MessageSource source, CancellationToken cancellationToken)
-				=> throw new NotImplementedException();
+				=> throw new NotSupportedException();
 
 			public ValueTask<OperationResult<ReceiveResult>> ReceiveMessagesAsync(MessageSource source, CancellationToken cancellationToken)
-				=> throw new NotImplementedException();
+				=> throw new NotSupportedException();
 
 			public ValueTask<OperationResult<ConnectorHealth>> GetHealthAsync(CancellationToken cancellationToken)
-				=> throw new NotImplementedException();
+				=> throw new NotSupportedException();
 
 			public ValueTask ShutdownAsync(CancellationToken cancellationToken)
 				=> default;
@@ -331,28 +331,28 @@ namespace Deveel.Messaging.XUnit
 				=> new ValueTask<OperationResult<bool>>(OperationResult<bool>.Success(true));
 
 			public ValueTask<OperationResult<SendResult>> SendMessageAsync(IMessage message, CancellationToken cancellationToken)
-				=> throw new NotImplementedException();
+				=> throw new NotSupportedException();
 
 			public ValueTask<OperationResult<BatchSendResult>> SendBatchAsync(IMessageBatch batch, CancellationToken cancellationToken)
-				=> throw new NotImplementedException();
+				=> throw new NotSupportedException();
 
 			public ValueTask<OperationResult<StatusInfo>> GetStatusAsync(CancellationToken cancellationToken)
-				=> throw new NotImplementedException();
+				=> throw new NotSupportedException();
 
 			public ValueTask<OperationResult<StatusUpdatesResult>> GetMessageStatusAsync(string messageId, CancellationToken cancellationToken)
-				=> throw new NotImplementedException();
+				=> throw new NotSupportedException();
 
 			public IAsyncEnumerable<ValidationResult> ValidateMessageAsync(IMessage message, CancellationToken cancellationToken)
-				=> throw new NotImplementedException();
+				=> throw new NotSupportedException();
 
 			public ValueTask<OperationResult<StatusUpdateResult>> ReceiveMessageStatusAsync(MessageSource source, CancellationToken cancellationToken)
-				=> throw new NotImplementedException();
+				=> throw new NotSupportedException();
 
 			public ValueTask<OperationResult<ReceiveResult>> ReceiveMessagesAsync(MessageSource source, CancellationToken cancellationToken)
-				=> throw new NotImplementedException();
+				=> throw new NotSupportedException();
 
 			public ValueTask<OperationResult<ConnectorHealth>> GetHealthAsync(CancellationToken cancellationToken)
-				=> throw new NotImplementedException();
+				=> throw new NotSupportedException();
 
 			public ValueTask ShutdownAsync(CancellationToken cancellationToken)
 				=> default;

--- a/test/Deveel.Messaging.Connectors.XUnit/Unit/ConnectorOptionsTests.cs
+++ b/test/Deveel.Messaging.Connectors.XUnit/Unit/ConnectorOptionsTests.cs
@@ -38,14 +38,14 @@ namespace Deveel.Messaging.XUnit
 
             public ValueTask<OperationResult<bool>> InitializeAsync(CancellationToken ct) => new(OperationResult<bool>.Success(true));
             public ValueTask<OperationResult<bool>> TestConnectionAsync(CancellationToken ct) => new(OperationResult<bool>.Success(true));
-            public ValueTask<OperationResult<SendResult>> SendMessageAsync(IMessage m, CancellationToken ct) => throw new NotImplementedException();
-            public ValueTask<OperationResult<BatchSendResult>> SendBatchAsync(IMessageBatch b, CancellationToken ct) => throw new NotImplementedException();
-            public ValueTask<OperationResult<StatusInfo>> GetStatusAsync(CancellationToken ct) => throw new NotImplementedException();
-            public ValueTask<OperationResult<StatusUpdatesResult>> GetMessageStatusAsync(string id, CancellationToken ct) => throw new NotImplementedException();
-            public IAsyncEnumerable<ValidationResult> ValidateMessageAsync(IMessage m, CancellationToken ct) => throw new NotImplementedException();
-            public ValueTask<OperationResult<StatusUpdateResult>> ReceiveMessageStatusAsync(MessageSource s, CancellationToken ct) => throw new NotImplementedException();
-            public ValueTask<OperationResult<ReceiveResult>> ReceiveMessagesAsync(MessageSource s, CancellationToken ct) => throw new NotImplementedException();
-            public ValueTask<OperationResult<ConnectorHealth>> GetHealthAsync(CancellationToken ct) => throw new NotImplementedException();
+            public ValueTask<OperationResult<SendResult>> SendMessageAsync(IMessage m, CancellationToken ct) => throw new NotSupportedException();
+            public ValueTask<OperationResult<BatchSendResult>> SendBatchAsync(IMessageBatch b, CancellationToken ct) => throw new NotSupportedException();
+            public ValueTask<OperationResult<StatusInfo>> GetStatusAsync(CancellationToken ct) => throw new NotSupportedException();
+            public ValueTask<OperationResult<StatusUpdatesResult>> GetMessageStatusAsync(string id, CancellationToken ct) => throw new NotSupportedException();
+            public IAsyncEnumerable<ValidationResult> ValidateMessageAsync(IMessage m, CancellationToken ct) => throw new NotSupportedException();
+            public ValueTask<OperationResult<StatusUpdateResult>> ReceiveMessageStatusAsync(MessageSource s, CancellationToken ct) => throw new NotSupportedException();
+            public ValueTask<OperationResult<ReceiveResult>> ReceiveMessagesAsync(MessageSource s, CancellationToken ct) => throw new NotSupportedException();
+            public ValueTask<OperationResult<ConnectorHealth>> GetHealthAsync(CancellationToken ct) => throw new NotSupportedException();
             public ValueTask ShutdownAsync(CancellationToken ct) => default;
         }
 

--- a/test/Deveel.Messaging.Connectors.XUnit/Unit/MessagingBuilderExtendedTests.cs
+++ b/test/Deveel.Messaging.Connectors.XUnit/Unit/MessagingBuilderExtendedTests.cs
@@ -148,8 +148,8 @@ namespace Deveel.Messaging.XUnit
 			public TestConnector(IChannelSchema schema, ConnectionSettings? settings = null) : base(schema, settings) { }
 			protected override ValueTask InitializeConnectorAsync(CancellationToken cancellationToken) { SetState(ConnectorState.Ready); return ValueTask.CompletedTask; }
 			protected override ValueTask TestConnectorConnectionAsync(CancellationToken cancellationToken) => ValueTask.CompletedTask;
-			protected override Task<SendResult> SendMessageCoreAsync(IMessage message, CancellationToken cancellationToken) => throw new NotImplementedException();
-			protected override Task<StatusInfo> GetConnectorStatusAsync(CancellationToken cancellationToken) => throw new NotImplementedException();
+			protected override Task<SendResult> SendMessageCoreAsync(IMessage message, CancellationToken cancellationToken) => throw new NotSupportedException();
+			protected override Task<StatusInfo> GetConnectorStatusAsync(CancellationToken cancellationToken) => throw new NotSupportedException();
 		}
 
 		[ChannelSchema(typeof(AnotherTestSchemaFactory))]
@@ -158,8 +158,8 @@ namespace Deveel.Messaging.XUnit
 			public AnotherTestConnector(IChannelSchema schema, ConnectionSettings? settings = null) : base(schema, settings) { }
 			protected override ValueTask InitializeConnectorAsync(CancellationToken cancellationToken) { SetState(ConnectorState.Ready); return ValueTask.CompletedTask; }
 			protected override ValueTask TestConnectorConnectionAsync(CancellationToken cancellationToken) => ValueTask.CompletedTask;
-			protected override Task<SendResult> SendMessageCoreAsync(IMessage message, CancellationToken cancellationToken) => throw new NotImplementedException();
-			protected override Task<StatusInfo> GetConnectorStatusAsync(CancellationToken cancellationToken) => throw new NotImplementedException();
+			protected override Task<SendResult> SendMessageCoreAsync(IMessage message, CancellationToken cancellationToken) => throw new NotSupportedException();
+			protected override Task<StatusInfo> GetConnectorStatusAsync(CancellationToken cancellationToken) => throw new NotSupportedException();
 		}
 
 		[ChannelSchema(typeof(ThirdTestSchemaFactory))]
@@ -168,8 +168,8 @@ namespace Deveel.Messaging.XUnit
 			public ThirdTestConnector(IChannelSchema schema, ConnectionSettings? settings = null) : base(schema, settings) { }
 			protected override ValueTask InitializeConnectorAsync(CancellationToken cancellationToken) { SetState(ConnectorState.Ready); return ValueTask.CompletedTask; }
 			protected override ValueTask TestConnectorConnectionAsync(CancellationToken cancellationToken) => ValueTask.CompletedTask;
-			protected override Task<SendResult> SendMessageCoreAsync(IMessage message, CancellationToken cancellationToken) => throw new NotImplementedException();
-			protected override Task<StatusInfo> GetConnectorStatusAsync(CancellationToken cancellationToken) => throw new NotImplementedException();
+			protected override Task<SendResult> SendMessageCoreAsync(IMessage message, CancellationToken cancellationToken) => throw new NotSupportedException();
+			protected override Task<StatusInfo> GetConnectorStatusAsync(CancellationToken cancellationToken) => throw new NotSupportedException();
 		}
 
 		private class ConnectorWithoutAttribute : ChannelConnectorBase
@@ -177,8 +177,8 @@ namespace Deveel.Messaging.XUnit
 			public ConnectorWithoutAttribute(IChannelSchema schema, ConnectionSettings? settings = null) : base(schema, settings) { }
 			protected override ValueTask InitializeConnectorAsync(CancellationToken cancellationToken) => ValueTask.CompletedTask;
 			protected override ValueTask TestConnectorConnectionAsync(CancellationToken cancellationToken) => ValueTask.CompletedTask;
-			protected override Task<SendResult> SendMessageCoreAsync(IMessage message, CancellationToken cancellationToken) => throw new NotImplementedException();
-			protected override Task<StatusInfo> GetConnectorStatusAsync(CancellationToken cancellationToken) => throw new NotImplementedException();
+			protected override Task<SendResult> SendMessageCoreAsync(IMessage message, CancellationToken cancellationToken) => throw new NotSupportedException();
+			protected override Task<StatusInfo> GetConnectorStatusAsync(CancellationToken cancellationToken) => throw new NotSupportedException();
 		}
 
 		private class TestSchemaFactory : IChannelSchemaFactory

--- a/test/Deveel.Messaging.Connectors.XUnit/Unit/MessagingBuilderTests.cs
+++ b/test/Deveel.Messaging.Connectors.XUnit/Unit/MessagingBuilderTests.cs
@@ -238,14 +238,14 @@ namespace Deveel.Messaging.XUnit
 
 			public ValueTask<OperationResult<bool>> InitializeAsync(CancellationToken ct) => new ValueTask<OperationResult<bool>>(OperationResult<bool>.Success(true));
 			public ValueTask<OperationResult<bool>> TestConnectionAsync(CancellationToken ct) => new ValueTask<OperationResult<bool>>(OperationResult<bool>.Success(true));
-			public ValueTask<OperationResult<SendResult>> SendMessageAsync(IMessage message, CancellationToken ct) => throw new NotImplementedException();
-			public ValueTask<OperationResult<BatchSendResult>> SendBatchAsync(IMessageBatch batch, CancellationToken ct) => throw new NotImplementedException();
-			public ValueTask<OperationResult<StatusInfo>> GetStatusAsync(CancellationToken ct) => throw new NotImplementedException();
-			public ValueTask<OperationResult<StatusUpdatesResult>> GetMessageStatusAsync(string messageId, CancellationToken ct) => throw new NotImplementedException();
-			public IAsyncEnumerable<ValidationResult> ValidateMessageAsync(IMessage message, CancellationToken ct) => throw new NotImplementedException();
-			public ValueTask<OperationResult<StatusUpdateResult>> ReceiveMessageStatusAsync(MessageSource source, CancellationToken ct) => throw new NotImplementedException();
-			public ValueTask<OperationResult<ReceiveResult>> ReceiveMessagesAsync(MessageSource source, CancellationToken ct) => throw new NotImplementedException();
-			public ValueTask<OperationResult<ConnectorHealth>> GetHealthAsync(CancellationToken ct) => throw new NotImplementedException();
+			public ValueTask<OperationResult<SendResult>> SendMessageAsync(IMessage message, CancellationToken ct) => throw new NotSupportedException();
+			public ValueTask<OperationResult<BatchSendResult>> SendBatchAsync(IMessageBatch batch, CancellationToken ct) => throw new NotSupportedException();
+			public ValueTask<OperationResult<StatusInfo>> GetStatusAsync(CancellationToken ct) => throw new NotSupportedException();
+			public ValueTask<OperationResult<StatusUpdatesResult>> GetMessageStatusAsync(string messageId, CancellationToken ct) => throw new NotSupportedException();
+			public IAsyncEnumerable<ValidationResult> ValidateMessageAsync(IMessage message, CancellationToken ct) => throw new NotSupportedException();
+			public ValueTask<OperationResult<StatusUpdateResult>> ReceiveMessageStatusAsync(MessageSource source, CancellationToken ct) => throw new NotSupportedException();
+			public ValueTask<OperationResult<ReceiveResult>> ReceiveMessagesAsync(MessageSource source, CancellationToken ct) => throw new NotSupportedException();
+			public ValueTask<OperationResult<ConnectorHealth>> GetHealthAsync(CancellationToken ct) => throw new NotSupportedException();
 			public ValueTask ShutdownAsync(CancellationToken ct) => default;
 		}
 
@@ -259,14 +259,14 @@ namespace Deveel.Messaging.XUnit
 
 			public ValueTask<OperationResult<bool>> InitializeAsync(CancellationToken ct) => new ValueTask<OperationResult<bool>>(OperationResult<bool>.Success(true));
 			public ValueTask<OperationResult<bool>> TestConnectionAsync(CancellationToken ct) => new ValueTask<OperationResult<bool>>(OperationResult<bool>.Success(true));
-			public ValueTask<OperationResult<SendResult>> SendMessageAsync(IMessage message, CancellationToken ct) => throw new NotImplementedException();
-			public ValueTask<OperationResult<BatchSendResult>> SendBatchAsync(IMessageBatch batch, CancellationToken ct) => throw new NotImplementedException();
-			public ValueTask<OperationResult<StatusInfo>> GetStatusAsync(CancellationToken ct) => throw new NotImplementedException();
-			public ValueTask<OperationResult<StatusUpdatesResult>> GetMessageStatusAsync(string messageId, CancellationToken ct) => throw new NotImplementedException();
-			public IAsyncEnumerable<ValidationResult> ValidateMessageAsync(IMessage message, CancellationToken ct) => throw new NotImplementedException();
-			public ValueTask<OperationResult<StatusUpdateResult>> ReceiveMessageStatusAsync(MessageSource source, CancellationToken ct) => throw new NotImplementedException();
-			public ValueTask<OperationResult<ReceiveResult>> ReceiveMessagesAsync(MessageSource source, CancellationToken ct) => throw new NotImplementedException();
-			public ValueTask<OperationResult<ConnectorHealth>> GetHealthAsync(CancellationToken ct) => throw new NotImplementedException();
+			public ValueTask<OperationResult<SendResult>> SendMessageAsync(IMessage message, CancellationToken ct) => throw new NotSupportedException();
+			public ValueTask<OperationResult<BatchSendResult>> SendBatchAsync(IMessageBatch batch, CancellationToken ct) => throw new NotSupportedException();
+			public ValueTask<OperationResult<StatusInfo>> GetStatusAsync(CancellationToken ct) => throw new NotSupportedException();
+			public ValueTask<OperationResult<StatusUpdatesResult>> GetMessageStatusAsync(string messageId, CancellationToken ct) => throw new NotSupportedException();
+			public IAsyncEnumerable<ValidationResult> ValidateMessageAsync(IMessage message, CancellationToken ct) => throw new NotSupportedException();
+			public ValueTask<OperationResult<StatusUpdateResult>> ReceiveMessageStatusAsync(MessageSource source, CancellationToken ct) => throw new NotSupportedException();
+			public ValueTask<OperationResult<ReceiveResult>> ReceiveMessagesAsync(MessageSource source, CancellationToken ct) => throw new NotSupportedException();
+			public ValueTask<OperationResult<ConnectorHealth>> GetHealthAsync(CancellationToken ct) => throw new NotSupportedException();
 			public ValueTask ShutdownAsync(CancellationToken ct) => default;
 		}
 
@@ -276,16 +276,16 @@ namespace Deveel.Messaging.XUnit
 			public IChannelSchema Schema { get; }
 			public ConnectorState State => ConnectorState.Uninitialized;
 
-			public ValueTask<OperationResult<bool>> InitializeAsync(CancellationToken ct) => throw new NotImplementedException();
-			public ValueTask<OperationResult<bool>> TestConnectionAsync(CancellationToken ct) => throw new NotImplementedException();
-			public ValueTask<OperationResult<SendResult>> SendMessageAsync(IMessage message, CancellationToken ct) => throw new NotImplementedException();
-			public ValueTask<OperationResult<BatchSendResult>> SendBatchAsync(IMessageBatch batch, CancellationToken ct) => throw new NotImplementedException();
-			public ValueTask<OperationResult<StatusInfo>> GetStatusAsync(CancellationToken ct) => throw new NotImplementedException();
-			public ValueTask<OperationResult<StatusUpdatesResult>> GetMessageStatusAsync(string messageId, CancellationToken ct) => throw new NotImplementedException();
-			public IAsyncEnumerable<ValidationResult> ValidateMessageAsync(IMessage message, CancellationToken ct) => throw new NotImplementedException();
-			public ValueTask<OperationResult<StatusUpdateResult>> ReceiveMessageStatusAsync(MessageSource source, CancellationToken ct) => throw new NotImplementedException();
-			public ValueTask<OperationResult<ReceiveResult>> ReceiveMessagesAsync(MessageSource source, CancellationToken ct) => throw new NotImplementedException();
-			public ValueTask<OperationResult<ConnectorHealth>> GetHealthAsync(CancellationToken ct) => throw new NotImplementedException();
+			public ValueTask<OperationResult<bool>> InitializeAsync(CancellationToken ct) => throw new NotSupportedException();
+			public ValueTask<OperationResult<bool>> TestConnectionAsync(CancellationToken ct) => throw new NotSupportedException();
+			public ValueTask<OperationResult<SendResult>> SendMessageAsync(IMessage message, CancellationToken ct) => throw new NotSupportedException();
+			public ValueTask<OperationResult<BatchSendResult>> SendBatchAsync(IMessageBatch batch, CancellationToken ct) => throw new NotSupportedException();
+			public ValueTask<OperationResult<StatusInfo>> GetStatusAsync(CancellationToken ct) => throw new NotSupportedException();
+			public ValueTask<OperationResult<StatusUpdatesResult>> GetMessageStatusAsync(string messageId, CancellationToken ct) => throw new NotSupportedException();
+			public IAsyncEnumerable<ValidationResult> ValidateMessageAsync(IMessage message, CancellationToken ct) => throw new NotSupportedException();
+			public ValueTask<OperationResult<StatusUpdateResult>> ReceiveMessageStatusAsync(MessageSource source, CancellationToken ct) => throw new NotSupportedException();
+			public ValueTask<OperationResult<ReceiveResult>> ReceiveMessagesAsync(MessageSource source, CancellationToken ct) => throw new NotSupportedException();
+			public ValueTask<OperationResult<ConnectorHealth>> GetHealthAsync(CancellationToken ct) => throw new NotSupportedException();
 			public ValueTask ShutdownAsync(CancellationToken ct) => default;
 		}
 

--- a/test/Deveel.Messaging.Connectors.XUnit/Unit/ServiceCollectionExtensionsTests.cs
+++ b/test/Deveel.Messaging.Connectors.XUnit/Unit/ServiceCollectionExtensionsTests.cs
@@ -128,8 +128,8 @@ namespace Deveel.Messaging.XUnit
 				return ValueTask.CompletedTask;
 			}
 			protected override ValueTask TestConnectorConnectionAsync(CancellationToken cancellationToken) => ValueTask.CompletedTask;
-			protected override Task<SendResult> SendMessageCoreAsync(IMessage message, CancellationToken cancellationToken) => throw new NotImplementedException();
-			protected override Task<StatusInfo> GetConnectorStatusAsync(CancellationToken cancellationToken) => throw new NotImplementedException();
+			protected override Task<SendResult> SendMessageCoreAsync(IMessage message, CancellationToken cancellationToken) => throw new NotSupportedException();
+			protected override Task<StatusInfo> GetConnectorStatusAsync(CancellationToken cancellationToken) => throw new NotSupportedException();
 		}
 
 		[ChannelSchema(typeof(AnotherTestSchemaFactory))]
@@ -142,8 +142,8 @@ namespace Deveel.Messaging.XUnit
 				return ValueTask.CompletedTask;
 			}
 			protected override ValueTask TestConnectorConnectionAsync(CancellationToken cancellationToken) => ValueTask.CompletedTask;
-			protected override Task<SendResult> SendMessageCoreAsync(IMessage message, CancellationToken cancellationToken) => throw new NotImplementedException();
-			protected override Task<StatusInfo> GetConnectorStatusAsync(CancellationToken cancellationToken) => throw new NotImplementedException();
+			protected override Task<SendResult> SendMessageCoreAsync(IMessage message, CancellationToken cancellationToken) => throw new NotSupportedException();
+			protected override Task<StatusInfo> GetConnectorStatusAsync(CancellationToken cancellationToken) => throw new NotSupportedException();
 		}
 
 		private class ConnectorWithoutAttribute : ChannelConnectorBase
@@ -151,8 +151,8 @@ namespace Deveel.Messaging.XUnit
 			public ConnectorWithoutAttribute(IChannelSchema schema, ConnectionSettings? settings = null) : base(schema, settings) { }
 			protected override ValueTask InitializeConnectorAsync(CancellationToken cancellationToken) => ValueTask.CompletedTask;
 			protected override ValueTask TestConnectorConnectionAsync(CancellationToken cancellationToken) => ValueTask.CompletedTask;
-			protected override Task<SendResult> SendMessageCoreAsync(IMessage message, CancellationToken cancellationToken) => throw new NotImplementedException();
-			protected override Task<StatusInfo> GetConnectorStatusAsync(CancellationToken cancellationToken) => throw new NotImplementedException();
+			protected override Task<SendResult> SendMessageCoreAsync(IMessage message, CancellationToken cancellationToken) => throw new NotSupportedException();
+			protected override Task<StatusInfo> GetConnectorStatusAsync(CancellationToken cancellationToken) => throw new NotSupportedException();
 		}
 
 		private class TestSchemaFactory : IChannelSchemaFactory

--- a/test/Deveel.Messaging.XUnit/Unit/AddConnectorTypeRegistrationTests.cs
+++ b/test/Deveel.Messaging.XUnit/Unit/AddConnectorTypeRegistrationTests.cs
@@ -16,7 +16,10 @@ namespace Deveel.Messaging.XUnit.Unit
 
             builder.AddConnectorType<MockConnector>("mock");
 
-            Assert.Contains(builder.ConnectorTypeRegistrations, r => r.Name == "mock" && r.ConnectorType == typeof(MockConnector));
+            var prop = typeof(MessagingBuilder).GetProperty("ConnectorTypeRegistrations",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            var registrations = (List<(string Name, Type ConnectorType)>)prop!.GetValue(builder)!;
+            Assert.Contains(registrations, r => r.Name == "mock" && r.ConnectorType == typeof(MockConnector));
         }
 
         [Fact]
@@ -87,9 +90,12 @@ namespace Deveel.Messaging.XUnit.Unit
             builder.AddConnectorType<MockConnector>("first");
             builder.AddConnectorType<MockConnector>("second");
 
-            Assert.Equal(2, builder.ConnectorTypeRegistrations.Count);
-            Assert.Contains(builder.ConnectorTypeRegistrations, r => r.Name == "first");
-            Assert.Contains(builder.ConnectorTypeRegistrations, r => r.Name == "second");
+            var prop = typeof(MessagingBuilder).GetProperty("ConnectorTypeRegistrations",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            var registrations = (List<(string Name, Type ConnectorType)>)prop!.GetValue(builder)!;
+            Assert.Equal(2, registrations.Count);
+            Assert.Contains(registrations, r => r.Name == "first");
+            Assert.Contains(registrations, r => r.Name == "second");
         }
 
         [Fact]
@@ -162,7 +168,10 @@ namespace Deveel.Messaging.XUnit.Unit
 
             builder.AddConnectorType<MockConnector>();
 
-            Assert.Contains(builder.ConnectorTypeRegistrations,
+            var prop = typeof(MessagingBuilder).GetProperty("ConnectorTypeRegistrations",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            var registrations = (List<(string Name, Type ConnectorType)>)prop!.GetValue(builder)!;
+            Assert.Contains(registrations,
                 r => r.Name == "MockConnector" && r.ConnectorType == typeof(MockConnector));
         }
 

--- a/test/Deveel.Messaging.XUnit/Unit/AddConnectorTypeRegistrationTests.cs
+++ b/test/Deveel.Messaging.XUnit/Unit/AddConnectorTypeRegistrationTests.cs
@@ -227,26 +227,26 @@ namespace Deveel.Messaging.XUnit.Unit
 
         private class InvalidConnector : IChannelConnector
         {
-            public IChannelSchema Schema => throw new NotImplementedException();
+            public IChannelSchema Schema => throw new NotSupportedException();
             public ConnectorState State => ConnectorState.Uninitialized;
 
             public ValueTask<OperationResult<bool>> InitializeAsync(CancellationToken cancellationToken)
                 => new(OperationResult<bool>.Fail("X", "X", "X"));
 
             public ValueTask<OperationResult<SendResult>> SendMessageAsync(IMessage message, CancellationToken cancellationToken)
-                => throw new NotImplementedException();
+                => throw new NotSupportedException();
 
             public ValueTask<OperationResult<BatchSendResult>> SendBatchAsync(IMessageBatch batch, CancellationToken cancellationToken)
-                => throw new NotImplementedException();
+                => throw new NotSupportedException();
 
             public ValueTask<OperationResult<ReceiveResult>> ReceiveMessagesAsync(MessageSource source, CancellationToken cancellationToken)
-                => throw new NotImplementedException();
+                => throw new NotSupportedException();
 
             public ValueTask<OperationResult<StatusInfo>> GetStatusAsync(CancellationToken cancellationToken)
-                => throw new NotImplementedException();
+                => throw new NotSupportedException();
 
             public ValueTask<OperationResult<StatusUpdatesResult>> GetMessageStatusAsync(string messageId, CancellationToken cancellationToken)
-                => throw new NotImplementedException();
+                => throw new NotSupportedException();
 
             public async IAsyncEnumerable<ValidationResult> ValidateMessageAsync(IMessage message, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
             {
@@ -255,13 +255,13 @@ namespace Deveel.Messaging.XUnit.Unit
             }
 
             public ValueTask<OperationResult<StatusUpdateResult>> ReceiveMessageStatusAsync(MessageSource source, CancellationToken cancellationToken)
-                => throw new NotImplementedException();
+                => throw new NotSupportedException();
 
             public ValueTask<OperationResult<bool>> TestConnectionAsync(CancellationToken cancellationToken)
-                => throw new NotImplementedException();
+                => throw new NotSupportedException();
 
             public ValueTask<OperationResult<ConnectorHealth>> GetHealthAsync(CancellationToken cancellationToken)
-                => throw new NotImplementedException();
+                => throw new NotSupportedException();
 
             public ValueTask ShutdownAsync(CancellationToken cancellationToken)
                 => default;

--- a/test/Deveel.Messaging.XUnit/Unit/ChannelSchemaRegistryTests.cs
+++ b/test/Deveel.Messaging.XUnit/Unit/ChannelSchemaRegistryTests.cs
@@ -61,14 +61,14 @@ namespace Deveel.Messaging.XUnit.Unit
             public ConnectorState State => ConnectorState.Uninitialized;
             public ValueTask<OperationResult<bool>> InitializeAsync(CancellationToken ct) => new ValueTask<OperationResult<bool>>(OperationResult<bool>.Success(true));
             public ValueTask<OperationResult<bool>> TestConnectionAsync(CancellationToken ct) => new ValueTask<OperationResult<bool>>(OperationResult<bool>.Success(true));
-            public ValueTask<OperationResult<SendResult>> SendMessageAsync(IMessage message, CancellationToken ct) => throw new NotImplementedException();
-            public ValueTask<OperationResult<BatchSendResult>> SendBatchAsync(IMessageBatch batch, CancellationToken ct) => throw new NotImplementedException();
-            public ValueTask<OperationResult<StatusInfo>> GetStatusAsync(CancellationToken ct) => throw new NotImplementedException();
-            public ValueTask<OperationResult<StatusUpdatesResult>> GetMessageStatusAsync(string messageId, CancellationToken ct) => throw new NotImplementedException();
+            public ValueTask<OperationResult<SendResult>> SendMessageAsync(IMessage message, CancellationToken ct) => throw new NotSupportedException();
+            public ValueTask<OperationResult<BatchSendResult>> SendBatchAsync(IMessageBatch batch, CancellationToken ct) => throw new NotSupportedException();
+            public ValueTask<OperationResult<StatusInfo>> GetStatusAsync(CancellationToken ct) => throw new NotSupportedException();
+            public ValueTask<OperationResult<StatusUpdatesResult>> GetMessageStatusAsync(string messageId, CancellationToken ct) => throw new NotSupportedException();
             public async IAsyncEnumerable<ValidationResult> ValidateMessageAsync(IMessage message, [EnumeratorCancellation] CancellationToken ct) { await Task.CompletedTask; yield break; }
-            public ValueTask<OperationResult<StatusUpdateResult>> ReceiveMessageStatusAsync(MessageSource source, CancellationToken ct) => throw new NotImplementedException();
-            public ValueTask<OperationResult<ReceiveResult>> ReceiveMessagesAsync(MessageSource source, CancellationToken ct) => throw new NotImplementedException();
-            public ValueTask<OperationResult<ConnectorHealth>> GetHealthAsync(CancellationToken ct) => throw new NotImplementedException();
+            public ValueTask<OperationResult<StatusUpdateResult>> ReceiveMessageStatusAsync(MessageSource source, CancellationToken ct) => throw new NotSupportedException();
+            public ValueTask<OperationResult<ReceiveResult>> ReceiveMessagesAsync(MessageSource source, CancellationToken ct) => throw new NotSupportedException();
+            public ValueTask<OperationResult<ConnectorHealth>> GetHealthAsync(CancellationToken ct) => throw new NotSupportedException();
             public ValueTask ShutdownAsync(CancellationToken ct) => default;
         }
 
@@ -85,14 +85,14 @@ namespace Deveel.Messaging.XUnit.Unit
             public ConnectorState State => ConnectorState.Uninitialized;
             public ValueTask<OperationResult<bool>> InitializeAsync(CancellationToken ct) => new ValueTask<OperationResult<bool>>(OperationResult<bool>.Success(true));
             public ValueTask<OperationResult<bool>> TestConnectionAsync(CancellationToken ct) => new ValueTask<OperationResult<bool>>(OperationResult<bool>.Success(true));
-            public ValueTask<OperationResult<SendResult>> SendMessageAsync(IMessage message, CancellationToken ct) => throw new NotImplementedException();
-            public ValueTask<OperationResult<BatchSendResult>> SendBatchAsync(IMessageBatch batch, CancellationToken ct) => throw new NotImplementedException();
-            public ValueTask<OperationResult<StatusInfo>> GetStatusAsync(CancellationToken ct) => throw new NotImplementedException();
-            public ValueTask<OperationResult<StatusUpdatesResult>> GetMessageStatusAsync(string messageId, CancellationToken ct) => throw new NotImplementedException();
+            public ValueTask<OperationResult<SendResult>> SendMessageAsync(IMessage message, CancellationToken ct) => throw new NotSupportedException();
+            public ValueTask<OperationResult<BatchSendResult>> SendBatchAsync(IMessageBatch batch, CancellationToken ct) => throw new NotSupportedException();
+            public ValueTask<OperationResult<StatusInfo>> GetStatusAsync(CancellationToken ct) => throw new NotSupportedException();
+            public ValueTask<OperationResult<StatusUpdatesResult>> GetMessageStatusAsync(string messageId, CancellationToken ct) => throw new NotSupportedException();
             public async IAsyncEnumerable<ValidationResult> ValidateMessageAsync(IMessage message, [EnumeratorCancellation] CancellationToken ct) { await Task.CompletedTask; yield break; }
-            public ValueTask<OperationResult<StatusUpdateResult>> ReceiveMessageStatusAsync(MessageSource source, CancellationToken ct) => throw new NotImplementedException();
-            public ValueTask<OperationResult<ReceiveResult>> ReceiveMessagesAsync(MessageSource source, CancellationToken ct) => throw new NotImplementedException();
-            public ValueTask<OperationResult<ConnectorHealth>> GetHealthAsync(CancellationToken ct) => throw new NotImplementedException();
+            public ValueTask<OperationResult<StatusUpdateResult>> ReceiveMessageStatusAsync(MessageSource source, CancellationToken ct) => throw new NotSupportedException();
+            public ValueTask<OperationResult<ReceiveResult>> ReceiveMessagesAsync(MessageSource source, CancellationToken ct) => throw new NotSupportedException();
+            public ValueTask<OperationResult<ConnectorHealth>> GetHealthAsync(CancellationToken ct) => throw new NotSupportedException();
             public ValueTask ShutdownAsync(CancellationToken ct) => default;
         }
 

--- a/test/Deveel.Messaging.XUnit/Unit/ConnectorSchemaHelperTests.cs
+++ b/test/Deveel.Messaging.XUnit/Unit/ConnectorSchemaHelperTests.cs
@@ -140,5 +140,81 @@ namespace Deveel.Messaging.XUnit.Unit
             Assert.NotNull(connector);
             Assert.Equal("PublicTest", connector.Schema.ChannelProvider);
         }
+        [ChannelSchema(typeof(int))]
+        private class ConnectorWithInvalidSchemaType : IChannelConnector
+        {
+            public ConnectorWithInvalidSchemaType(IChannelSchema schema, ConnectionSettings? settings = null)
+            {
+                Schema = schema;
+                ConnectionSettings = settings ?? new ConnectionSettings();
+            }
+            public IChannelSchema Schema { get; }
+            public ConnectionSettings ConnectionSettings { get; }
+            public ConnectorState State => ConnectorState.Uninitialized;
+            public ValueTask<OperationResult<bool>> InitializeAsync(CancellationToken ct) => new ValueTask<OperationResult<bool>>(OperationResult<bool>.Success(true));
+            public ValueTask<OperationResult<bool>> TestConnectionAsync(CancellationToken ct) => new ValueTask<OperationResult<bool>>(OperationResult<bool>.Success(true));
+            public ValueTask<OperationResult<SendResult>> SendMessageAsync(IMessage message, CancellationToken ct) => throw new NotImplementedException();
+            public ValueTask<OperationResult<BatchSendResult>> SendBatchAsync(IMessageBatch batch, CancellationToken ct) => throw new NotImplementedException();
+            public ValueTask<OperationResult<StatusInfo>> GetStatusAsync(CancellationToken ct) => throw new NotImplementedException();
+            public ValueTask<OperationResult<StatusUpdatesResult>> GetMessageStatusAsync(string messageId, CancellationToken ct) => throw new NotImplementedException();
+            public async IAsyncEnumerable<ValidationResult> ValidateMessageAsync(IMessage message, [EnumeratorCancellation] CancellationToken ct) { await Task.CompletedTask; yield break; }
+            public ValueTask<OperationResult<StatusUpdateResult>> ReceiveMessageStatusAsync(MessageSource source, CancellationToken ct) => throw new NotImplementedException();
+            public ValueTask<OperationResult<ReceiveResult>> ReceiveMessagesAsync(MessageSource source, CancellationToken ct) => throw new NotImplementedException();
+            public ValueTask<OperationResult<ConnectorHealth>> GetHealthAsync(CancellationToken ct) => throw new NotImplementedException();
+            public ValueTask ShutdownAsync(CancellationToken ct) => default;
+        }
+
+        [Fact]
+        public void Should_ThrowArgumentException_When_SchemaTypeIsNotValid()
+        {
+            var services = new ServiceCollection();
+            services.AddMessaging().AddConnector<ConnectorWithInvalidSchemaType>();
+            var provider = services.BuildServiceProvider();
+
+            Assert.Throws<ArgumentException>(() => provider.GetRequiredService<ConnectorWithInvalidSchemaType>());
+        }
+
+        private class ThrowingSchemaFactory : IChannelSchemaFactory
+        {
+            public ThrowingSchemaFactory(string _)
+            {
+            }
+
+            public IChannelSchema CreateSchema() => throw new NotImplementedException();
+        }
+
+        [ChannelSchema(typeof(ThrowingSchemaFactory))]
+        private class ConnectorWithThrowingFactory : IChannelConnector
+        {
+            public ConnectorWithThrowingFactory(IChannelSchema schema, ConnectionSettings? settings = null)
+            {
+                Schema = schema;
+                ConnectionSettings = settings ?? new ConnectionSettings();
+            }
+            public IChannelSchema Schema { get; }
+            public ConnectionSettings ConnectionSettings { get; }
+            public ConnectorState State => ConnectorState.Uninitialized;
+            public ValueTask<OperationResult<bool>> InitializeAsync(CancellationToken ct) => new ValueTask<OperationResult<bool>>(OperationResult<bool>.Success(true));
+            public ValueTask<OperationResult<bool>> TestConnectionAsync(CancellationToken ct) => new ValueTask<OperationResult<bool>>(OperationResult<bool>.Success(true));
+            public ValueTask<OperationResult<SendResult>> SendMessageAsync(IMessage message, CancellationToken ct) => throw new NotImplementedException();
+            public ValueTask<OperationResult<BatchSendResult>> SendBatchAsync(IMessageBatch batch, CancellationToken ct) => throw new NotImplementedException();
+            public ValueTask<OperationResult<StatusInfo>> GetStatusAsync(CancellationToken ct) => throw new NotImplementedException();
+            public ValueTask<OperationResult<StatusUpdatesResult>> GetMessageStatusAsync(string messageId, CancellationToken ct) => throw new NotImplementedException();
+            public async IAsyncEnumerable<ValidationResult> ValidateMessageAsync(IMessage message, [EnumeratorCancellation] CancellationToken ct) { await Task.CompletedTask; yield break; }
+            public ValueTask<OperationResult<StatusUpdateResult>> ReceiveMessageStatusAsync(MessageSource source, CancellationToken ct) => throw new NotImplementedException();
+            public ValueTask<OperationResult<ReceiveResult>> ReceiveMessagesAsync(MessageSource source, CancellationToken ct) => throw new NotImplementedException();
+            public ValueTask<OperationResult<ConnectorHealth>> GetHealthAsync(CancellationToken ct) => throw new NotImplementedException();
+            public ValueTask ShutdownAsync(CancellationToken ct) => default;
+        }
+
+        [Fact]
+        public void Should_ThrowInvalidOperation_When_FactoryCannotBeCreated()
+        {
+            var services = new ServiceCollection();
+            services.AddMessaging().AddConnector<ConnectorWithThrowingFactory>();
+            var provider = services.BuildServiceProvider();
+
+            Assert.Throws<InvalidOperationException>(() => provider.GetRequiredService<ConnectorWithThrowingFactory>());
+        }
     }
 }

--- a/test/Deveel.Messaging.XUnit/Unit/ConnectorSchemaHelperTests.cs
+++ b/test/Deveel.Messaging.XUnit/Unit/ConnectorSchemaHelperTests.cs
@@ -41,14 +41,14 @@ namespace Deveel.Messaging.XUnit.Unit
             public ConnectorState State => ConnectorState.Uninitialized;
             public ValueTask<OperationResult<bool>> InitializeAsync(CancellationToken ct) => new ValueTask<OperationResult<bool>>(OperationResult<bool>.Success(true));
             public ValueTask<OperationResult<bool>> TestConnectionAsync(CancellationToken ct) => new ValueTask<OperationResult<bool>>(OperationResult<bool>.Success(true));
-            public ValueTask<OperationResult<SendResult>> SendMessageAsync(IMessage message, CancellationToken ct) => throw new NotImplementedException();
-            public ValueTask<OperationResult<BatchSendResult>> SendBatchAsync(IMessageBatch batch, CancellationToken ct) => throw new NotImplementedException();
-            public ValueTask<OperationResult<StatusInfo>> GetStatusAsync(CancellationToken ct) => throw new NotImplementedException();
-            public ValueTask<OperationResult<StatusUpdatesResult>> GetMessageStatusAsync(string messageId, CancellationToken ct) => throw new NotImplementedException();
+            public ValueTask<OperationResult<SendResult>> SendMessageAsync(IMessage message, CancellationToken ct) => throw new NotSupportedException();
+            public ValueTask<OperationResult<BatchSendResult>> SendBatchAsync(IMessageBatch batch, CancellationToken ct) => throw new NotSupportedException();
+            public ValueTask<OperationResult<StatusInfo>> GetStatusAsync(CancellationToken ct) => throw new NotSupportedException();
+            public ValueTask<OperationResult<StatusUpdatesResult>> GetMessageStatusAsync(string messageId, CancellationToken ct) => throw new NotSupportedException();
             public async IAsyncEnumerable<ValidationResult> ValidateMessageAsync(IMessage message, [EnumeratorCancellation] CancellationToken ct) { await Task.CompletedTask; yield break; }
-            public ValueTask<OperationResult<StatusUpdateResult>> ReceiveMessageStatusAsync(MessageSource source, CancellationToken ct) => throw new NotImplementedException();
-            public ValueTask<OperationResult<ReceiveResult>> ReceiveMessagesAsync(MessageSource source, CancellationToken ct) => throw new NotImplementedException();
-            public ValueTask<OperationResult<ConnectorHealth>> GetHealthAsync(CancellationToken ct) => throw new NotImplementedException();
+            public ValueTask<OperationResult<StatusUpdateResult>> ReceiveMessageStatusAsync(MessageSource source, CancellationToken ct) => throw new NotSupportedException();
+            public ValueTask<OperationResult<ReceiveResult>> ReceiveMessagesAsync(MessageSource source, CancellationToken ct) => throw new NotSupportedException();
+            public ValueTask<OperationResult<ConnectorHealth>> GetHealthAsync(CancellationToken ct) => throw new NotSupportedException();
             public ValueTask ShutdownAsync(CancellationToken ct) => default;
         }
 
@@ -65,14 +65,14 @@ namespace Deveel.Messaging.XUnit.Unit
             public ConnectorState State => ConnectorState.Uninitialized;
             public ValueTask<OperationResult<bool>> InitializeAsync(CancellationToken ct) => new ValueTask<OperationResult<bool>>(OperationResult<bool>.Success(true));
             public ValueTask<OperationResult<bool>> TestConnectionAsync(CancellationToken ct) => new ValueTask<OperationResult<bool>>(OperationResult<bool>.Success(true));
-            public ValueTask<OperationResult<SendResult>> SendMessageAsync(IMessage message, CancellationToken ct) => throw new NotImplementedException();
-            public ValueTask<OperationResult<BatchSendResult>> SendBatchAsync(IMessageBatch batch, CancellationToken ct) => throw new NotImplementedException();
-            public ValueTask<OperationResult<StatusInfo>> GetStatusAsync(CancellationToken ct) => throw new NotImplementedException();
-            public ValueTask<OperationResult<StatusUpdatesResult>> GetMessageStatusAsync(string messageId, CancellationToken ct) => throw new NotImplementedException();
+            public ValueTask<OperationResult<SendResult>> SendMessageAsync(IMessage message, CancellationToken ct) => throw new NotSupportedException();
+            public ValueTask<OperationResult<BatchSendResult>> SendBatchAsync(IMessageBatch batch, CancellationToken ct) => throw new NotSupportedException();
+            public ValueTask<OperationResult<StatusInfo>> GetStatusAsync(CancellationToken ct) => throw new NotSupportedException();
+            public ValueTask<OperationResult<StatusUpdatesResult>> GetMessageStatusAsync(string messageId, CancellationToken ct) => throw new NotSupportedException();
             public async IAsyncEnumerable<ValidationResult> ValidateMessageAsync(IMessage message, [EnumeratorCancellation] CancellationToken ct) { await Task.CompletedTask; yield break; }
-            public ValueTask<OperationResult<StatusUpdateResult>> ReceiveMessageStatusAsync(MessageSource source, CancellationToken ct) => throw new NotImplementedException();
-            public ValueTask<OperationResult<ReceiveResult>> ReceiveMessagesAsync(MessageSource source, CancellationToken ct) => throw new NotImplementedException();
-            public ValueTask<OperationResult<ConnectorHealth>> GetHealthAsync(CancellationToken ct) => throw new NotImplementedException();
+            public ValueTask<OperationResult<StatusUpdateResult>> ReceiveMessageStatusAsync(MessageSource source, CancellationToken ct) => throw new NotSupportedException();
+            public ValueTask<OperationResult<ReceiveResult>> ReceiveMessagesAsync(MessageSource source, CancellationToken ct) => throw new NotSupportedException();
+            public ValueTask<OperationResult<ConnectorHealth>> GetHealthAsync(CancellationToken ct) => throw new NotSupportedException();
             public ValueTask ShutdownAsync(CancellationToken ct) => default;
         }
 
@@ -153,14 +153,14 @@ namespace Deveel.Messaging.XUnit.Unit
             public ConnectorState State => ConnectorState.Uninitialized;
             public ValueTask<OperationResult<bool>> InitializeAsync(CancellationToken ct) => new ValueTask<OperationResult<bool>>(OperationResult<bool>.Success(true));
             public ValueTask<OperationResult<bool>> TestConnectionAsync(CancellationToken ct) => new ValueTask<OperationResult<bool>>(OperationResult<bool>.Success(true));
-            public ValueTask<OperationResult<SendResult>> SendMessageAsync(IMessage message, CancellationToken ct) => throw new NotImplementedException();
-            public ValueTask<OperationResult<BatchSendResult>> SendBatchAsync(IMessageBatch batch, CancellationToken ct) => throw new NotImplementedException();
-            public ValueTask<OperationResult<StatusInfo>> GetStatusAsync(CancellationToken ct) => throw new NotImplementedException();
-            public ValueTask<OperationResult<StatusUpdatesResult>> GetMessageStatusAsync(string messageId, CancellationToken ct) => throw new NotImplementedException();
+            public ValueTask<OperationResult<SendResult>> SendMessageAsync(IMessage message, CancellationToken ct) => throw new NotSupportedException();
+            public ValueTask<OperationResult<BatchSendResult>> SendBatchAsync(IMessageBatch batch, CancellationToken ct) => throw new NotSupportedException();
+            public ValueTask<OperationResult<StatusInfo>> GetStatusAsync(CancellationToken ct) => throw new NotSupportedException();
+            public ValueTask<OperationResult<StatusUpdatesResult>> GetMessageStatusAsync(string messageId, CancellationToken ct) => throw new NotSupportedException();
             public async IAsyncEnumerable<ValidationResult> ValidateMessageAsync(IMessage message, [EnumeratorCancellation] CancellationToken ct) { await Task.CompletedTask; yield break; }
-            public ValueTask<OperationResult<StatusUpdateResult>> ReceiveMessageStatusAsync(MessageSource source, CancellationToken ct) => throw new NotImplementedException();
-            public ValueTask<OperationResult<ReceiveResult>> ReceiveMessagesAsync(MessageSource source, CancellationToken ct) => throw new NotImplementedException();
-            public ValueTask<OperationResult<ConnectorHealth>> GetHealthAsync(CancellationToken ct) => throw new NotImplementedException();
+            public ValueTask<OperationResult<StatusUpdateResult>> ReceiveMessageStatusAsync(MessageSource source, CancellationToken ct) => throw new NotSupportedException();
+            public ValueTask<OperationResult<ReceiveResult>> ReceiveMessagesAsync(MessageSource source, CancellationToken ct) => throw new NotSupportedException();
+            public ValueTask<OperationResult<ConnectorHealth>> GetHealthAsync(CancellationToken ct) => throw new NotSupportedException();
             public ValueTask ShutdownAsync(CancellationToken ct) => default;
         }
 
@@ -180,7 +180,7 @@ namespace Deveel.Messaging.XUnit.Unit
             {
             }
 
-            public IChannelSchema CreateSchema() => throw new NotImplementedException();
+            public IChannelSchema CreateSchema() => throw new NotSupportedException();
         }
 
         [ChannelSchema(typeof(ThrowingSchemaFactory))]
@@ -196,14 +196,14 @@ namespace Deveel.Messaging.XUnit.Unit
             public ConnectorState State => ConnectorState.Uninitialized;
             public ValueTask<OperationResult<bool>> InitializeAsync(CancellationToken ct) => new ValueTask<OperationResult<bool>>(OperationResult<bool>.Success(true));
             public ValueTask<OperationResult<bool>> TestConnectionAsync(CancellationToken ct) => new ValueTask<OperationResult<bool>>(OperationResult<bool>.Success(true));
-            public ValueTask<OperationResult<SendResult>> SendMessageAsync(IMessage message, CancellationToken ct) => throw new NotImplementedException();
-            public ValueTask<OperationResult<BatchSendResult>> SendBatchAsync(IMessageBatch batch, CancellationToken ct) => throw new NotImplementedException();
-            public ValueTask<OperationResult<StatusInfo>> GetStatusAsync(CancellationToken ct) => throw new NotImplementedException();
-            public ValueTask<OperationResult<StatusUpdatesResult>> GetMessageStatusAsync(string messageId, CancellationToken ct) => throw new NotImplementedException();
+            public ValueTask<OperationResult<SendResult>> SendMessageAsync(IMessage message, CancellationToken ct) => throw new NotSupportedException();
+            public ValueTask<OperationResult<BatchSendResult>> SendBatchAsync(IMessageBatch batch, CancellationToken ct) => throw new NotSupportedException();
+            public ValueTask<OperationResult<StatusInfo>> GetStatusAsync(CancellationToken ct) => throw new NotSupportedException();
+            public ValueTask<OperationResult<StatusUpdatesResult>> GetMessageStatusAsync(string messageId, CancellationToken ct) => throw new NotSupportedException();
             public async IAsyncEnumerable<ValidationResult> ValidateMessageAsync(IMessage message, [EnumeratorCancellation] CancellationToken ct) { await Task.CompletedTask; yield break; }
-            public ValueTask<OperationResult<StatusUpdateResult>> ReceiveMessageStatusAsync(MessageSource source, CancellationToken ct) => throw new NotImplementedException();
-            public ValueTask<OperationResult<ReceiveResult>> ReceiveMessagesAsync(MessageSource source, CancellationToken ct) => throw new NotImplementedException();
-            public ValueTask<OperationResult<ConnectorHealth>> GetHealthAsync(CancellationToken ct) => throw new NotImplementedException();
+            public ValueTask<OperationResult<StatusUpdateResult>> ReceiveMessageStatusAsync(MessageSource source, CancellationToken ct) => throw new NotSupportedException();
+            public ValueTask<OperationResult<ReceiveResult>> ReceiveMessagesAsync(MessageSource source, CancellationToken ct) => throw new NotSupportedException();
+            public ValueTask<OperationResult<ConnectorHealth>> GetHealthAsync(CancellationToken ct) => throw new NotSupportedException();
             public ValueTask ShutdownAsync(CancellationToken ct) => default;
         }
 

--- a/test/Deveel.Messaging.XUnit/Unit/ConnectorTypeCatalogTests.cs
+++ b/test/Deveel.Messaging.XUnit/Unit/ConnectorTypeCatalogTests.cs
@@ -11,7 +11,9 @@ namespace Deveel.Messaging.XUnit.Unit
         public void Should_RegisterEntry_And_LookupByName()
         {
             var catalog = new ConnectorTypeCatalog();
-            catalog.Register("mock", typeof(MockConnector));
+            typeof(ConnectorTypeCatalog).GetMethod("Register", 
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)
+                .Invoke(catalog, new object[] { "mock", typeof(MockConnector) });
 
             var found = catalog.TryGetEntry("mock", out var entry);
 
@@ -25,7 +27,9 @@ namespace Deveel.Messaging.XUnit.Unit
         public void Should_LookupByName_CaseInsensitive()
         {
             var catalog = new ConnectorTypeCatalog();
-            catalog.Register("MockChannel", typeof(MockConnector));
+            typeof(ConnectorTypeCatalog).GetMethod("Register", 
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)
+                .Invoke(catalog, new object[] { "MockChannel", typeof(MockConnector) });
 
             var found = catalog.TryGetEntry("mockchannel", out var entry);
 
@@ -49,8 +53,12 @@ namespace Deveel.Messaging.XUnit.Unit
         public void Should_Overwrite_When_SameNameRegisteredTwice()
         {
             var catalog = new ConnectorTypeCatalog();
-            catalog.Register("dup", typeof(MockConnector));
-            catalog.Register("dup", typeof(MockConnector));
+            typeof(ConnectorTypeCatalog).GetMethod("Register", 
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)
+                .Invoke(catalog, new object[] { "dup", typeof(MockConnector) });
+            typeof(ConnectorTypeCatalog).GetMethod("Register", 
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)
+                .Invoke(catalog, new object[] { "dup", typeof(MockConnector) });
 
             var found = catalog.TryGetEntry("dup", out var entry);
             Assert.True(found);
@@ -61,7 +69,9 @@ namespace Deveel.Messaging.XUnit.Unit
         public void Should_ReturnSchema_FromServiceProvider()
         {
             var catalog = new ConnectorTypeCatalog();
-            catalog.Register("mock", typeof(MockConnector));
+            typeof(ConnectorTypeCatalog).GetMethod("Register", 
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)
+                .Invoke(catalog, new object[] { "mock", typeof(MockConnector) });
 
             var services = new ServiceCollection();
             var provider = services.BuildServiceProvider();
@@ -80,7 +90,9 @@ namespace Deveel.Messaging.XUnit.Unit
         public void Should_CacheSchema_AfterFirstAccess()
         {
             var catalog = new ConnectorTypeCatalog();
-            catalog.Register("mock", typeof(MockConnector));
+            typeof(ConnectorTypeCatalog).GetMethod("Register", 
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)
+                .Invoke(catalog, new object[] { "mock", typeof(MockConnector) });
 
             var services = new ServiceCollection();
             var provider = services.BuildServiceProvider();
@@ -98,7 +110,9 @@ namespace Deveel.Messaging.XUnit.Unit
         public void Should_LookupByType()
         {
             var catalog = new ConnectorTypeCatalog();
-            catalog.Register("mock", typeof(MockConnector));
+            typeof(ConnectorTypeCatalog).GetMethod("Register", 
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)
+                .Invoke(catalog, new object[] { "mock", typeof(MockConnector) });
 
             var found = catalog.TryGetEntry(typeof(MockConnector), out var entry);
 
@@ -122,7 +136,9 @@ namespace Deveel.Messaging.XUnit.Unit
         public void Should_BeThreadSafe_When_AccessingSchemaConcurrently()
         {
             var catalog = new ConnectorTypeCatalog();
-            catalog.Register("mock", typeof(MockConnector));
+            typeof(ConnectorTypeCatalog).GetMethod("Register", 
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)
+                .Invoke(catalog, new object[] { "mock", typeof(MockConnector) });
 
             var services = new ServiceCollection();
             var provider = services.BuildServiceProvider();


### PR DESCRIPTION
This pull request introduces several improvements and refactorings to the Facebook and Firebase connectors in the messaging library, focusing on extensibility, code documentation, and abstraction. The most significant changes include the introduction of an abstraction layer for Firebase messaging operations, enhanced XML documentation for public APIs, and minor project/README cleanups.

### Firebase Connector Refactoring and Abstractions

* Introduced the `IFirebaseMessagingClient` interface and its implementation `FirebaseMessagingClient` to abstract Firebase Admin SDK messaging operations, enabling easier testing and improved separation of concerns. The `FirebaseService` now depends on this abstraction instead of directly on the SDK. [[1]](diffhunk://#diff-4204cf3827666184bb58fb0483a476bc656ada906278ba68bf0e03d03e8fcedeR1-R41) [[2]](diffhunk://#diff-205861c8cc4c47789008f2e9d417e231067437c2cf6b91dc1a59c4d7f3f247cbR1-R31) [[3]](diffhunk://#diff-e5fd13e70d06b21ffa739bde6fe758b7730fd5832ee244876ad6c5c60833db91L19-R37) [[4]](diffhunk://#diff-e5fd13e70d06b21ffa739bde6fe758b7730fd5832ee244876ad6c5c60833db91L55-R67)
* Refactored `FirebaseService` to use `IFirebaseMessagingClient` for all messaging operations, updating methods like `SendAsync`, `SendEachAsync`, `SendMulticastAsync`, and `TestConnectionAsync` to use the new abstraction. [[1]](diffhunk://#diff-e5fd13e70d06b21ffa739bde6fe758b7730fd5832ee244876ad6c5c60833db91L85-R97) [[2]](diffhunk://#diff-e5fd13e70d06b21ffa739bde6fe758b7730fd5832ee244876ad6c5c60833db91L113-R125) [[3]](diffhunk://#diff-e5fd13e70d06b21ffa739bde6fe758b7730fd5832ee244876ad6c5c60833db91L141-R153) [[4]](diffhunk://#diff-e5fd13e70d06b21ffa739bde6fe758b7730fd5832ee244876ad6c5c60833db91L182-R194)
* Made `MapFirebaseErrorCode` public and documented it for mapping Firebase SDK error codes to internal codes.

### Documentation Improvements

* Added or improved XML documentation for public classes and methods in the Facebook and Firebase connectors, including `FacebookService`, `FacebookConnectionSettingsExtensions`, `FacebookConnectionSettingsDefaults`, and `FirebaseConnectionSettingsExtensions`. [[1]](diffhunk://#diff-228a5328fe7d8fdca677cbf30783c2b03673690c2b7f4cc9e7803a2e53f440fbR15-R31) [[2]](diffhunk://#diff-228a5328fe7d8fdca677cbf30783c2b03673690c2b7f4cc9e7803a2e53f440fbR56-R59) [[3]](diffhunk://#diff-228a5328fe7d8fdca677cbf30783c2b03673690c2b7f4cc9e7803a2e53f440fbR70-R77) [[4]](diffhunk://#diff-228a5328fe7d8fdca677cbf30783c2b03673690c2b7f4cc9e7803a2e53f440fbR126-R133) [[5]](diffhunk://#diff-654c877964f51f68f4692f98bb9ce8429ae46220b973587e2025864f5f849173R3-R36) [[6]](diffhunk://#diff-bba625689f10f360537d8d57872b866601a434c3609939371b6b825ef3bd4252R3-R5) [[7]](diffhunk://#diff-1b23bbb5d1e52391142c3a76cbf4583f138b94f7c177475fa4f417ddc8d679f0R3-R28)

### Project and API Cleanups

* Removed the `InternalsVisibleTo` entry for the Facebook connector's test project, locking down the public API surface.
* Fixed a minor XML documentation reference in `MessagingErrorCodes.cs`.
* Updated the README to mark the interactive content model as complete.

These changes collectively improve code maintainability, testability, and clarity across the connectors.