### PR TITLE
Implement retry policies with exponential backoff and circuit breaker

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,42 +113,107 @@ Start from the docs home and follow the path that best matches what you are buil
 
 The project roadmap is tracked in detail in [ROADMAP.md](ROADMAP.md). The summary below highlights the upcoming milestones and the main features planned for each release.
 
-### v0.4.0 - Framework Foundations
+### v0.4.0 — Framework Foundations ✓
 
 Strengthens quality gates, release automation, observability, and docs completeness across the existing connector ecosystem.
 
-- [x] **Test coverage target (>= 80%)** - Enforce minimum line coverage per library in CI.
-- [x] **CI/CD pipeline hardening** - Automate build, test, compatibility checks, signing, and NuGet publishing from release tags.
-- [x] **Structured logging improvements** - Standardize event IDs, scopes, and `LoggerMessage` patterns across connectors.
-- [x] **Documentation completeness** - Complete XML API docs and connector guides with consistent coverage.
+- [x] **Test coverage target (≥ 80%)** — Enforce minimum line coverage per library in CI.
+- [x] **CI/CD pipeline hardening** — Automate build, test, compatibility checks, signing, and NuGet publishing from release tags.
+- [x] **Structured logging improvements** — Standardize event IDs, scopes, and `LoggerMessage` patterns across connectors.
+- [x] **Documentation completeness** — Complete XML API docs and connector guides with consistent coverage.
 
-### v0.5.0 - Inbound Messaging
+### v0.5.0 — Inbound Messaging ✓
 
 Completes the receive-side model for current connectors to support bidirectional messaging scenarios.
 
-- [x] **Twilio inbound messages (SMS/WhatsApp)** - Parse inbound payloads into framework messages and endpoints.
-- [x] **SendGrid inbound parse support** - Map multipart inbound emails, content, and attachments into the message model.
-- [x] **Firebase inbound messages** - Support upstream device data messages through the same receive abstractions.
+- [x] **Twilio inbound messages (SMS/WhatsApp)** — Parse inbound payloads into framework messages and endpoints.
+- [x] **SendGrid inbound parse support** — Map multipart inbound emails, content, and attachments into the message model.
+- [x] **Firebase inbound messages** — Support upstream device data messages through the same receive abstractions.
 
-### v1.0.0 - First Stable Release
+### v1.0.0 — First Stable Release ✓
 
 Locks the public API and ships stable package releases with production-ready guarantees.
 
-- [x] **API freeze and compatibility enforcement** - Prevent breaking API changes without a major version bump.
-- [x] **NuGet GA release** - Publish stable `Ratatosk.*` packages without prerelease suffixes.
-- [x] **Interactive content model** - Add cross-channel abstractions for buttons, quick replies, carousels, and lists.
-- [x] **Sender identity model** - Provide typed sender identities for phone, email, and bot-based channels.
+- [x] **API freeze and compatibility enforcement** — Prevent breaking API changes without a major version bump.
+- [x] **NuGet GA release** — Publish stable `Ratatosk.*` packages without prerelease suffixes.
+- [x] **Interactive content model** — Add cross-channel abstractions for buttons, quick replies, carousels, and lists.
+- [x] **Sender identity model** — Provide typed sender identities for phone, email, and bot-based channels.
 
-### v1.1.0 and beyond - Platform Expansion
+### v1.1.0 — Resilience & Observability
 
-Extends resilience, observability, connectors, protocol support, and higher-level messaging capabilities.
+Adds retry/circuit-breaker policies, OpenTelemetry signals, health checks, and timeout controls.
 
-- [ ] **Resilience and observability** - Retry/circuit-breaker policies, OpenTelemetry signals, health checks, and timeout controls.
-- [ ] **New SaaS connectors** - Add Slack, Microsoft Teams, WhatsApp Business API, Viber, and LINE connectors.
-- [ ] **Protocol connectors** - Add SMPP, SMTP, RCS, and direct APNs support with shared protocol base classes.
-- [ ] **Content adaptation and validation** - Introduce transcoding, channel-aware fallback, segmentation, and address validation.
-- [ ] **Tooling and diagnostics** - Ship connector scaffolding templates and ASP.NET Core diagnostic middleware.
-- [ ] **Conversations and templates (v2.x)** - Add conversation state/correlation and provider-agnostic template modeling.
+- [x] **Retry policies** — Polly-based retry and circuit-breaker integrated at the connector base level.
+- [ ] **OpenTelemetry tracing & metrics** — ActivitySources, Meters, and histograms per connector.
+- [ ] **Health checks** — ASP.NET Core `IHealthCheck` implementations auto-registered per connector.
+- [ ] **Connector-level timeout configuration** — Per-operation timeout via the DI registration API.
+
+### v1.2.0 — New SaaS Connectors
+
+Extends the connector ecosystem with additional major cloud messaging providers.
+
+- [ ] **Slack** — Incoming Webhooks and Bot API support with Block Kit content mapping.
+- [ ] **Microsoft Teams** — Incoming Webhooks and Bot Framework API with Adaptive Card support.
+- [ ] **WhatsApp Business API** — Direct Meta Cloud API connector (text, media, interactive, templates).
+- [ ] **Viber Business** — Viber Business Messages API (text, image, rich media, keyboards).
+- [ ] **LINE** — LINE Messaging API (text, image, video, audio, Flex Messages).
+
+### v1.3.0 — Protocol Connectors
+
+Raw protocol support for teams with direct carrier or Apple developer relationships.
+
+- [ ] **Protocol connector base classes** — Session management, connection lifecycle, reconnection policies.
+- [ ] **SMPP** — Direct SMSC connectivity (v3.4 session client, `submit_sm`/`deliver_sm` mapping).
+- [ ] **SMTP** — Direct email delivery via MailKit (RFC 5321 MIME messages).
+- [ ] **RCS** — Rich Communication Services Business Messaging API.
+- [ ] **APNs (direct)** — Apple Push Notification HTTP/2 API without Firebase dependency.
+
+### v1.4.0 — Content Adaptation & Transcoding
+
+Transcoding layer that converts content between types for multi-channel delivery.
+
+- [ ] **`IContentTranscoder` abstraction** — Generic content conversion with resolution registry.
+- [ ] **Built-in transcoders** — HTML-to-plaintext, HTML-to-Markdown, Markdown-to-GSM-7, and more.
+- [ ] **Channel-aware content fallback** — Automatic fallback to best available content type per channel.
+- [ ] **SMS segmentation** — GSM-7/UCS-2 segment counting and encoding analysis.
+- [ ] **Character encoding detection** — `SmsEncodingAnalyzer` for pre-send encoding warnings.
+
+### v1.5.0 — Address & Number Validation
+
+Validation layer for recipient addresses across all channels.
+
+- [ ] **E.164 normalization** — libphonenumber-based canonical phone number formatting.
+- [ ] **HLR lookup** — Optional Home Location Register reachability checks before SMS send.
+- [ ] **Number portability awareness** — Ported number routing in the SMPP connector.
+- [ ] **Email address validation** — RFC 5321 syntax, MX record, and disposable domain checks.
+- [ ] **`IAddressValidator` abstraction** — Extensible validation chain per connector.
+
+### v1.6.0 — Tooling & Instrumentation
+
+Developer and operator tooling for the framework.
+
+- [ ] **`dotnet new` connector scaffold** — Template package for bootstrapping new connectors.
+- [ ] **ASP.NET Core diagnostic middleware** — Runtime connector state, health, and counters endpoint.
+
+### v2.0.0 — Conversations
+
+Conversation management as a first-class framework concept.
+
+- [ ] **`IConversation` abstraction** — Thread of messages with participants, status, and history.
+- [ ] **Conversation state model** — State transitions, persistence, in-memory store for testing.
+- [ ] **Conversation correlation** — Link inbound replies to originating conversations.
+- [ ] **Multi-channel conversations** — Span single conversations across SMS, WhatsApp, email, and more.
+- [ ] **Multi-tenant channel registry** — Tenant-aware connector and schema resolution.
+- [ ] **xUnit test helpers** — Fake inbound injectors and assertion helpers for conversation flows.
+
+### v2.1.0 — Message Templates
+
+Provider-agnostic template model with local and server-side rendering.
+
+- [ ] **`IMessageTemplate` abstraction** — Named templates with locale, content structure, and variable schema.
+- [ ] **Variable substitution engine** — Local rendering with placeholder resolution and type-safe binding.
+- [ ] **Per-connector template rendering** — Bridge between framework templates and provider-native systems.
+- [ ] **Template registry** — Central store with startup validation and locale-aware resolution.
 
 For milestone-level detail, rationale, and dependencies, see [ROADMAP.md](ROADMAP.md).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -95,6 +95,7 @@ The framework is deliberately focused on the messaging contract and connector co
 - [Connector implementation](connector-implementation.md) — writing custom connectors with `ChannelConnectorBase`
 - [Authentication](authentication.md) — auth providers, credential management, OAuth flows
 - [Result types](result-types.md) — `OperationResult<T>`, send results, health data
+- [Retry policies](retry-policies.md) — automatic retry with backoff, jitter, and circuit breaker
 - [Advanced configuration](advanced.md) — security, named connector isolation, health checks, testing
 
 **Connector guides:**

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -181,6 +181,22 @@ public class MetricsDecorator : IChannelConnector
 }
 ```
 
+## Retry policies
+
+Connector send operations can be configured with automatic retry for transient failures using a policy-based approach. See [Retry Policies](retry-policies.md) for full documentation.
+
+```csharp
+services.AddMessaging()
+    .AddConnector<TwilioSmsConnector>("sms", cfg => cfg
+        .WithRetryPolicy(options =>
+        {
+            options.WithMaxAttempts(3)
+                   .WithExponentialBackoff()
+                   .WithJitter()
+                   .RetryOnErrorCodes("RATE_LIMITED", "SERVICE_UNAVAILABLE");
+        }));
+```
+
 ## Performance
 
 ### Bulk sending

--- a/docs/connector-implementation.md
+++ b/docs/connector-implementation.md
@@ -120,6 +120,7 @@ public class MyConnector : ChannelConnectorBase
 | Authentication | Provides `AuthenticateAsync()`, `GetAuthenticationHeader()` |
 | Logging scopes | Auto-creates scopes per connector and per message |
 | Cancellation | Passes token to all operations |
+| Retry support | Override `GetDefaultRetryPolicy()`; configurable via builder or connection settings (see [Retry Policies](retry-policies.md)) |
 | Result wrapping | Your core methods return raw values; base class wraps them |
 
 ### How wrapping works
@@ -134,6 +135,21 @@ Your override returns a raw `SendResult` or `ValueTask`. The base class:
 6. Wraps the result (or error) in `OperationResult<T>`
 
 This means your override can throw on error — you never need to create `OperationResult<T>` instances yourself.
+
+## Retry policy
+
+Connectors can provide a default retry policy by overriding `GetDefaultRetryPolicy()`:
+
+```csharp
+protected override RetryPolicyOptions? GetDefaultRetryPolicy()
+    => new RetryPolicyOptions
+    {
+        MaxRetryAttempts = 5,
+        RetryableErrorCodes = { "RATE_LIMITED", "NETWORK_ERROR" }
+    };
+```
+
+The policy configured via `WithRetryPolicy` or `ConnectionSettings.Parameters["RetryPolicy"]` takes precedence. See [Retry Policies](retry-policies.md) for details.
 
 ## Optional overrides
 

--- a/docs/connector-implementation.md
+++ b/docs/connector-implementation.md
@@ -149,7 +149,7 @@ protected override RetryPolicyOptions? GetDefaultRetryPolicy()
     };
 ```
 
-The policy configured via `WithRetryPolicy` or `ConnectionSettings.Parameters["RetryPolicy"]` takes precedence. See [Retry Policies](retry-policies.md) for details.
+The policy configured via `WithRetryPolicy` or individual `RetrySettingsKeys.*` parameters in `ConnectionSettings` takes precedence. See [Retry Policies](retry-policies.md) for details.
 
 ## Optional overrides
 

--- a/docs/result-types.md
+++ b/docs/result-types.md
@@ -91,7 +91,14 @@ if (result.IsSuccess())
 | `RemoteMessageId` | `string` | Provider-assigned message identifier |
 | `Status` | `MessageStatus?` | Initial delivery status from provider |
 | `Timestamp` | `DateTimeOffset?` | When the provider accepted the message |
-| `AdditionalData` | `IDictionary<string, object>` | Provider-specific metadata |
+| `AdditionalData` | `IDictionary<string, object>` | Provider-specific metadata; includes `RetryAttempts` when [retry policy](retry-policies.md) is active |
+
+The `GetRetryAttempts()` extension method reads the retry count from `AdditionalData`:
+
+```csharp
+var result = await connector.SendMessageAsync(message, ct);
+Console.WriteLine($"Attempts: {result.Value.GetRetryAttempts()}"); // 1 if no retries
+```
 
 ### In a connector override
 
@@ -225,7 +232,7 @@ if (statusResult.IsSuccess())
 | `Status` | `MessageStatus` | Status value (`Received`, `Queued`, `Sent`, `Delivered`, `DeliveryFailed`, etc.) |
 | `Timestamp` | `DateTimeOffset` | When the status was recorded |
 | `Description` | `string?` | Optional human-readable description |
-| `AdditionalData` | `IDictionary<string, object>` | Provider-specific metadata |
+| `AdditionalData` | `IDictionary<string, object>` | Provider-specific metadata; includes `RetryAttempts` when [retry policy](retry-policies.md) is active |
 
 **StatusUpdatesResult** properties:
 
@@ -258,7 +265,7 @@ if (status.IsSuccess())
 | `Status` | `string` | Status string (provider-specific) |
 | `Description` | `string?` | Optional description |
 | `Timestamp` | `DateTimeOffset` | When the status was determined |
-| `AdditionalData` | `IDictionary<string, object>` | Provider-specific metadata |
+| `AdditionalData` | `IDictionary<string, object>` | Provider-specific metadata; includes `RetryAttempts` when [retry policy](retry-policies.md) is active |
 
 ## ConnectorHealth
 

--- a/docs/retry-policies.md
+++ b/docs/retry-policies.md
@@ -1,0 +1,167 @@
+# Retry Policies
+
+When a connector sends a message, transient failures can happen: rate limits, network timeouts, or temporary provider outages. The retry policy system lets you control how `ChannelConnectorBase` retries failed send operations with configurable backoff, jitter, and optional circuit breaking.
+
+Retry is **opt-in** by default — no retries happen unless you configure a policy.
+
+## How it works
+
+The base class wraps `SendMessageCoreAsync()` with a Polly resilience pipeline when a retry policy is configured. The pipeline uses `Microsoft.Extensions.Resilience` (based on Polly v8) and respects your configured error codes, backoff strategy, and jitter settings.
+
+Only errors whose code appears in `RetryableErrorCodes` trigger a retry. All other errors (including non-`ConnectorException` exceptions) are classified as non-retryable and fail immediately.
+
+## Configuration
+
+### Via the connector builder (recommended)
+
+```csharp
+services.AddMessaging()
+    .AddConnector<TwilioSmsConnector>("sms", cfg => cfg
+        .WithRetryPolicy(options =>
+        {
+            options.WithMaxAttempts(3)                    // maximum send attempts (incl. initial)
+                   .WithExponentialBackoff()              // delay increases exponentially
+                   .WithBaseDelay(TimeSpan.FromSeconds(1)) // base delay for backoff calculation
+                   .WithJitter()                          // randomize delay to avoid thundering herd
+                   .RetryOnErrorCodes("RATE_LIMITED", "SERVICE_UNAVAILABLE");
+        }));
+```
+
+### Via connection settings
+
+You can also configure retry by setting individual parameters on the connection settings:
+
+```csharp
+var settings = new ConnectionSettings()
+    .SetParameter("Retry.MaxAttempts", 3)
+    .SetParameter("Retry.RetryableErrorCodes", "RATE_LIMITED,SERVICE_UNAVAILABLE")
+    .SetParameter("Retry.EnableCircuitBreaker", true)
+    .SetParameter("Retry.BackoffType", "Exponential")
+    .SetParameter("Retry.BaseDelay", "00:00:02")
+    .SetParameter("Retry.UseJitter", true)
+    .SetParameter("Retry.CircuitBreaker.FailureRatio", 0.5);
+
+var connector = new TwilioSmsConnector(schema, settings);
+```
+
+All settings keys are available as constants in `RetrySettingsKeys`:
+
+| Key | `RetrySettingsKeys` constant | Expected value |
+|---|---|---|
+| `Retry.MaxAttempts` | `.MaxAttempts` | `int` — total send attempts (including initial) |
+| `Retry.BackoffType` | `.BackoffType` | `string` — `"Constant"`, `"Linear"`, or `"Exponential"` |
+| `Retry.BaseDelay` | `.BaseDelay` | `string` — `TimeSpan` format (e.g. `"00:00:02"`) |
+| `Retry.UseJitter` | `.UseJitter` | `bool` |
+| `Retry.RetryableErrorCodes` | `.RetryableErrorCodes` | `string` — comma-separated error codes |
+| `Retry.EnableCircuitBreaker` | `.EnableCircuitBreaker` | `bool` |
+| `Retry.CircuitBreaker.FailureRatio` | `.CircuitBreakerFailureRatio` | `double` |
+| `Retry.CircuitBreaker.SamplingDuration` | `.CircuitBreakerSamplingDuration` | `string` — `TimeSpan` format |
+| `Retry.CircuitBreaker.MinimumThroughput` | `.CircuitBreakerMinimumThroughput` | `int` |
+| `Retry.CircuitBreaker.BreakDuration` | `.CircuitBreakerBreakDuration` | `string` — `TimeSpan` format |
+
+Settings configured via `WithRetryPolicy` or individual keys in `ConnectionSettings` always take precedence over `GetDefaultRetryPolicy()`.
+
+## RetryPolicyOptions reference
+
+| Property | Default | Description |
+|---|---|---|
+| `MaxRetryAttempts` | `3` | Maximum number of send attempts (inclusive of the initial attempt). Set to `1` to disable retries. |
+| `BaseDelay` | `1s` | Base delay between retries, adjusted by the backoff type |
+| `BackoffType` | `Exponential` | Backoff strategy: `Constant`, `Linear`, or `Exponential` |
+| `UseJitter` | `true` | Randomizes the delay to prevent thundering herd |
+| `RetryableErrorCodes` | empty | Error codes that trigger a retry. Empty = nothing is retried. |
+| `EnableCircuitBreaker` | `false` | Enables circuit breaker pattern |
+| `CircuitBreakerFailureRatio` | `0.5` | Ratio of failures required to open the circuit |
+| `CircuitBreakerSamplingDuration` | `30s` | Time window for evaluating the failure ratio |
+| `CircuitBreakerMinimumThroughput` | `10` | Minimum requests in the sampling window before the breaker evaluates |
+| `CircuitBreakerBreakDuration` | `30s` | How long the circuit stays open before allowing a trial request |
+
+### Retry backoff types
+
+- **Constant**: `BaseDelay` between every retry
+- **Linear**: `BaseDelay * attempt` between retries
+- **Exponential**: `BaseDelay * 2^attempt` between retries (default)
+
+With jitter enabled, each delay is randomized within `[0, computedDelay)` to spread out concurrent retries.
+
+### Circuit breaker
+
+When enabled, the circuit breaker monitors the failure ratio within a sampling window. If the ratio exceeds `CircuitBreakerFailureRatio`, the circuit opens and all subsequent requests fail immediately for `CircuitBreakerBreakDuration`. After that duration, a trial request is allowed — if it succeeds, the circuit closes; if it fails, the circuit opens again.
+
+Circuit breaker errors use the `CircuitBreakerOpen` error code.
+
+## Attempt counting
+
+Each send result records the number of attempts made in its `AdditionalData` dictionary under the key `"RetryAttempts"`:
+
+```csharp
+var result = await connector.SendMessageAsync(message, ct);
+
+if (result.IsSuccess())
+{
+    int attempts = result.Value.GetRetryAttempts();
+    // 1 = first attempt succeeded
+    // 3 = first two attempts failed, third succeeded
+    Console.WriteLine($"Sent after {attempts} attempt(s)");
+}
+```
+
+The `GetRetryAttempts()` extension method is available on `SendResult`, `StatusUpdateResult`, and `StatusInfo`. It returns `1` when no retry information is present (message was sent on the first attempt or retry metadata is unavailable).
+
+## Error codes
+
+| Code | Description |
+|---|---|
+| `RETRY_ATTEMPTS_EXHAUSTED` | All retry attempts were exhausted and the operation failed |
+| `CIRCUIT_BREAKER_OPEN` | The circuit breaker is open; requests are blocked until it recovers |
+
+## Logging
+
+When retry is active, the connector logs at each stage:
+
+- `LogRetryAttempt` — a retry attempt is starting
+- `LogRetrySucceeded` — a retry attempt succeeded
+- `LogRetryExhausted` — all retry attempts exhausted
+- `RetryAttemptsExhausted` — the operation failed after exhausting retries
+- `CircuitBreakerOpen` — the circuit breaker blocked a request
+
+## Testing retry behavior
+
+When testing connectors that use retry policies, subclass `ChannelConnectorBase` and override `SendMessageCoreAsync` to simulate transient failures:
+
+```csharp
+public class TestableConnector : MyConnector
+{
+    public int CallCount;
+
+    protected override async Task<SendResult> SendMessageCoreAsync(
+        IMessage message, CancellationToken ct)
+    {
+        CallCount++;
+        if (CallCount < 3)
+            throw new ConnectorException("RATE_LIMITED", "Test", "Transient");
+
+        return new SendResult(message.Id, "remote-id")
+        {
+            Status = MessageStatus.Delivered
+        };
+    }
+}
+```
+
+Configure a policy with the matching error codes and verify that the connector retries until success (or exhaustion):
+
+```csharp
+var settings = new ConnectionSettings()
+    .SetParameter(RetrySettingsKeys.MaxAttempts, 5)
+    .SetParameter(RetrySettingsKeys.RetryableErrorCodes, "RATE_LIMITED");
+
+var connector = new TestableConnector(schema, settings);
+await connector.InitializeAsync(ct);
+
+var result = await connector.SendMessageAsync(message, ct);
+
+Assert.True(result.IsSuccess());
+Assert.Equal(3, connector.CallCount); // 2 failures + 1 success
+Assert.Equal(3, result.Value.GetRetryAttempts());
+```

--- a/docs/samples/facebook-messenger.md
+++ b/docs/samples/facebook-messenger.md
@@ -8,6 +8,7 @@ Demonstrates the Facebook Messenger connector (`FacebookMessengerConnector`): se
 - Sending via `IMessagingClient` using the `facebook` channel name
 - Validating messages against the Facebook channel schema before sending
 - Parsing inbound Facebook webhook payloads into `IMessage` objects
+- Retry policy with exponential backoff for rate limit errors (`RATE_LIMITED`)
 - Viewing the channel schema, capabilities, and parameters
 - Checking connector runtime status
 

--- a/docs/samples/firebase-push.md
+++ b/docs/samples/firebase-push.md
@@ -9,6 +9,7 @@ Demonstrates the Firebase push connector (`FirebasePushConnector`): sending push
 - Sending batch notifications to multiple targets
 - Using dry-run mode for testing without actual delivery
 - Validating messages against the Firebase channel schema before sending
+- Retry policy with exponential backoff for transient provider errors (`UNAVAILABLE`, `INTERNAL`, `DEADLINE_EXCEEDED`)
 - Viewing the channel schema, capabilities, and parameters
 - Checking connector runtime status
 

--- a/docs/samples/multi-connector.md
+++ b/docs/samples/multi-connector.md
@@ -9,6 +9,7 @@ Demonstrates running multiple Ratatosk connectors simultaneously in a single ASP
 - Exposing channel operations through REST endpoints
 - Sending messages, receiving webhooks, and checking status over HTTP
 - Handling all connector types in a single application with shared configuration
+- Shared retry policy applied to all connectors (exponential backoff, rate limit retries)
 
 ## Run
 

--- a/docs/samples/sendgrid-email.md
+++ b/docs/samples/sendgrid-email.md
@@ -8,6 +8,7 @@ Demonstrates the SendGrid email connector (`SendGridEmailConnector`): sending tr
 - Sending via `IMessagingClient` using the `sendgrid` channel name
 - Validating messages against the SendGrid channel schema before sending
 - Parsing inbound email webhook payloads and delivery event callbacks
+- Retry policy with exponential backoff for transient failures (`RATE_LIMITED`, `SERVER_ERROR`)
 - Viewing the channel schema, capabilities, and parameters
 - Checking connector runtime status
 

--- a/docs/samples/telegram-bot.md
+++ b/docs/samples/telegram-bot.md
@@ -7,6 +7,7 @@ Demonstrates the Telegram Bot connector (`TelegramBotConnector`): sending messag
 - Building a `Message` with text, media, or location content for a Telegram chat
 - Sending via `IMessagingClient` using the `telegram` channel name
 - Validating messages against the Telegram channel schema before sending
+- Retry policy with exponential backoff for rate limit errors (`RATE_LIMITED`, `RETRY_AFTER`)
 - Viewing the channel schema, capabilities, and parameters
 - Checking connector runtime status
 

--- a/docs/samples/twilio.md
+++ b/docs/samples/twilio.md
@@ -9,6 +9,7 @@ Demonstrates the Twilio connectors (`TwilioSmsConnector` and `TwilioWhatsAppConn
 - Validating messages against the Twilio channel schema before sending
 - Parsing inbound webhook payloads and delivery status callbacks
 - Using Messaging Service SID for SMS sending
+- Retry policy with exponential backoff for transient failures (`RATE_LIMITED`, `SERVICE_UNAVAILABLE`)
 - Viewing channel schemas, capabilities, and parameters
 - Checking connector runtime status
 

--- a/samples/facebook-messenger/src/Facebook/Program.cs
+++ b/samples/facebook-messenger/src/Facebook/Program.cs
@@ -26,7 +26,16 @@ builder.Services.AddLogging(logging =>
 
 builder.Services.AddMessaging()
     .AddClient()
-    .AddFacebookMessenger("facebook", c => c.WithSettings("Facebook"));
+    .AddFacebookMessenger("facebook", c => c
+        .WithSettings("Facebook")
+        .WithRetryPolicy(options =>
+        {
+            options.WithMaxAttempts(3)
+                   .WithExponentialBackoff()
+                   .WithBaseDelay(TimeSpan.FromSeconds(1))
+                   .WithJitter()
+                   .RetryOnErrorCodes("RATE_LIMITED");
+        }));
 
 builder.Services.AddSingleton<Facebook.FacebookSampleSupport>();
 

--- a/samples/firebase-push/src/Firebase/Program.cs
+++ b/samples/firebase-push/src/Firebase/Program.cs
@@ -26,7 +26,16 @@ builder.Services.AddLogging(logging =>
 
 builder.Services.AddMessaging()
     .AddClient()
-    .AddFirebasePush("firebase", c => c.WithSettings("Firebase"));
+    .AddFirebasePush("firebase", c => c
+        .WithSettings("Firebase")
+        .WithRetryPolicy(options =>
+        {
+            options.WithMaxAttempts(3)
+                   .WithExponentialBackoff()
+                   .WithBaseDelay(TimeSpan.FromSeconds(1))
+                   .WithJitter()
+                   .RetryOnErrorCodes("UNAVAILABLE", "INTERNAL", "DEADLINE_EXCEEDED");
+        }));
 
 builder.Services.AddSingleton<Firebase.FirebaseSampleSupport>();
 

--- a/samples/multi-connector/src/MultiConnector/Program.cs
+++ b/samples/multi-connector/src/MultiConnector/Program.cs
@@ -20,14 +20,23 @@ builder.Services.AddLogging(logging =>
     }
 });
 
+var retry = (Action<RetryPolicyOptions>)(options =>
+{
+    options.WithMaxAttempts(3)
+           .WithExponentialBackoff()
+           .WithBaseDelay(TimeSpan.FromSeconds(1))
+           .WithJitter()
+           .RetryOnErrorCodes("RATE_LIMITED", "SERVICE_UNAVAILABLE");
+});
+
 builder.Services.AddMessaging()
     .AddClient()
-    .AddFacebookMessenger("facebook", c => c.WithSettings("Facebook"))
-    .AddFirebasePush("firebase", c => c.WithSettings("Firebase"))
-    .AddSendGridEmail("sendgrid", c => c.WithSettings("SendGrid"))
-    .AddTelegramBot("telegram", c => c.WithSettings("Telegram"))
-    .AddTwilioSms("sms", c => c.WithSettings("Twilio"))
-    .AddTwilioWhatsApp("whatsapp", c => c.WithSettings("Twilio"));
+    .AddFacebookMessenger("facebook", c => c.WithSettings("Facebook").WithRetryPolicy(retry))
+    .AddFirebasePush("firebase", c => c.WithSettings("Firebase").WithRetryPolicy(retry))
+    .AddSendGridEmail("sendgrid", c => c.WithSettings("SendGrid").WithRetryPolicy(retry))
+    .AddTelegramBot("telegram", c => c.WithSettings("Telegram").WithRetryPolicy(retry))
+    .AddTwilioSms("sms", c => c.WithSettings("Twilio").WithRetryPolicy(retry))
+    .AddTwilioWhatsApp("whatsapp", c => c.WithSettings("Twilio").WithRetryPolicy(retry));
 
 var app = builder.Build();
 

--- a/samples/sendgrid-email/src/SendGridSample/Program.cs
+++ b/samples/sendgrid-email/src/SendGridSample/Program.cs
@@ -26,7 +26,16 @@ builder.Services.AddLogging(logging =>
 
 builder.Services.AddMessaging()
     .AddClient()
-    .AddSendGridEmail("sendgrid", c => c.WithSettings("SendGrid"));
+    .AddSendGridEmail("sendgrid", c => c
+        .WithSettings("SendGrid")
+        .WithRetryPolicy(options =>
+        {
+            options.WithMaxAttempts(3)
+                   .WithExponentialBackoff()
+                   .WithBaseDelay(TimeSpan.FromSeconds(1))
+                   .WithJitter()
+                   .RetryOnErrorCodes("RATE_LIMITED", "SERVER_ERROR");
+        }));
 
 builder.Services.AddSingleton<SendGridSample.SendGridSampleSupport>();
 

--- a/samples/telegram-bot/src/Telegram/Program.cs
+++ b/samples/telegram-bot/src/Telegram/Program.cs
@@ -26,7 +26,16 @@ builder.Services.AddLogging(logging =>
 
 builder.Services.AddMessaging()
     .AddClient()
-    .AddTelegramBot("telegram", c => c.WithSettings("Telegram"));
+    .AddTelegramBot("telegram", c => c
+        .WithSettings("Telegram")
+        .WithRetryPolicy(options =>
+        {
+            options.WithMaxAttempts(3)
+                   .WithExponentialBackoff()
+                   .WithBaseDelay(TimeSpan.FromSeconds(1))
+                   .WithJitter()
+                   .RetryOnErrorCodes("RATE_LIMITED", "RETRY_AFTER");
+        }));
 
 builder.Services.AddSingleton<Telegram.TelegramSampleSupport>();
 

--- a/samples/twilio/src/TwilioSample/Program.cs
+++ b/samples/twilio/src/TwilioSample/Program.cs
@@ -26,8 +26,26 @@ builder.Services.AddLogging(logging =>
 
 builder.Services.AddMessaging()
     .AddClient()
-    .AddTwilioSms("sms", c => c.WithSettings("Twilio"))
-    .AddTwilioWhatsApp("whatsapp", c => c.WithSettings("Twilio"));
+    .AddTwilioSms("sms", c => c
+        .WithSettings("Twilio")
+        .WithRetryPolicy(options =>
+        {
+            options.WithMaxAttempts(3)
+                   .WithExponentialBackoff()
+                   .WithBaseDelay(TimeSpan.FromSeconds(2))
+                   .WithJitter()
+                   .RetryOnErrorCodes("RATE_LIMITED", "SERVICE_UNAVAILABLE");
+        }))
+    .AddTwilioWhatsApp("whatsapp", c => c
+        .WithSettings("Twilio")
+        .WithRetryPolicy(options =>
+        {
+            options.WithMaxAttempts(3)
+                   .WithExponentialBackoff()
+                   .WithBaseDelay(TimeSpan.FromSeconds(2))
+                   .WithJitter()
+                   .RetryOnErrorCodes("RATE_LIMITED", "SERVICE_UNAVAILABLE");
+        }));
 
 builder.Services.AddSingleton<TwilioSample.TwilioSampleSupport>();
 

--- a/src/Ratatosk.Connector.Abstractions/ResultMetadataKeys.cs
+++ b/src/Ratatosk.Connector.Abstractions/ResultMetadataKeys.cs
@@ -1,0 +1,7 @@
+namespace Ratatosk
+{
+    public static class ResultMetadataKeys
+    {
+        public const string RetryAttempts = "RetryAttempts";
+    }
+}

--- a/src/Ratatosk.Connector.Abstractions/ResultRetryExtensions.cs
+++ b/src/Ratatosk.Connector.Abstractions/ResultRetryExtensions.cs
@@ -1,0 +1,28 @@
+namespace Ratatosk
+{
+    public static class ResultRetryExtensions
+    {
+        public static int GetRetryAttempts(this SendResult result)
+        {
+            ArgumentNullException.ThrowIfNull(result);
+            if (result.AdditionalData.TryGetValue(ResultMetadataKeys.RetryAttempts, out var value) && value is int attempts)
+                return attempts;
+            return 1;
+        }
+
+        public static int GetRetryAttempts(this StatusUpdateResult result)
+        {
+            ArgumentNullException.ThrowIfNull(result);
+            if (result.AdditionalData.TryGetValue(ResultMetadataKeys.RetryAttempts, out var value) && value is int attempts)
+                return attempts;
+            return 1;
+        }
+
+        public static int GetRetryAttempts(this StatusInfo result)
+        {
+            if (result.AdditionalData.TryGetValue(ResultMetadataKeys.RetryAttempts, out var value) && value is int attempts)
+                return attempts;
+            return 1;
+        }
+    }
+}

--- a/src/Ratatosk.Connector.Abstractions/ResultRetryExtensions.cs
+++ b/src/Ratatosk.Connector.Abstractions/ResultRetryExtensions.cs
@@ -20,6 +20,7 @@ namespace Ratatosk
 
         public static int GetRetryAttempts(this StatusInfo result)
         {
+            ArgumentNullException.ThrowIfNull(result);
             if (result.AdditionalData.TryGetValue(ResultMetadataKeys.RetryAttempts, out var value) && value is int attempts)
                 return attempts;
             return 1;

--- a/src/Ratatosk.Connector.Abstractions/RetryPolicyOptions.cs
+++ b/src/Ratatosk.Connector.Abstractions/RetryPolicyOptions.cs
@@ -1,0 +1,90 @@
+namespace Ratatosk
+{
+    public enum RetryBackoffType
+    {
+        Constant,
+        Linear,
+        Exponential
+    }
+
+    public class RetryPolicyOptions
+    {
+        public int MaxRetryAttempts { get; set; } = 3;
+
+        public TimeSpan BaseDelay { get; set; } = TimeSpan.FromSeconds(1);
+
+        public RetryBackoffType BackoffType { get; set; } = RetryBackoffType.Exponential;
+
+        public bool UseJitter { get; set; } = true;
+
+        public IList<string> RetryableErrorCodes { get; set; } = new List<string>();
+
+        public bool EnableCircuitBreaker { get; set; }
+
+        public double CircuitBreakerFailureRatio { get; set; } = 0.5;
+
+        public TimeSpan CircuitBreakerSamplingDuration { get; set; } = TimeSpan.FromSeconds(30);
+
+        public int CircuitBreakerMinimumThroughput { get; set; } = 10;
+
+        public TimeSpan CircuitBreakerBreakDuration { get; set; } = TimeSpan.FromSeconds(30);
+
+        public RetryPolicyOptions WithMaxAttempts(int maxAttempts)
+        {
+            MaxRetryAttempts = maxAttempts;
+            return this;
+        }
+
+        public RetryPolicyOptions WithBaseDelay(TimeSpan delay)
+        {
+            BaseDelay = delay;
+            return this;
+        }
+
+        public RetryPolicyOptions WithExponentialBackoff()
+        {
+            BackoffType = RetryBackoffType.Exponential;
+            return this;
+        }
+
+        public RetryPolicyOptions WithLinearBackoff()
+        {
+            BackoffType = RetryBackoffType.Linear;
+            return this;
+        }
+
+        public RetryPolicyOptions WithConstantBackoff()
+        {
+            BackoffType = RetryBackoffType.Constant;
+            return this;
+        }
+
+        public RetryPolicyOptions WithJitter(bool useJitter = true)
+        {
+            UseJitter = useJitter;
+            return this;
+        }
+
+        public RetryPolicyOptions RetryOnErrorCodes(params string[] errorCodes)
+        {
+            foreach (var code in errorCodes)
+            {
+                if (!RetryableErrorCodes.Contains(code))
+                    RetryableErrorCodes.Add(code);
+            }
+            return this;
+        }
+
+        public RetryPolicyOptions WithCircuitBreaker(double failureRatio, TimeSpan breakDuration, TimeSpan? samplingDuration = null, int? minimumThroughput = null)
+        {
+            EnableCircuitBreaker = true;
+            CircuitBreakerFailureRatio = failureRatio;
+            CircuitBreakerBreakDuration = breakDuration;
+            if (samplingDuration.HasValue)
+                CircuitBreakerSamplingDuration = samplingDuration.Value;
+            if (minimumThroughput.HasValue)
+                CircuitBreakerMinimumThroughput = minimumThroughput.Value;
+            return this;
+        }
+    }
+}

--- a/src/Ratatosk.Connector.Abstractions/RetrySettingsKeys.cs
+++ b/src/Ratatosk.Connector.Abstractions/RetrySettingsKeys.cs
@@ -1,0 +1,16 @@
+namespace Ratatosk
+{
+    public static class RetrySettingsKeys
+    {
+        public const string MaxAttempts = "Retry.MaxAttempts";
+        public const string BackoffType = "Retry.BackoffType";
+        public const string BaseDelay = "Retry.BaseDelay";
+        public const string UseJitter = "Retry.UseJitter";
+        public const string RetryableErrorCodes = "Retry.RetryableErrorCodes";
+        public const string EnableCircuitBreaker = "Retry.EnableCircuitBreaker";
+        public const string CircuitBreakerFailureRatio = "Retry.CircuitBreaker.FailureRatio";
+        public const string CircuitBreakerSamplingDuration = "Retry.CircuitBreaker.SamplingDuration";
+        public const string CircuitBreakerMinimumThroughput = "Retry.CircuitBreaker.MinimumThroughput";
+        public const string CircuitBreakerBreakDuration = "Retry.CircuitBreaker.BreakDuration";
+    }
+}

--- a/src/Ratatosk.Connectors/ChannelConnectorBase.cs
+++ b/src/Ratatosk.Connectors/ChannelConnectorBase.cs
@@ -26,6 +26,7 @@ namespace Ratatosk
         private bool _autoAuthenticationAttempted;
         private readonly IMessageIdGenerator _idGenerator;
         private readonly RetryPolicyOptions? _retryPolicy;
+        private readonly Lazy<ResiliencePipeline<SendResult>?> _sendPipeline;
 
         /// <summary>
         /// Constructs the connector base with the given schema and optional settings.
@@ -46,6 +47,11 @@ namespace Ratatosk
             _stateManager = stateManager ?? new ConnectorStateManager();
 
             _retryPolicy = ReadRetryPolicyFromSettings();
+            _sendPipeline = new Lazy<ResiliencePipeline<SendResult>?>(() =>
+            {
+                var options = _retryPolicy ?? GetDefaultRetryPolicy();
+                return ResiliencePipelineFactory.BuildPipeline<SendResult>(options);
+            });
         }
 
         /// <summary>
@@ -118,8 +124,8 @@ namespace Ratatosk
         public virtual bool IsReusable => true;
 
         /// <summary>
-        /// Gets the retry policy options for this connector, or <c>null</c> if no retry policy is configured.
-        /// Override to provide a connector-specific default retry policy.
+        /// Reads the retry policy options from the connection settings, or <c>null</c>
+        /// if no retry policy is configured in the settings.
         /// </summary>
         private RetryPolicyOptions? ReadRetryPolicyFromSettings()
         {
@@ -183,6 +189,9 @@ namespace Ratatosk
 
         private ResiliencePipeline<T>? BuildPipeline<T>()
         {
+            if (typeof(T) == typeof(SendResult))
+                return (ResiliencePipeline<T>?)(object?)_sendPipeline.Value;
+
             var options = _retryPolicy ?? GetDefaultRetryPolicy();
             return ResiliencePipelineFactory.BuildPipeline<T>(options);
         }
@@ -646,6 +655,17 @@ namespace Ratatosk
                                 ConnectorErrorCodes.CircuitBreakerOpen,
                                 MessagingErrorCodes.ErrorDomain,
                                 "The circuit breaker is open; requests are blocked until it recovers");
+                        }
+
+                        // Non-retryable ConnectorExceptions propagate to the outer handler
+                        // to preserve the original error code instead of being masked as exhaustion
+                        if (ex is ConnectorException connEx)
+                        {
+                            var retryPolicy = _retryPolicy ?? GetDefaultRetryPolicy();
+                            if (retryPolicy == null || !retryPolicy.RetryableErrorCodes.Contains(connEx.ErrorCode))
+                            {
+                                throw;
+                            }
                         }
 
                         Logger.LogRetryExhausted(_retryPolicy?.MaxRetryAttempts ?? 3, "SendMessage", ex.Message);

--- a/src/Ratatosk.Connectors/ChannelConnectorBase.cs
+++ b/src/Ratatosk.Connectors/ChannelConnectorBase.cs
@@ -26,6 +26,7 @@ namespace Ratatosk
         private bool _autoAuthenticationAttempted;
         private readonly IMessageIdGenerator _idGenerator;
         private readonly RetryPolicyOptions? _retryPolicy;
+        private RetryPolicyOptions? _effectiveRetryPolicy;
         private readonly Lazy<ResiliencePipeline<SendResult>?> _sendPipeline;
 
         /// <summary>
@@ -50,6 +51,7 @@ namespace Ratatosk
             _sendPipeline = new Lazy<ResiliencePipeline<SendResult>?>(() =>
             {
                 var options = _retryPolicy ?? GetDefaultRetryPolicy();
+                _effectiveRetryPolicy = options;
                 return ResiliencePipelineFactory.BuildPipeline<SendResult>(options);
             });
         }
@@ -650,7 +652,7 @@ namespace Ratatosk
                     {
                         if (ex.GetType().Name == "BrokenCircuitException")
                         {
-                            Logger.LogCircuitBreakerOpened("SendMessage", _retryPolicy?.CircuitBreakerBreakDuration ?? TimeSpan.FromSeconds(30));
+                            Logger.LogCircuitBreakerOpened("SendMessage", _effectiveRetryPolicy?.CircuitBreakerBreakDuration ?? TimeSpan.FromSeconds(30));
                             return OperationResult<SendResult>.Fail(
                                 ConnectorErrorCodes.CircuitBreakerOpen,
                                 MessagingErrorCodes.ErrorDomain,
@@ -661,14 +663,13 @@ namespace Ratatosk
                         // to preserve the original error code instead of being masked as exhaustion
                         if (ex is ConnectorException connEx)
                         {
-                            var retryPolicy = _retryPolicy ?? GetDefaultRetryPolicy();
-                            if (retryPolicy == null || !retryPolicy.RetryableErrorCodes.Contains(connEx.ErrorCode))
+                            if (_effectiveRetryPolicy == null || !_effectiveRetryPolicy.RetryableErrorCodes.Contains(connEx.ErrorCode))
                             {
                                 throw;
                             }
                         }
 
-                        Logger.LogRetryExhausted(_retryPolicy?.MaxRetryAttempts ?? 3, "SendMessage", ex.Message);
+                        Logger.LogRetryExhausted(_effectiveRetryPolicy?.MaxRetryAttempts ?? 3, "SendMessage", ex.Message);
                         return OperationResult<SendResult>.Fail(
                             ConnectorErrorCodes.RetryAttemptsExhausted,
                             MessagingErrorCodes.ErrorDomain,

--- a/src/Ratatosk.Connectors/ChannelConnectorBase.cs
+++ b/src/Ratatosk.Connectors/ChannelConnectorBase.cs
@@ -6,6 +6,8 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
+using Polly;
+
 using System.ComponentModel.DataAnnotations;
 using System.Runtime.CompilerServices;
 
@@ -23,6 +25,7 @@ namespace Ratatosk
         private readonly IAuthenticationManager _authenticationManager;
         private bool _autoAuthenticationAttempted;
         private readonly IMessageIdGenerator _idGenerator;
+        private readonly RetryPolicyOptions? _retryPolicy;
 
         /// <summary>
         /// Constructs the connector base with the given schema and optional settings.
@@ -41,6 +44,8 @@ namespace Ratatosk
             _authenticationManager = authenticationManager ?? new AuthenticationManager(logger: NullLogger<AuthenticationManager>.Instance);
             _idGenerator = idGenerator ?? new DefaultMessageIdGenerator();
             _stateManager = stateManager ?? new ConnectorStateManager();
+
+            _retryPolicy = ReadRetryPolicyFromSettings();
         }
 
         /// <summary>
@@ -111,6 +116,76 @@ namespace Ratatosk
         /// </para>
         /// </remarks>
         public virtual bool IsReusable => true;
+
+        /// <summary>
+        /// Gets the retry policy options for this connector, or <c>null</c> if no retry policy is configured.
+        /// Override to provide a connector-specific default retry policy.
+        /// </summary>
+        private RetryPolicyOptions? ReadRetryPolicyFromSettings()
+        {
+            if (!ConnectionSettings.Parameters.TryGetValue(RetrySettingsKeys.MaxAttempts, out var maxRaw))
+                return null;
+
+            var options = new RetryPolicyOptions
+            {
+                MaxRetryAttempts = Convert.ToInt32(maxRaw)
+            };
+
+            if (ConnectionSettings.Parameters.TryGetValue(RetrySettingsKeys.BackoffType, out var backoffRaw) && backoffRaw is string backoffStr)
+            {
+                if (Enum.TryParse<RetryBackoffType>(backoffStr, out var backoffType))
+                    options.BackoffType = backoffType;
+            }
+
+            if (ConnectionSettings.Parameters.TryGetValue(RetrySettingsKeys.BaseDelay, out var delayRaw) && delayRaw is string delayStr)
+            {
+                if (TimeSpan.TryParse(delayStr, out var baseDelay))
+                    options.BaseDelay = baseDelay;
+            }
+
+            if (ConnectionSettings.Parameters.TryGetValue(RetrySettingsKeys.UseJitter, out var jitterRaw))
+                options.UseJitter = Convert.ToBoolean(jitterRaw);
+
+            if (ConnectionSettings.Parameters.TryGetValue(RetrySettingsKeys.RetryableErrorCodes, out var codesRaw) && codesRaw is string codesStr && !string.IsNullOrWhiteSpace(codesStr))
+            {
+                foreach (var code in codesStr.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+                    options.RetryableErrorCodes.Add(code);
+            }
+
+            if (ConnectionSettings.Parameters.TryGetValue(RetrySettingsKeys.EnableCircuitBreaker, out var cbRaw))
+                options.EnableCircuitBreaker = Convert.ToBoolean(cbRaw);
+
+            if (options.EnableCircuitBreaker)
+            {
+                if (ConnectionSettings.Parameters.TryGetValue(RetrySettingsKeys.CircuitBreakerFailureRatio, out var ratioRaw))
+                    options.CircuitBreakerFailureRatio = Convert.ToDouble(ratioRaw);
+
+                if (ConnectionSettings.Parameters.TryGetValue(RetrySettingsKeys.CircuitBreakerSamplingDuration, out var sampleRaw) && sampleRaw is string sampleStr)
+                {
+                    if (TimeSpan.TryParse(sampleStr, out var samplingDuration))
+                        options.CircuitBreakerSamplingDuration = samplingDuration;
+                }
+
+                if (ConnectionSettings.Parameters.TryGetValue(RetrySettingsKeys.CircuitBreakerMinimumThroughput, out var throughputRaw))
+                    options.CircuitBreakerMinimumThroughput = Convert.ToInt32(throughputRaw);
+
+                if (ConnectionSettings.Parameters.TryGetValue(RetrySettingsKeys.CircuitBreakerBreakDuration, out var breakRaw) && breakRaw is string breakStr)
+                {
+                    if (TimeSpan.TryParse(breakStr, out var breakDuration))
+                        options.CircuitBreakerBreakDuration = breakDuration;
+                }
+            }
+
+            return options;
+        }
+
+        protected virtual RetryPolicyOptions? GetDefaultRetryPolicy() => null;
+
+        private ResiliencePipeline<T>? BuildPipeline<T>()
+        {
+            var options = _retryPolicy ?? GetDefaultRetryPolicy();
+            return ResiliencePipelineFactory.BuildPipeline<T>(options);
+        }
 
         /// <summary>
         /// Gets the current state of the connector.
@@ -543,11 +618,57 @@ namespace Ratatosk
 
                 Logger.LogSendingMessage(message.Id!);
 
-                var result = await SendMessageCoreAsync(message, cancellationToken);
+                var pipeline = BuildPipeline<SendResult>();
+                SendResult result;
+                var attempts = 1;
 
+                if (pipeline != null)
+                {
+                    var count = 0;
+
+                    try
+                    {
+                        result = await pipeline.ExecuteAsync(async ct =>
+                        {
+                            count++;
+                            return await SendMessageCoreAsync(message, ct);
+                        }, cancellationToken);
+
+                        attempts = count;
+                        Logger.LogRetrySucceeded("SendMessage", attempts);
+                    }
+                    catch (Exception ex)
+                    {
+                        if (ex.GetType().Name == "BrokenCircuitException")
+                        {
+                            Logger.LogCircuitBreakerOpened("SendMessage", _retryPolicy?.CircuitBreakerBreakDuration ?? TimeSpan.FromSeconds(30));
+                            return OperationResult<SendResult>.Fail(
+                                ConnectorErrorCodes.CircuitBreakerOpen,
+                                MessagingErrorCodes.ErrorDomain,
+                                "The circuit breaker is open; requests are blocked until it recovers");
+                        }
+
+                        Logger.LogRetryExhausted(_retryPolicy?.MaxRetryAttempts ?? 3, "SendMessage", ex.Message);
+                        return OperationResult<SendResult>.Fail(
+                            ConnectorErrorCodes.RetryAttemptsExhausted,
+                            MessagingErrorCodes.ErrorDomain,
+                            $"All retry attempts exhausted: {ex.Message}");
+                    }
+                }
+                else
+                {
+                    result = await SendMessageCoreAsync(message, cancellationToken);
+
+                    result.AdditionalData[ResultMetadataKeys.RetryAttempts] = 1;
+                    Logger.LogMessageSent(result.RemoteMessageId);
+
+                    return OperationResult<SendResult>.Success(result);
+                }
+
+                result.AdditionalData[ResultMetadataKeys.RetryAttempts] = attempts;
                 Logger.LogMessageSent(result.RemoteMessageId);
 
-                return result;
+                return OperationResult<SendResult>.Success(result);
             }
             catch (MessagingException ex)
             {

--- a/src/Ratatosk.Connectors/ConnectorErrorCodes.cs
+++ b/src/Ratatosk.Connectors/ConnectorErrorCodes.cs
@@ -157,5 +157,19 @@ namespace Ratatosk
         public const string ReceiveMessagesError = "RECEIVE_MESSAGES_ERROR";
 
         #endregion
+
+        #region Retry Errors
+
+        /// <summary>
+        /// Indicates that all retry attempts have been exhausted for an operation.
+        /// </summary>
+        public const string RetryAttemptsExhausted = "RETRY_ATTEMPTS_EXHAUSTED";
+
+        /// <summary>
+        /// Indicates that the circuit breaker is open and the operation was not attempted.
+        /// </summary>
+        public const string CircuitBreakerOpen = "CIRCUIT_BREAKER_OPEN";
+
+        #endregion
     }
 }

--- a/src/Ratatosk.Connectors/ConnectorLoggerEventId.cs
+++ b/src/Ratatosk.Connectors/ConnectorLoggerEventId.cs
@@ -88,4 +88,11 @@ internal static class ConnectorLoggerEventId
     public const int TokenRefreshFailedWithStatus = LoggerEventId.BaseId + 143;
     public const int RetryingTokenObtainment = LoggerEventId.BaseId + 144;
     public const int TokenRefreshed = LoggerEventId.BaseId + 145;
+
+    // Retry Policy events
+    public const int RetryAttempt = LoggerEventId.BaseId + 150;
+    public const int RetrySucceeded = LoggerEventId.BaseId + 151;
+    public const int RetryExhausted = LoggerEventId.BaseId + 152;
+    public const int CircuitBreakerOpened = LoggerEventId.BaseId + 153;
+    public const int CircuitBreakerReset = LoggerEventId.BaseId + 154;
 }

--- a/src/Ratatosk.Connectors/LoggerExtensions.cs
+++ b/src/Ratatosk.Connectors/LoggerExtensions.cs
@@ -515,7 +515,7 @@ namespace Ratatosk
         [LoggerMessage(
             EventId = ConnectorLoggerEventId.CircuitBreakerReset,
             Level = LogLevel.Information,
-            Message = "Circuit breaker reset for {OperationType} —恢复正常 operation")]
+            Message = "Circuit breaker reset for {OperationType} — normal operation resumed")]
         internal static partial void LogCircuitBreakerReset(this ILogger logger, string operationType);
 
         #endregion

--- a/src/Ratatosk.Connectors/LoggerExtensions.cs
+++ b/src/Ratatosk.Connectors/LoggerExtensions.cs
@@ -485,5 +485,39 @@ namespace Ratatosk
         internal static partial void LogNotInOperationalState(this ILogger logger, ConnectorState state);
 
         #endregion
+
+        #region Retry Policy Logging
+
+        [LoggerMessage(
+            EventId = ConnectorLoggerEventId.RetryAttempt,
+            Level = LogLevel.Debug,
+            Message = "Retry attempt {AttemptNumber} of {MaxAttempts} for operation {OperationType}: {ErrorMessage}")]
+        internal static partial void LogRetryAttempt(this ILogger logger, int attemptNumber, int maxAttempts, string operationType, string? errorMessage);
+
+        [LoggerMessage(
+            EventId = ConnectorLoggerEventId.RetrySucceeded,
+            Level = LogLevel.Information,
+            Message = "Operation {OperationType} succeeded after {AttemptCount} attempt(s)")]
+        internal static partial void LogRetrySucceeded(this ILogger logger, string operationType, int attemptCount);
+
+        [LoggerMessage(
+            EventId = ConnectorLoggerEventId.RetryExhausted,
+            Level = LogLevel.Error,
+            Message = "All {MaxAttempts} retry attempt(s) exhausted for operation {OperationType}: {ErrorMessage}")]
+        internal static partial void LogRetryExhausted(this ILogger logger, int maxAttempts, string operationType, string? errorMessage);
+
+        [LoggerMessage(
+            EventId = ConnectorLoggerEventId.CircuitBreakerOpened,
+            Level = LogLevel.Warning,
+            Message = "Circuit breaker opened for {OperationType} — failing fast until {BreakDuration} elapses")]
+        internal static partial void LogCircuitBreakerOpened(this ILogger logger, string operationType, TimeSpan breakDuration);
+
+        [LoggerMessage(
+            EventId = ConnectorLoggerEventId.CircuitBreakerReset,
+            Level = LogLevel.Information,
+            Message = "Circuit breaker reset for {OperationType} —恢复正常 operation")]
+        internal static partial void LogCircuitBreakerReset(this ILogger logger, string operationType);
+
+        #endregion
     }
 }

--- a/src/Ratatosk.Connectors/Ratatosk.Connectors.csproj
+++ b/src/Ratatosk.Connectors/Ratatosk.Connectors.csproj
@@ -12,18 +12,21 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Resilience" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net9.0'">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.8" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.8" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Resilience" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net10.0'">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Resilience" Version="10.0.0" />
   </ItemGroup>
 
 

--- a/src/Ratatosk.Connectors/ResiliencePipelineFactory.cs
+++ b/src/Ratatosk.Connectors/ResiliencePipelineFactory.cs
@@ -15,7 +15,7 @@ namespace Ratatosk
 
             var retryOptions = new RetryStrategyOptions<T>
             {
-                MaxRetryAttempts = options.MaxRetryAttempts,
+                MaxRetryAttempts = options.MaxRetryAttempts - 1,
                 Delay = options.BaseDelay,
                 BackoffType = MapBackoffType(options.BackoffType),
                 UseJitter = options.UseJitter,

--- a/src/Ratatosk.Connectors/ResiliencePipelineFactory.cs
+++ b/src/Ratatosk.Connectors/ResiliencePipelineFactory.cs
@@ -1,0 +1,57 @@
+using Polly;
+using Polly.CircuitBreaker;
+using Polly.Retry;
+
+namespace Ratatosk
+{
+    internal static class ResiliencePipelineFactory
+    {
+        public static ResiliencePipeline<T>? BuildPipeline<T>(RetryPolicyOptions? options)
+        {
+            if (options == null || options.MaxRetryAttempts <= 1)
+                return null;
+
+            var builder = new ResiliencePipelineBuilder<T>();
+
+            var retryOptions = new RetryStrategyOptions<T>
+            {
+                MaxRetryAttempts = options.MaxRetryAttempts,
+                Delay = options.BaseDelay,
+                BackoffType = MapBackoffType(options.BackoffType),
+                UseJitter = options.UseJitter,
+                ShouldHandle = args => ValueTask.FromResult(args.Outcome.Exception is ConnectorException ex &&
+                    options.RetryableErrorCodes.Contains(ex.ErrorCode))
+            };
+
+            builder.AddRetry(retryOptions);
+
+            if (options.EnableCircuitBreaker)
+            {
+                var breakerOptions = new CircuitBreakerStrategyOptions<T>
+                {
+                    FailureRatio = options.CircuitBreakerFailureRatio,
+                    SamplingDuration = options.CircuitBreakerSamplingDuration,
+                    MinimumThroughput = options.CircuitBreakerMinimumThroughput,
+                    BreakDuration = options.CircuitBreakerBreakDuration,
+                    ShouldHandle = args => ValueTask.FromResult(args.Outcome.Exception is ConnectorException ex &&
+                        options.RetryableErrorCodes.Contains(ex.ErrorCode))
+                };
+
+                builder.AddCircuitBreaker(breakerOptions);
+            }
+
+            return builder.Build();
+        }
+
+        private static DelayBackoffType MapBackoffType(RetryBackoffType type)
+        {
+            return type switch
+            {
+                RetryBackoffType.Constant => DelayBackoffType.Constant,
+                RetryBackoffType.Linear => DelayBackoffType.Linear,
+                RetryBackoffType.Exponential => DelayBackoffType.Exponential,
+                _ => DelayBackoffType.Exponential
+            };
+        }
+    }
+}

--- a/src/Ratatosk.Facebook/Ratatosk.Facebook.csproj
+++ b/src/Ratatosk.Facebook/Ratatosk.Facebook.csproj
@@ -19,6 +19,26 @@
     <PackageReference Include="System.Text.Json" Version="10.0.8" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Polly.Core" Version="8.6.6" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Deveel" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(TargetFramework) == 'net9.0'">
+    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.16" />
+    <PackageReference Include="Polly.Core" Version="9.0.0" />
+    <PackageReference Include="System.Text.Json" Version="9.0.16" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(TargetFramework) == 'net10.0'">
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.8" />
+    <PackageReference Include="Polly.Core" Version="10.0.0" />
+    <PackageReference Include="System.Text.Json" Version="10.0.8" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <Using Include="Deveel" />

--- a/src/Ratatosk.Facebook/Ratatosk.Facebook.csproj
+++ b/src/Ratatosk.Facebook/Ratatosk.Facebook.csproj
@@ -19,9 +19,6 @@
     <PackageReference Include="System.Text.Json" Version="10.0.8" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Polly.Core" Version="8.6.6" />
-  </ItemGroup>
 
   <ItemGroup>
     <Using Include="Deveel" />

--- a/src/Ratatosk/ChannelConnectorBuilder.cs
+++ b/src/Ratatosk/ChannelConnectorBuilder.cs
@@ -173,6 +173,47 @@ namespace Ratatosk
         // ── Factory override ───────────────────────────────────────────────────
 
         /// <summary>
+        /// Configures the retry policy for the connector, controlling how transient
+        /// failures are retried and whether a circuit breaker is enabled.
+        /// </summary>
+        /// <param name="configure">
+        /// A delegate that configures the <see cref="RetryPolicyOptions"/> instance.
+        /// </param>
+        /// <returns>
+        /// Returns the current builder instance to allow chaining.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown if <paramref name="configure"/> is <c>null</c>.
+        /// </exception>
+        public ChannelConnectorBuilder<TConnector> WithRetryPolicy(Action<RetryPolicyOptions> configure)
+        {
+            ArgumentNullException.ThrowIfNull(configure, nameof(configure));
+
+            var options = new RetryPolicyOptions();
+            configure(options);
+
+            _fluentSettings[RetrySettingsKeys.MaxAttempts] = options.MaxRetryAttempts;
+            _fluentSettings[RetrySettingsKeys.BackoffType] = options.BackoffType.ToString();
+            _fluentSettings[RetrySettingsKeys.BaseDelay] = options.BaseDelay.ToString();
+            _fluentSettings[RetrySettingsKeys.UseJitter] = options.UseJitter;
+
+            if (options.RetryableErrorCodes.Count > 0)
+                _fluentSettings[RetrySettingsKeys.RetryableErrorCodes] = string.Join(",", options.RetryableErrorCodes);
+
+            _fluentSettings[RetrySettingsKeys.EnableCircuitBreaker] = options.EnableCircuitBreaker;
+
+            if (options.EnableCircuitBreaker)
+            {
+                _fluentSettings[RetrySettingsKeys.CircuitBreakerFailureRatio] = options.CircuitBreakerFailureRatio;
+                _fluentSettings[RetrySettingsKeys.CircuitBreakerSamplingDuration] = options.CircuitBreakerSamplingDuration.ToString();
+                _fluentSettings[RetrySettingsKeys.CircuitBreakerMinimumThroughput] = options.CircuitBreakerMinimumThroughput;
+                _fluentSettings[RetrySettingsKeys.CircuitBreakerBreakDuration] = options.CircuitBreakerBreakDuration.ToString();
+            }
+
+            return this;
+        }
+
+        /// <summary>
         /// Overrides the default factory used to create the connector
         /// with a custom factory type.
         /// </summary>

--- a/test/Ratatosk.Connectors.XUnit/Unit/ResultRetryExtensionsTests.cs
+++ b/test/Ratatosk.Connectors.XUnit/Unit/ResultRetryExtensionsTests.cs
@@ -1,0 +1,79 @@
+namespace Ratatosk;
+
+[Trait("Category", "Unit")]
+[Trait("Feature", "RetryPolicy")]
+public class ResultRetryExtensionsTests
+{
+    [Fact]
+    public void Should_ReturnOne_When_SendResultHasNoRetryAttempts()
+    {
+        var result = new SendResult("msg-1", "remote-1");
+        Assert.Equal(1, result.GetRetryAttempts());
+    }
+
+    [Fact]
+    public void Should_ReturnCorrectAttempts_When_SendResultHasRetryAttempts()
+    {
+        var result = new SendResult("msg-1", "remote-1")
+        {
+            AdditionalData =
+            {
+                ["RetryAttempts"] = 3
+            }
+        };
+        Assert.Equal(3, result.GetRetryAttempts());
+    }
+
+    [Fact]
+    public void Should_ReturnOne_When_StatusUpdateResultHasNoRetryAttempts()
+    {
+        var result = new StatusUpdateResult("msg-1", MessageStatus.Delivered);
+        Assert.Equal(1, result.GetRetryAttempts());
+    }
+
+    [Fact]
+    public void Should_ReturnCorrectAttempts_When_StatusUpdateResultHasRetryAttempts()
+    {
+        var result = new StatusUpdateResult("msg-1", MessageStatus.Delivered)
+        {
+            AdditionalData =
+            {
+                ["RetryAttempts"] = 2
+            }
+        };
+        Assert.Equal(2, result.GetRetryAttempts());
+    }
+
+    [Fact]
+    public void Should_ReturnOne_When_StatusInfoHasNoRetryAttempts()
+    {
+        var info = new StatusInfo("OK");
+        Assert.Equal(1, info.GetRetryAttempts());
+    }
+
+    [Fact]
+    public void Should_ReturnCorrectAttempts_When_StatusInfoHasRetryAttempts()
+    {
+        var info = new StatusInfo("OK")
+        {
+            AdditionalData =
+            {
+                ["RetryAttempts"] = 1
+            }
+        };
+        Assert.Equal(1, info.GetRetryAttempts());
+    }
+
+    [Fact]
+    public void Should_ReturnOne_When_RetryAttemptsIsWrongType()
+    {
+        var result = new SendResult("msg-1", "remote-1")
+        {
+            AdditionalData =
+            {
+                ["RetryAttempts"] = "not-an-int"
+            }
+        };
+        Assert.Equal(1, result.GetRetryAttempts());
+    }
+}

--- a/test/Ratatosk.Connectors.XUnit/Unit/RetryPolicyOptionsTests.cs
+++ b/test/Ratatosk.Connectors.XUnit/Unit/RetryPolicyOptionsTests.cs
@@ -1,0 +1,108 @@
+namespace Ratatosk;
+
+[Trait("Category", "Unit")]
+[Trait("Feature", "RetryPolicy")]
+public class RetryPolicyOptionsTests
+{
+    [Fact]
+    public void Should_HaveDefaultValues_When_Created()
+    {
+        var options = new RetryPolicyOptions();
+
+        Assert.Equal(3, options.MaxRetryAttempts);
+        Assert.Equal(TimeSpan.FromSeconds(1), options.BaseDelay);
+        Assert.Equal(RetryBackoffType.Exponential, options.BackoffType);
+        Assert.True(options.UseJitter);
+        Assert.Empty(options.RetryableErrorCodes);
+        Assert.False(options.EnableCircuitBreaker);
+        Assert.Equal(0.5, options.CircuitBreakerFailureRatio);
+        Assert.Equal(TimeSpan.FromSeconds(30), options.CircuitBreakerSamplingDuration);
+        Assert.Equal(10, options.CircuitBreakerMinimumThroughput);
+        Assert.Equal(TimeSpan.FromSeconds(30), options.CircuitBreakerBreakDuration);
+    }
+
+    [Fact]
+    public void Should_SetMaxAttempts_When_WithMaxAttemptsCalled()
+    {
+        var options = new RetryPolicyOptions().WithMaxAttempts(5);
+        Assert.Equal(5, options.MaxRetryAttempts);
+    }
+
+    [Fact]
+    public void Should_SetBaseDelay_When_WithBaseDelayCalled()
+    {
+        var options = new RetryPolicyOptions().WithBaseDelay(TimeSpan.FromSeconds(3));
+        Assert.Equal(TimeSpan.FromSeconds(3), options.BaseDelay);
+    }
+
+    [Fact]
+    public void Should_SetExponentialBackoff_When_WithExponentialBackoffCalled()
+    {
+        var options = new RetryPolicyOptions().WithExponentialBackoff();
+        Assert.Equal(RetryBackoffType.Exponential, options.BackoffType);
+    }
+
+    [Fact]
+    public void Should_SetLinearBackoff_When_WithLinearBackoffCalled()
+    {
+        var options = new RetryPolicyOptions().WithLinearBackoff();
+        Assert.Equal(RetryBackoffType.Linear, options.BackoffType);
+    }
+
+    [Fact]
+    public void Should_SetConstantBackoff_When_WithConstantBackoffCalled()
+    {
+        var options = new RetryPolicyOptions().WithConstantBackoff();
+        Assert.Equal(RetryBackoffType.Constant, options.BackoffType);
+    }
+
+    [Fact]
+    public void Should_DisableJitter_When_WithJitterFalse()
+    {
+        var options = new RetryPolicyOptions().WithJitter(false);
+        Assert.False(options.UseJitter);
+    }
+
+    [Fact]
+    public void Should_AddErrorCodes_When_RetryOnErrorCodesCalled()
+    {
+        var options = new RetryPolicyOptions()
+            .RetryOnErrorCodes("RATE_LIMITED", "SERVICE_UNAVAILABLE");
+
+        Assert.Contains("RATE_LIMITED", options.RetryableErrorCodes);
+        Assert.Contains("SERVICE_UNAVAILABLE", options.RetryableErrorCodes);
+    }
+
+    [Fact]
+    public void Should_EnableCircuitBreaker_When_WithCircuitBreakerCalled()
+    {
+        var options = new RetryPolicyOptions()
+            .WithCircuitBreaker(0.3, TimeSpan.FromSeconds(60));
+
+        Assert.True(options.EnableCircuitBreaker);
+        Assert.Equal(0.3, options.CircuitBreakerFailureRatio);
+        Assert.Equal(TimeSpan.FromSeconds(60), options.CircuitBreakerBreakDuration);
+    }
+
+    [Fact]
+    public void Should_SetCircuitBreakerDetails_When_WithCircuitBreakerCalledWithOptionalParams()
+    {
+        var options = new RetryPolicyOptions()
+            .WithCircuitBreaker(0.2, TimeSpan.FromSeconds(45), TimeSpan.FromSeconds(15), 5);
+
+        Assert.Equal(0.2, options.CircuitBreakerFailureRatio);
+        Assert.Equal(TimeSpan.FromSeconds(45), options.CircuitBreakerBreakDuration);
+        Assert.Equal(TimeSpan.FromSeconds(15), options.CircuitBreakerSamplingDuration);
+        Assert.Equal(5, options.CircuitBreakerMinimumThroughput);
+    }
+
+    [Fact]
+    public void Should_NotDuplicateErrorCodes_When_RetryOnErrorCodesCalledMultipleTimes()
+    {
+        var options = new RetryPolicyOptions()
+            .RetryOnErrorCodes("RATE_LIMITED")
+            .RetryOnErrorCodes("RATE_LIMITED");
+
+        Assert.Single(options.RetryableErrorCodes);
+    }
+}

--- a/test/Ratatosk.Connectors.XUnit/Unit/RetryPolicySendTests.cs
+++ b/test/Ratatosk.Connectors.XUnit/Unit/RetryPolicySendTests.cs
@@ -1,0 +1,297 @@
+namespace Ratatosk;
+
+[Trait("Category", "Unit")]
+[Trait("Feature", "RetryPolicy")]
+public class RetryPolicySendTests
+{
+    private sealed class RetryTestConnector : ChannelConnectorBase
+    {
+        private readonly int _failUntilCall;
+        private readonly string _retryableErrorCode;
+        private bool _failOnNonRetryable;
+
+        public int CallCount;
+
+        public RetryTestConnector(
+            IChannelSchema schema,
+            ConnectionSettings? settings = null,
+            int failUntilCall = 0,
+            string retryableErrorCode = "RATE_LIMITED")
+            : base(schema, settings ?? new ConnectionSettings())
+        {
+            _failUntilCall = failUntilCall;
+            _retryableErrorCode = retryableErrorCode;
+        }
+
+        public RetryTestConnector WithNonRetryableFailure()
+        {
+            _failOnNonRetryable = true;
+            return this;
+        }
+
+        protected override ValueTask InitializeConnectorAsync(CancellationToken cancellationToken)
+        {
+            SetState(ConnectorState.Ready);
+            return ValueTask.CompletedTask;
+        }
+
+        protected override ValueTask TestConnectorConnectionAsync(CancellationToken cancellationToken)
+            => ValueTask.CompletedTask;
+
+        protected override Task<SendResult> SendMessageCoreAsync(IMessage message, CancellationToken cancellationToken)
+        {
+            CallCount++;
+
+            if (_failOnNonRetryable)
+                throw new ConnectorException("INVALID_CONFIG", "Test", "Non-retryable error");
+
+            if (CallCount < _failUntilCall)
+                throw new ConnectorException(_retryableErrorCode, "Test", "Transient error");
+
+            return Task.FromResult(new SendResult(message.Id, "remote-id")
+            {
+                Status = MessageStatus.Delivered
+            });
+        }
+
+        protected override Task<StatusInfo> GetConnectorStatusAsync(CancellationToken cancellationToken)
+            => Task.FromResult(new StatusInfo("OK"));
+    }
+
+    private static IChannelSchema CreateSchema()
+        => new ChannelSchemaBuilder("TestProvider", "test", "1.0")
+            .WithCapabilities(ChannelCapability.SendMessages)
+            .HandlesMessageEndpoint(EndpointType.PhoneNumber, e => { e.CanSend = true; e.CanReceive = true; })
+            .Build();
+
+    private static Message CreateTestMessage()
+        => new Message
+        {
+            Id = "msg-1",
+            Sender = new Endpoint(EndpointType.PhoneNumber, "+1234"),
+            Receiver = new Endpoint(EndpointType.PhoneNumber, "+5678")
+        };
+
+    [Fact]
+    public async Task Should_SucceedWithoutRetry_When_NoPolicyConfigured()
+    {
+        var schema = CreateSchema();
+        var connector = new RetryTestConnector(schema);
+        await connector.InitializeAsync(TestContext.Current.CancellationToken);
+
+        var result = await connector.SendMessageAsync(CreateTestMessage(), TestContext.Current.CancellationToken);
+
+        Assert.True(result.IsSuccess());
+        Assert.Equal(1, connector.CallCount);
+        Assert.Equal(1, result.Value.GetRetryAttempts());
+    }
+
+    [Fact]
+    public async Task Should_SucceedOnFirstAttempt_When_NoFailure()
+    {
+        var settings = new ConnectionSettings()
+            .SetParameter(RetrySettingsKeys.MaxAttempts, 3)
+            .SetParameter(RetrySettingsKeys.RetryableErrorCodes, "RATE_LIMITED");
+        var schema = CreateSchema();
+        var connector = new RetryTestConnector(schema, settings);
+        await connector.InitializeAsync(TestContext.Current.CancellationToken);
+
+        var result = await connector.SendMessageAsync(CreateTestMessage(), TestContext.Current.CancellationToken);
+
+        Assert.True(result.IsSuccess());
+        Assert.Equal(1, connector.CallCount);
+        Assert.Equal(1, result.Value.GetRetryAttempts());
+    }
+
+    [Fact]
+    public async Task Should_SucceedOnSecondAttempt_When_FirstFailsWithRetryableError()
+    {
+        var settings = new ConnectionSettings()
+            .SetParameter(RetrySettingsKeys.MaxAttempts, 3)
+            .SetParameter(RetrySettingsKeys.RetryableErrorCodes, "RATE_LIMITED");
+        var schema = CreateSchema();
+        var connector = new RetryTestConnector(schema, settings, failUntilCall: 2);
+        await connector.InitializeAsync(TestContext.Current.CancellationToken);
+
+        var result = await connector.SendMessageAsync(CreateTestMessage(), TestContext.Current.CancellationToken);
+
+        Assert.True(result.IsSuccess());
+        Assert.Equal(2, connector.CallCount);
+        Assert.Equal(2, result.Value.GetRetryAttempts());
+    }
+
+    [Fact]
+    public async Task Should_SucceedOnThirdAttempt_When_FirstTwoFailWithRetryableError()
+    {
+        var settings = new ConnectionSettings()
+            .SetParameter(RetrySettingsKeys.MaxAttempts, 5)
+            .SetParameter(RetrySettingsKeys.RetryableErrorCodes, "RATE_LIMITED");
+        var schema = CreateSchema();
+        var connector = new RetryTestConnector(schema, settings, failUntilCall: 3);
+        await connector.InitializeAsync(TestContext.Current.CancellationToken);
+
+        var result = await connector.SendMessageAsync(CreateTestMessage(), TestContext.Current.CancellationToken);
+
+        Assert.True(result.IsSuccess());
+        Assert.Equal(3, connector.CallCount);
+        Assert.Equal(3, result.Value.GetRetryAttempts());
+    }
+
+    [Fact]
+    public async Task Should_Fail_When_RetriesExhausted()
+    {
+        var settings = new ConnectionSettings()
+            .SetParameter(RetrySettingsKeys.MaxAttempts, 3)
+            .SetParameter(RetrySettingsKeys.RetryableErrorCodes, "RATE_LIMITED");
+        var schema = CreateSchema();
+        var connector = new RetryTestConnector(schema, settings, failUntilCall: 10);
+        await connector.InitializeAsync(TestContext.Current.CancellationToken);
+
+        var result = await connector.SendMessageAsync(CreateTestMessage(), TestContext.Current.CancellationToken);
+
+        Assert.False(result.IsSuccess());
+        Assert.Equal(ConnectorErrorCodes.RetryAttemptsExhausted, result.Error?.Code);
+        Assert.Equal(4, connector.CallCount);
+    }
+
+    [Fact]
+    public async Task Should_NotRetry_When_NonRetryableErrorOccurs()
+    {
+        var settings = new ConnectionSettings()
+            .SetParameter(RetrySettingsKeys.MaxAttempts, 3)
+            .SetParameter(RetrySettingsKeys.RetryableErrorCodes, "RATE_LIMITED");
+        var schema = CreateSchema();
+        var connector = new RetryTestConnector(schema, settings)
+            .WithNonRetryableFailure();
+        await connector.InitializeAsync(TestContext.Current.CancellationToken);
+
+        var result = await connector.SendMessageAsync(CreateTestMessage(), TestContext.Current.CancellationToken);
+
+        Assert.False(result.IsSuccess());
+        Assert.Equal(1, connector.CallCount);
+    }
+
+    [Fact]
+    public async Task Should_ReturnCircuitBreakerOpen_When_CircuitBreakerTrips()
+    {
+        var schema = CreateSchema();
+        var connector = new CircuitBreakerTestConnector(schema);
+        await connector.InitializeAsync(TestContext.Current.CancellationToken);
+
+        var result = await connector.SendMessageAsync(CreateTestMessage(), TestContext.Current.CancellationToken);
+
+        Assert.False(result.IsSuccess());
+        Assert.Equal(ConnectorErrorCodes.CircuitBreakerOpen, result.Error?.Code);
+    }
+
+    private sealed class CircuitBreakerTestConnector : ChannelConnectorBase
+    {
+        public int CallCount;
+
+        public CircuitBreakerTestConnector(IChannelSchema schema, ConnectionSettings? settings = null)
+            : base(schema, settings ?? new ConnectionSettings())
+        {
+        }
+
+        protected override RetryPolicyOptions? GetDefaultRetryPolicy()
+            => new RetryPolicyOptions
+            {
+                MaxRetryAttempts = 3,
+                RetryableErrorCodes = { "RATE_LIMITED" },
+                EnableCircuitBreaker = true,
+                CircuitBreakerFailureRatio = 0.5,
+                CircuitBreakerSamplingDuration = TimeSpan.FromSeconds(5),
+                CircuitBreakerMinimumThroughput = 2,
+                CircuitBreakerBreakDuration = TimeSpan.FromSeconds(10)
+            };
+
+        protected override ValueTask InitializeConnectorAsync(CancellationToken cancellationToken)
+        {
+            SetState(ConnectorState.Ready);
+            return ValueTask.CompletedTask;
+        }
+
+        protected override ValueTask TestConnectorConnectionAsync(CancellationToken cancellationToken)
+            => ValueTask.CompletedTask;
+
+        protected override Task<SendResult> SendMessageCoreAsync(IMessage message, CancellationToken cancellationToken)
+        {
+            CallCount++;
+            throw new ConnectorException("RATE_LIMITED", "Test", "Transient error");
+        }
+
+        protected override Task<StatusInfo> GetConnectorStatusAsync(CancellationToken cancellationToken)
+            => Task.FromResult(new StatusInfo("OK"));
+    }
+
+    [Fact]
+    public async Task Should_NotRetry_When_MaxRetryAttemptsIsOne()
+    {
+        var settings = new ConnectionSettings()
+            .SetParameter(RetrySettingsKeys.MaxAttempts, 1)
+            .SetParameter(RetrySettingsKeys.RetryableErrorCodes, "RATE_LIMITED");
+        var schema = CreateSchema();
+        var connector = new RetryTestConnector(schema, settings, failUntilCall: 10);
+        await connector.InitializeAsync(TestContext.Current.CancellationToken);
+
+        var result = await connector.SendMessageAsync(CreateTestMessage(), TestContext.Current.CancellationToken);
+
+        Assert.False(result.IsSuccess());
+        Assert.Equal(1, connector.CallCount);
+    }
+
+    [Fact]
+    public async Task Should_UseGetDefaultRetryPolicy_When_OverrideExists()
+    {
+        var schema = CreateSchema();
+        var connector = new CustomRetryTestConnector(schema);
+        await connector.InitializeAsync(TestContext.Current.CancellationToken);
+
+        var result = await connector.SendMessageAsync(CreateTestMessage(), TestContext.Current.CancellationToken);
+
+        // Connector fails 3 times, default retry is 5, so should succeed
+        Assert.True(result.IsSuccess());
+        Assert.Equal(4, connector.CallCount);
+    }
+
+    private sealed class CustomRetryTestConnector : ChannelConnectorBase
+    {
+        public int CallCount;
+
+        public CustomRetryTestConnector(IChannelSchema schema, ConnectionSettings? settings = null)
+            : base(schema, settings ?? new ConnectionSettings())
+        {
+        }
+
+        protected override RetryPolicyOptions? GetDefaultRetryPolicy()
+            => new RetryPolicyOptions
+            {
+                MaxRetryAttempts = 5,
+                RetryableErrorCodes = { "RATE_LIMITED" }
+            };
+
+        protected override ValueTask InitializeConnectorAsync(CancellationToken cancellationToken)
+        {
+            SetState(ConnectorState.Ready);
+            return ValueTask.CompletedTask;
+        }
+
+        protected override ValueTask TestConnectorConnectionAsync(CancellationToken cancellationToken)
+            => ValueTask.CompletedTask;
+
+        protected override Task<SendResult> SendMessageCoreAsync(IMessage message, CancellationToken cancellationToken)
+        {
+            CallCount++;
+            if (CallCount < 4)
+                throw new ConnectorException("RATE_LIMITED", "Test", "Transient error");
+
+            return Task.FromResult(new SendResult(message.Id, "remote-id")
+            {
+                Status = MessageStatus.Delivered
+            });
+        }
+
+        protected override Task<StatusInfo> GetConnectorStatusAsync(CancellationToken cancellationToken)
+            => Task.FromResult(new StatusInfo("OK"));
+    }
+}

--- a/test/Ratatosk.Connectors.XUnit/Unit/RetryPolicySendTests.cs
+++ b/test/Ratatosk.Connectors.XUnit/Unit/RetryPolicySendTests.cs
@@ -151,7 +151,7 @@ public class RetryPolicySendTests
 
         Assert.False(result.IsSuccess());
         Assert.Equal(ConnectorErrorCodes.RetryAttemptsExhausted, result.Error?.Code);
-        Assert.Equal(4, connector.CallCount);
+        Assert.Equal(3, connector.CallCount);
     }
 
     [Fact]
@@ -168,6 +168,7 @@ public class RetryPolicySendTests
         var result = await connector.SendMessageAsync(CreateTestMessage(), TestContext.Current.CancellationToken);
 
         Assert.False(result.IsSuccess());
+        Assert.Equal("INVALID_CONFIG", result.Error?.Code);
         Assert.Equal(1, connector.CallCount);
     }
 


### PR DESCRIPTION
This pull request introduces comprehensive support for configurable retry policies across connectors, including documentation, sample usage, and integration into all sample projects. The main focus is to allow connectors to automatically retry transient failures (such as rate limits or network errors) with customizable backoff, jitter, and circuit breaker options. Documentation has been expanded to explain configuration, error reporting, and result handling for retries.

**Retry Policy System and Documentation:**

* Added a new section and detailed documentation on retry policies, including configuration options, error codes, circuit breaker behavior, and attempt counting in `docs/retry-policies.md`.
* Updated connector implementation and advanced configuration docs to explain how to provide default retry policies and override them via builder or connection settings. [[1]](diffhunk://#diff-da5f42deecb21d29568cba0f2a7626a55ab7b069c3099160517df9a051c0336eR123) [[2]](diffhunk://#diff-da5f42deecb21d29568cba0f2a7626a55ab7b069c3099160517df9a051c0336eR139-R153) [[3]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938R98) [[4]](diffhunk://#diff-0f0c40de44a0841ed5180f16d66212d1cece2a7d4400789007c2f73bf8432622R184-R199)

**Result Types and Attempt Reporting:**

* Enhanced all result type docs (`SendResult`, `StatusUpdateResult`, `StatusInfo`) to document the inclusion of `RetryAttempts` in `AdditionalData` and provided examples for reading the retry count with `GetRetryAttempts()`. [[1]](diffhunk://#diff-dd93cf0e5ccbcea4f707fc81fd78707bf820514581d50b6bf0d3385f25a932afL94-R101) [[2]](diffhunk://#diff-dd93cf0e5ccbcea4f707fc81fd78707bf820514581d50b6bf0d3385f25a932afL228-R235) [[3]](diffhunk://#diff-dd93cf0e5ccbcea4f707fc81fd78707bf820514581d50b6bf0d3385f25a932afL261-R268)

**Sample Project Integration:**

* Updated all sample projects (`facebook-messenger`, `firebase-push`, `multi-connector`, `sendgrid-email`, `telegram-bot`, `twilio`) to demonstrate usage of the retry policy API, configuring exponential backoff, jitter, and error code matching for retries. [[1]](diffhunk://#diff-4e9367a02ddec3c7ff0ba77db8e030491aa2ea1f6eb78094f69d7ab433282eb5L29-R38) [[2]](diffhunk://#diff-ab9d91d555b780c071a78bc491f436f8cc1901fe3668b0ffb7d168a179024534L29-R38) [[3]](diffhunk://#diff-4f1fb9cfa6433c5868d68bf8ab3f4cf01142d8912be95420b54973368cc8f1cbR23-R39) [[4]](diffhunk://#diff-5da9971e4e3c269fc4c35c728deb533bc84d2f28e966689366a562146f2eb7caL29-R38) [[5]](diffhunk://#diff-415f4128ebdbea5f1232f8e7d592f8f62cc3d9eb630e97edfe9c8f85115379b3L29-R38) [[6]](diffhunk://#diff-f0d148a6ec02b83b48f74555beff3e74118025b3233a7bf56fb08b122f5fddcaR12)

**Sample Documentation:**

* Updated all sample documentation to highlight retry policy usage and the specific error codes each sample is configured to retry on. [[1]](diffhunk://#diff-1bd4c1d0fecdb58ca5c0c55c8f0d74f07edb424a387279ca0a416094bb5ff5a1R11) [[2]](diffhunk://#diff-3fc8d59a6b416d15ce2f18b25d76b8a0802b4a9a1544b6b4fa95ad57765d9be8R12) [[3]](diffhunk://#diff-6c4208c15ea2a163919b4c2c101dbcc6f5c8fc100f08cef91c9798a0e397b93cR12) [[4]](diffhunk://#diff-ac4cc2e70b4e45c5bae748c87caab750eca9f7cda1b0fbb8d8ab3070d6cf426cR11) [[5]](diffhunk://#diff-1e73e1ad4c5c31e1f0457d2f3518edd0cdce64f2b046def4519064c5c3e895d8R10) [[6]](diffhunk://#diff-f0d148a6ec02b83b48f74555beff3e74118025b3233a7bf56fb08b122f5fddcaR12)

These changes make retry handling more robust, visible, and configurable for all connectors and provide clear guidance for users on how to take advantage of these features.…onential backoff and circuit breaker support