### PR TITLE
docs: update stale repository links after rename

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,9 +26,9 @@ For larger changes, open an issue or discussion first so the approach can be ali
 ### Setup
 
 ```bash
-git clone https://github.com/YOUR_USERNAME/deveel.messaging.git
-cd deveel.messaging
-git remote add upstream https://github.com/deveel/deveel.messaging.git
+git clone https://github.com/YOUR_USERNAME/ratatosk.git
+cd ratatosk
+git remote add upstream https://github.com/deveel/ratatosk.git
 dotnet build
 dotnet test
 ```

--- a/README.md
+++ b/README.md
@@ -186,4 +186,4 @@ See [LICENSE](LICENSE) for the full text and terms.
 
 ## Contributors
 
-[![Contributors](https://contrib.rocks/image?repo=deveel/ratatosk)](https://github.com/deveel/deveel.messaging/graphs/contributors)
+[![Contributors](https://contrib.rocks/image?repo=deveel/ratatosk)](https://github.com/deveel/ratatosk/graphs/contributors)

--- a/docs/samples/multi-connector.md
+++ b/docs/samples/multi-connector.md
@@ -50,4 +50,4 @@ Content-Type: application/json
 
 ## Configuration
 
-Configure credentials in `appsettings.json` or via environment variables. See the [`samples/multi-connector/README.md`](https://github.com/deveel/deveel.messaging/blob/main/samples/multi-connector/README.md) file in the repository for the full configuration reference.
+Configure credentials in `appsettings.json` or via environment variables. See the [`samples/multi-connector/README.md`](https://github.com/deveel/ratatosk/blob/main/samples/multi-connector/README.md) file in the repository for the full configuration reference.

--- a/docs/samples/sender-manager.md
+++ b/docs/samples/sender-manager.md
@@ -93,4 +93,4 @@ The sample never resolves the sender in the API handler. It passes a `SenderRef`
 
 ## Configuration
 
-See the [`samples/sender-manager/README.md`](https://github.com/deveel/deveel.messaging/blob/main/samples/sender-manager/README.md) file in the repository for the full configuration reference and SendGrid setup.
+See the [`samples/sender-manager/README.md`](https://github.com/deveel/ratatosk/blob/main/samples/sender-manager/README.md) file in the repository for the full configuration reference and SendGrid setup.


### PR DESCRIPTION
## Summary
- update contributor and sample links that still point to the old `deveel.messaging` repository
- fix the contributor setup commands in `CONTRIBUTING.md` to clone `ratatosk` and add the correct upstream remote

## Validation
- verified the edited documentation files no longer contain `deveel.messaging` references with `rg`
- did not run `dotnet test` because this PR only changes documentation links and contributor instructions
