### PR TITLE
Add OpenTelemetry support for tracing and metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -419,3 +419,6 @@ FodyWeavers.xsd
 
 .idea
 samples/**/src/**/appsettings.local.json
+
+# macOS
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Those are application-level concerns, so you can choose your own architecture.
 | `Ratatosk.Senders` | Sender identity infrastructure: `ISenderRepository<TSender>`, `ISenderResolver`, cache, per-connector configuration, `MessageBuilder.FromSender()` extension. | [![NuGet](https://img.shields.io/nuget/v/Ratatosk.Senders.svg?label=NuGet)](https://www.nuget.org/packages/Ratatosk.Senders/) |
 | `Ratatosk.Senders.InMemory` | In-memory `IRepository<Sender>` for development and testing. | [![NuGet](https://img.shields.io/nuget/v/Ratatosk.Senders.InMemory.svg?label=NuGet)](https://www.nuget.org/packages/Ratatosk.Senders.InMemory/) |
 | `Ratatosk.Senders.EntityFramework` | EF Core persistence for the sender identity registry (`SenderDbContext`, `EntitySenderRepository`, `DbSender`). | [![NuGet](https://img.shields.io/nuget/v/Ratatosk.Senders.EntityFramework.svg?label=NuGet)](https://www.nuget.org/packages/Ratatosk.Senders.EntityFramework/) |
+| `Ratatosk.Extensions.OpenTelemetry` | Convenience extensions for wiring Ratatosk telemetry sources into OpenTelemetry SDK. | [![NuGet](https://img.shields.io/nuget/v/Ratatosk.Extensions.OpenTelemetry.svg?label=NuGet)](https://www.nuget.org/packages/Ratatosk.Extensions.OpenTelemetry/) |
 
 ## Quick example
 
@@ -144,7 +145,7 @@ Locks the public API and ships stable package releases with production-ready gua
 Adds retry/circuit-breaker policies, OpenTelemetry signals, health checks, and timeout controls.
 
 - [x] **Retry policies** — Polly-based retry and circuit-breaker integrated at the connector base level.
-- [ ] **OpenTelemetry tracing & metrics** — ActivitySources, Meters, and histograms per connector.
+- [x] **OpenTelemetry tracing & metrics** — ActivitySources, Meters, and histograms per connector.
 - [ ] **Health checks** — ASP.NET Core `IHealthCheck` implementations auto-registered per connector.
 - [ ] **Connector-level timeout configuration** — Per-operation timeout via the DI registration API.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,9 +2,9 @@
 
 This document describes the planned evolution of the **Ratatosk Framework** — a .NET library that provides a unified, provider-agnostic model for sending and receiving messages across multiple channels and connectors. Each milestone below includes a summary of its intent, detailed descriptions of every planned feature, and the rationale behind each decision.
 
-> **Current stable release:** `v0.4.0`  
+> **Current stable release:** `v1.0.1`  
 > Connectors available: Facebook Messenger, Firebase Push, SendGrid Email, Telegram Bot, Twilio SMS/WhatsApp  
-> Framework includes: `IMessagingClient` facade, `MessageBuilder`, auto-initialization, `ChannelSchema` derivation, expanded validation
+> Framework includes: `IMessagingClient` facade, `MessageBuilder`, auto-initialization, `ChannelSchema` derivation, expanded validation, retry policies, OpenTelemetry tracing & metrics
 
 ---
 
@@ -15,7 +15,7 @@ This document describes the planned evolution of the **Ratatosk Framework** — 
 | [Framework Foundations](#v040--framework-foundations) | v0.4.0 | [Test Coverage Target](#test-coverage-target--80) · [CI/CD Pipeline Hardening](#cicd-pipeline-hardening) · [Structured Logging Improvements](#structured-logging-improvements) · [Documentation](#documentation) |
 | [Inbound Messaging](#v050--inbound-messaging) | v0.5.0 | [Twilio Inbound Messages](#twilio-inbound-messages-sms--whatsapp) · [SendGrid Inbound Messages](#sendgrid-inbound-messages-inbound-parse) · [Firebase Inbound Messages](#firebase-inbound-messages-data--notification-messages) |
 | [First Stable Release](#v100--first-stable-release) | v1.0.0 | [API Freeze](#api-freeze) · [NuGet GA Release](#nuget-ga-release) · [Interactive Content](#interactive-content) · [Sender Identity Model](#sender-identity-model) |
-| [Resilience & Observability](#v110--resilience--observability) | v1.1.0 | [Retry Policies](#retry-policies) · [OpenTelemetry Tracing & Metrics](#opentelemetry-tracing--metrics) · [Health Checks](#health-checks) · [Connector-Level Timeout Configuration](#connector-level-timeout-configuration) |
+| [Resilience & Observability](#v110--resilience--observability) | v1.1.0 | [Retry Policies](#retry-policies) ✓ · [OpenTelemetry Tracing & Metrics](#opentelemetry-tracing--metrics) ✓ · [Health Checks](#health-checks) · [Connector-Level Timeout Configuration](#connector-level-timeout-configuration) |
 | [New SaaS Connectors](#v120--new-saas-connectors) | v1.2.0 | [Slack](#slack-connector) · [Microsoft Teams](#microsoft-teams-connector) · [WhatsApp Business API](#whatsapp-business-api-connector-direct-cloud-api) · [Viber Business](#viber-business-connector) · [LINE](#line-connector) |
 | [Protocol Connectors](#v130--protocol-connectors) | v1.3.0 | [Base Classes](#protocol-connector-base-classes) · [SMPP](#smpp-connector) · [SMTP](#smtp-connector) · [RCS](#rcs-connector) · [APNs](#apns-connector-direct) |
 | [Content Adaptation & Transcoding](#v140--content-adaptation--transcoding) | v1.4.0 | [IContentTranscoder Abstraction](#icontenttrancoder-abstraction) · [Built-In Transcoders](#built-in-transcoders) · [Channel-Aware Fallback](#channel-aware-content-fallback) · [SMS Segmentation](#sms-segmentation) · [Character Encoding Detection](#character-encoding-detection) |
@@ -272,6 +272,8 @@ A generic sender identity system that decouples message composition from sender 
 
 A messaging connector that fails silently, cannot be monitored, or brings down dependent services on provider outages is not production-ready. This milestone adds the operational layer that connectors need to be trusted in production: structured retry and circuit-breaker policies, distributed tracing and metrics via OpenTelemetry, health check endpoints, and consistent structured logging across all connectors.
 
+Retry policies and OpenTelemetry tracing & metrics are complete in this release. Health checks and timeout configuration remain in progress.
+
 ---
 
 ### Retry Policies
@@ -294,23 +296,24 @@ Polly-based retry and circuit-breaker policies integrated at the connector base 
 
 ---
 
-### OpenTelemetry Tracing & Metrics
+### OpenTelemetry Tracing & Metrics ✓
 
 > *"You cannot improve what you cannot observe."*
 
-#### The Problem Today
+#### The Problem (Before)
 
-There is no built-in telemetry in the connector layer. Developers who want to trace message send latency, track delivery rates, or count failures must instrument their own wrapper code on top of the connectors.
+There was no built-in telemetry in the connector layer. Developers who wanted to trace message send latency, track delivery rates, or count failures had to instrument their own wrapper code on top of the connectors.
 
-#### What We Are Building
+#### What We Built
 
-Activity sources and metric instruments built into the connector base: an `ActivitySource` per connector for distributed tracing (spans for send, receive, status query), and `Meter` instruments for counters (messages sent, received, failed) and histograms (send latency, payload size). All telemetry follows OpenTelemetry semantic conventions and is automatically exported via the application's configured OTLP pipeline.
+Activity sources and metric instruments built into the connector base: an `ActivitySource` per connector for distributed tracing (spans for send, receive, status query), and `Meter` instruments for counters (messages sent, received, failed) and histograms (send latency, payload size). All telemetry follows OpenTelemetry semantic conventions and is automatically exported via the application's configured OTLP pipeline. A dedicated `Ratatosk.Extensions.OpenTelemetry` package provides convenience extensions (`WithOpenTelemetry()` on `MessagingBuilder`, `AddRatatoskInstrumentation()` on `TracerProviderBuilder`/`MeterProviderBuilder`). Telemetry options (`EnableTracing`, `EnableMetrics`, `EnablePayloadSizeMetrics`) are configurable per connector through connection settings or the builder API, following the same pattern as retry policies.
 
 #### Benefits
 
 - End-to-end distributed traces include connector-level spans out of the box
 - Dashboards and alerts can be built on connector metrics without custom instrumentation
 - Fully compatible with any OpenTelemetry-compliant backend (Jaeger, Prometheus, Azure Monitor, etc.)
+- Payload size metrics are opt-in (disabled by default) to avoid serialisation overhead in high-throughput scenarios
 
 ---
 

--- a/Ratatosk.sln
+++ b/Ratatosk.sln
@@ -63,6 +63,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ratatosk.Senders.InMemory.X
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ratatosk.Senders.EntityFramework.XUnit", "test\Ratatosk.Senders.EntityFramework.XUnit\Ratatosk.Senders.EntityFramework.XUnit.csproj", "{15A47650-BE84-4ECC-86DD-245F7C0BA865}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ratatosk.Extensions.OpenTelemetry", "src\Ratatosk.Extensions.OpenTelemetry\Ratatosk.Extensions.OpenTelemetry.csproj", "{A5930328-ADBF-46E1-80D5-C14501FC93DD}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ratatosk.Extensions.OpenTelemetry.XUnit", "test\Ratatosk.Extensions.OpenTelemetry.XUnit\Ratatosk.Extensions.OpenTelemetry.XUnit.csproj", "{8AAD9B57-AE90-4916-B0A2-182C0DC1202F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -373,6 +377,30 @@ Global
 		{15A47650-BE84-4ECC-86DD-245F7C0BA865}.Release|x64.Build.0 = Release|Any CPU
 		{15A47650-BE84-4ECC-86DD-245F7C0BA865}.Release|x86.ActiveCfg = Release|Any CPU
 		{15A47650-BE84-4ECC-86DD-245F7C0BA865}.Release|x86.Build.0 = Release|Any CPU
+		{A5930328-ADBF-46E1-80D5-C14501FC93DD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A5930328-ADBF-46E1-80D5-C14501FC93DD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A5930328-ADBF-46E1-80D5-C14501FC93DD}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A5930328-ADBF-46E1-80D5-C14501FC93DD}.Debug|x64.Build.0 = Debug|Any CPU
+		{A5930328-ADBF-46E1-80D5-C14501FC93DD}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A5930328-ADBF-46E1-80D5-C14501FC93DD}.Debug|x86.Build.0 = Debug|Any CPU
+		{A5930328-ADBF-46E1-80D5-C14501FC93DD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A5930328-ADBF-46E1-80D5-C14501FC93DD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A5930328-ADBF-46E1-80D5-C14501FC93DD}.Release|x64.ActiveCfg = Release|Any CPU
+		{A5930328-ADBF-46E1-80D5-C14501FC93DD}.Release|x64.Build.0 = Release|Any CPU
+		{A5930328-ADBF-46E1-80D5-C14501FC93DD}.Release|x86.ActiveCfg = Release|Any CPU
+		{A5930328-ADBF-46E1-80D5-C14501FC93DD}.Release|x86.Build.0 = Release|Any CPU
+		{8AAD9B57-AE90-4916-B0A2-182C0DC1202F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8AAD9B57-AE90-4916-B0A2-182C0DC1202F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8AAD9B57-AE90-4916-B0A2-182C0DC1202F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8AAD9B57-AE90-4916-B0A2-182C0DC1202F}.Debug|x64.Build.0 = Debug|Any CPU
+		{8AAD9B57-AE90-4916-B0A2-182C0DC1202F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8AAD9B57-AE90-4916-B0A2-182C0DC1202F}.Debug|x86.Build.0 = Debug|Any CPU
+		{8AAD9B57-AE90-4916-B0A2-182C0DC1202F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8AAD9B57-AE90-4916-B0A2-182C0DC1202F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8AAD9B57-AE90-4916-B0A2-182C0DC1202F}.Release|x64.ActiveCfg = Release|Any CPU
+		{8AAD9B57-AE90-4916-B0A2-182C0DC1202F}.Release|x64.Build.0 = Release|Any CPU
+		{8AAD9B57-AE90-4916-B0A2-182C0DC1202F}.Release|x86.ActiveCfg = Release|Any CPU
+		{8AAD9B57-AE90-4916-B0A2-182C0DC1202F}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -403,6 +431,8 @@ Global
 		{BB959F65-44CD-4444-8607-108AE75AE7EA} = {0F91077D-AC47-4319-96FF-09CA6EE50CC6}
 		{D1A54750-C8F4-4B48-A7E2-0CDAF0F6DD29} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{15A47650-BE84-4ECC-86DD-245F7C0BA865} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{A5930328-ADBF-46E1-80D5-C14501FC93DD} = {0F91077D-AC47-4319-96FF-09CA6EE50CC6}
+		{8AAD9B57-AE90-4916-B0A2-182C0DC1202F} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {64BF9420-C7A8-4D2B-804F-41EB2E83437F}

--- a/docs/README.md
+++ b/docs/README.md
@@ -70,6 +70,7 @@ The framework is deliberately focused on the messaging contract and connector co
 | `Ratatosk.Senders` | Sender identity infrastructure: `ISenderRepository<TSender>`, `ISenderResolver`, cache, per-connector configuration, and `MessageBuilder.FromSender()` extension. | [![NuGet](https://img.shields.io/nuget/v/Ratatosk.Senders)](https://nuget.org/packages/Ratatosk.Senders) |
 | `Ratatosk.Senders.InMemory` | In-memory sender repository for development and testing, with optional seed data. | [![NuGet](https://img.shields.io/nuget/v/Ratatosk.Senders.InMemory)](https://nuget.org/packages/Ratatosk.Senders.InMemory) |
 | `Ratatosk.Senders.EntityFramework` | EF Core persistence for the sender identity registry (`SenderDbContext`, `EntitySenderRepository`, `DbSender`). | [![NuGet](https://img.shields.io/nuget/v/Ratatosk.Senders.EntityFramework)](https://nuget.org/packages/Ratatosk.Senders.EntityFramework) |
+| `Ratatosk.Extensions.OpenTelemetry` | Convenience extensions for wiring Ratatosk telemetry sources into OpenTelemetry SDK (`WithOpenTelemetry()` on `MessagingBuilder`, `AddRatatoskInstrumentation()` on `TracerProviderBuilder`/`MeterProviderBuilder`). | [![NuGet](https://img.shields.io/nuget/v/Ratatosk.Extensions.OpenTelemetry)](https://nuget.org/packages/Ratatosk.Extensions.OpenTelemetry) |
 
 ## Reading path
 
@@ -96,6 +97,7 @@ The framework is deliberately focused on the messaging contract and connector co
 - [Authentication](authentication.md) — auth providers, credential management, OAuth flows
 - [Result types](result-types.md) — `OperationResult<T>`, send results, health data
 - [Retry policies](retry-policies.md) — automatic retry with backoff, jitter, and circuit breaker
+- [Telemetry](telemetry.md) — OpenTelemetry tracing and metrics, wiring, configuration
 - [Advanced configuration](advanced.md) — security, named connector isolation, health checks, testing
 
 **Connector guides:**

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -145,41 +145,11 @@ Logger.LogInformation("Sending to {Receiver}", message.Receiver?.Address);
 // [Connector: Twilio/SMS] [Message: sms-123] Sending to +15550002222
 ```
 
-### Metrics to track
+### OpenTelemetry tracing & metrics
 
-For production monitoring, track per-connector metrics:
+Ratatosk emits `ActivitySource` and `Meter` instruments from every connector operation — spans for send, receive, status query, and initialization; counters for messages sent, received, and failed; histograms for latency and payload size. The `IMessagingClient` facade emits its own telemetry under `Ratatosk.Client`.
 
-| Metric | Source | What it detects |
-|---|---|---|
-| Send attempts | Count before `SendMessageAsync` call | Volume trends |
-| Send success rate | `OperationResult.IsSuccess()` | Provider degradation |
-| Send latency | Stopwatch around `SendMessageAsync` | Provider performance |
-| Error codes | `OperationResult.Error.Code` | Failure type distribution |
-| Connection state | `Connector.State` | Connectivity issues |
-
-```csharp
-public class MetricsDecorator : IChannelConnector
-{
-    private readonly IChannelConnector _inner;
-    private readonly IMeterFactory _meters;
-
-    public async Task<OperationResult<SendResult>> SendMessageAsync(
-        IMessage message, CancellationToken ct)
-    {
-        var sw = Stopwatch.StartNew();
-        var result = await _inner.SendMessageAsync(message, ct);
-        sw.Stop();
-
-        _meters.CreateCounter("messaging.sends").Add(1);
-        _meters.CreateHistogram("messaging.latency").Record(sw.ElapsedMilliseconds);
-
-        if (result.IsFailure())
-            _meters.CreateCounter($"messaging.errors.{result.Error?.Code}").Add(1);
-
-        return result;
-    }
-}
-```
+See [Telemetry](telemetry.md) for the full signal reference, wiring instructions, configuration options, and performance considerations.
 
 ## Retry policies
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -29,6 +29,9 @@ dotnet add package Ratatosk.Abstractions
 # Custom connector authoring — needed only if you build your own connector
 dotnet add package Ratatosk.Connector.Abstractions
 dotnet add package Ratatosk.Connectors
+
+# OpenTelemetry — convenience extensions for wiring Ratatosk telemetry sources
+dotnet add package Ratatosk.Extensions.OpenTelemetry
 ```
 
 `Ratatosk` depends on `Ratatosk.Abstractions` and `Ratatosk.Connectors` (which bring in `Microsoft.Extensions.DependencyInjection.Abstractions` and `Microsoft.Extensions.Logging.Abstractions`). The `Abstractions` and `Connector.Abstractions` packages have no external dependencies beyond the .NET BCL.

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,0 +1,226 @@
+# Telemetry (Tracing & Metrics)
+
+Ratatosk emits OpenTelemetry-compatible tracing and metrics from every connector operation. Each connector has its own `ActivitySource` and `Meter` — traces and metrics are available out of the box without any manual instrumentation.
+
+## Signals emitted
+
+### Tracing (Activity)
+
+| Operation | Span name | ActivitySource |
+|---|---|---|
+| `SendMessageAsync` | `{connector} send` | `Ratatosk.Connector.{type}` |
+| `ReceiveMessagesAsync` | `{connector} receive` | `Ratatosk.Connector.{type}` |
+| `SendBatchAsync` | `{connector} batch_send` | `Ratatosk.Connector.{type}` |
+| `InitializeAsync` | `{connector} initialize` | `Ratatosk.Connector.{type}` |
+| `GetStatusAsync` | `{connector} status_query` | `Ratatosk.Connector.{type}` |
+| `GetMessageStatusAsync` | `{connector} status_query` | `Ratatosk.Connector.{type}` |
+| `ReceiveMessageStatusAsync` | `{connector} receive_status` | `Ratatosk.Connector.{type}` |
+| `GetHealthAsync` | `{connector} health_check` | `Ratatosk.Connector.{type}` |
+
+Each span carries semantic convention attributes:
+
+| Attribute | Example value |
+|---|---|
+| `messaging.system` | `ratatosk` |
+| `messaging.operation` | `send`, `receive`, `status_query` |
+| `messaging.destination` | Channel name |
+| `messaging.message.id` | Message ID |
+| `ratatosk.connector.type` | `twilio_sms` |
+| `ratatosk.connector.name` | Connector instance name |
+| `error.type` | Error code (on failure) |
+
+### Metrics (Meter)
+
+Each connector exposes a `Meter` named `Ratatosk.Connector.{type}` with the following instruments:
+
+| Metric name | Type | Unit | Description |
+|---|---|---|---|
+| `ratatosk.messages.sent` | Counter | `{message}` | Total messages sent |
+| `ratatosk.messages.send_failed` | Counter | `{message}` | Messages that failed to send |
+| `ratatosk.messages.received` | Counter | `{message}` | Total messages received |
+| `ratatosk.messages.receive_failed` | Counter | `{message}` | Messages that failed to receive |
+| `ratatosk.messages.send.duration` | Histogram | `ms` | Send operation latency |
+| `ratatosk.messages.receive.duration` | Histogram | `ms` | Receive operation latency |
+| `ratatosk.messages.send.payload_size` | Histogram | `By` | Payload size in bytes |
+| `ratatosk.connector.state_changes` | Counter | `{change}` | Connector state transitions |
+
+The `IMessagingClient` facade also emits its own telemetry under `Ratatosk.Client`:
+
+| Metric name | Type | Unit |
+|---|---|---|
+| `ratatosk.client.messages.sent` | Counter | `{message}` |
+| `ratatosk.client.messages.send_failed` | Counter | `{message}` |
+| `ratatosk.client.messages.send.duration` | Histogram | `ms` |
+
+## Wiring with OpenTelemetry SDK
+
+Add the `Ratatosk.Extensions.OpenTelemetry` package to register all sources:
+
+```bash
+dotnet add package Ratatosk.Extensions.OpenTelemetry
+```
+
+### Option 1 — Automatic (recommended)
+
+```csharp
+using Ratatosk;
+
+builder.Services
+    .AddMessaging()
+    .AddTwilioSmsConnector(options => { /* ... */ })
+    .WithOpenTelemetry();
+```
+
+`.WithOpenTelemetry()` internally calls `AddOpenTelemetry().WithTracing().WithMetrics()`, registers both the connector (`Ratatosk.Connector.*`) and client (`Ratatosk.Client`) sources, and manages the `TracerProvider`/`MeterProvider` lifecycle through the host.
+
+### Option 2 — Manual on TracerProviderBuilder / MeterProviderBuilder
+
+When you already have an OpenTelemetry setup and want to add Ratatosk sources:
+
+```csharp
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+using Ratatosk;
+
+builder.Services.AddOpenTelemetry()
+    .WithTracing(t => t
+        .AddRatatoskInstrumentation()
+        .AddConsoleExporter()   // or any exporter
+    )
+    .WithMetrics(m => m
+        .AddRatatoskInstrumentation()
+        .AddConsoleExporter()
+    );
+```
+
+`AddRatatoskInstrumentation()` adds:
+- `Ratatosk.Client` — client-level ActivitySource and Meter
+- `Ratatosk.Connector.*` — all connector ActivitySources and Meters (wildcard matching, new connectors are picked up automatically)
+
+## Configuration
+
+Telemetry can be configured per connector without modifying its provider-specific options.
+
+### Via the connector builder
+
+```csharp
+services.AddMessaging()
+    .AddConnector<TwilioSmsConnector>("sms", cfg => cfg
+        .WithSettings("Twilio")
+        .WithTelemetry(t =>
+        {
+            t.EnableTracing = true;
+            t.EnableMetrics = true;
+            t.EnablePayloadSizeMetrics = false;   // off by default
+        }));
+```
+
+### Via ConnectionSettings
+
+```csharp
+var settings = new ConnectionSettings()
+    .SetParameter("Telemetry.EnableTracing", false)
+    .SetParameter("Telemetry.EnablePayloadSizeMetrics", true);
+
+var connector = new TwilioSmsConnector(schema, settings);
+```
+
+### TelemetryOptions reference
+
+| Property | Default | Description |
+|---|---|---|
+| `EnableTracing` | `true` | Emit Activity spans for connector operations |
+| `EnableMetrics` | `true` | Record metric counters and histograms |
+| `EnablePayloadSizeMetrics` | `false` | Serialize message to measure payload size (may impact throughput) |
+
+### Client-level telemetry
+
+The `IMessagingClient` facade reads its telemetry configuration from `MessagingClientOptions`:
+
+```csharp
+services.AddMessaging()
+    .AddClient(options =>
+    {
+        options.Telemetry.EnableTracing = true;
+        options.Telemetry.EnableMetrics = true;
+    });
+```
+
+### ConnectionSettings keys
+
+All telemetry settings keys are available as constants in `TelemetrySettingsKeys`:
+
+| Key | Constant | Expected value |
+|---|---|---|
+| `Telemetry.EnableTracing` | `.EnableTracing` | `bool` |
+| `Telemetry.EnableMetrics` | `.EnableMetrics` | `bool` |
+| `Telemetry.EnablePayloadSizeMetrics` | `.EnablePayloadSizeMetrics` | `bool` |
+
+## Performance considerations
+
+- **Payload size metrics** require serialising the message to JSON to measure byte count — this adds CPU and memory overhead per send. Disabled by default.
+- When telemetry is fully enabled, the overhead is limited to creating `Activity` objects and recording metric observations, both designed for high-throughput scenarios.
+- Each connector has its own `ActivitySource` and `Meter` — if no OpenTelemetry SDK is configured (no listeners attached), `HasListeners()` returns `false` and the activity creation is skipped entirely with negligible cost.
+
+## Viewing telemetry
+
+Once wired, traces and metrics flow to any OpenTelemetry-compatible backend:
+
+```bash
+# Console output during development
+dotnet add package OpenTelemetry.Exporter.Console
+
+builder.Services.AddOpenTelemetry()
+    .WithTracing(t => t
+        .AddRatatoskInstrumentation()
+        .AddConsoleExporter())
+    .WithMetrics(m => m
+        .AddRatatoskInstrumentation()
+        .AddConsoleExporter());
+```
+
+For production, configure an OTLP exporter:
+
+```bash
+dotnet add package OpenTelemetry.Exporter.OpenTelemetryProtocol
+```
+
+```csharp
+builder.Services.AddOpenTelemetry()
+    .WithTracing(t => t
+        .AddRatatoskInstrumentation()
+        .AddOtlpExporter())
+    .WithMetrics(m => m
+        .AddRatatoskInstrumentation()
+        .AddOtlpExporter());
+```
+
+## Example: tracing a send operation
+
+```
+Service A                          Twilio Connector
+  │                                     │
+  │ SendAsync(channel, message)          │
+  │─────────────────────────────────▶    │
+  │          Span: "twilio_sms send"     │
+  │          tags:                       │
+  │            messaging.system=ratatosk │
+  │            messaging.operation=send  │
+  │            messaging.message.id=...  │
+  │            ratatosk.connector.type=  │
+  │              twilio_sms              │
+  │                                     │
+  │         SendMessageCoreAsync()       │
+  │         ─────────────────────────▶   │
+  │         ◀────────────────────────    │
+  │                                     │
+  │          counter: sent +1           │
+  │          histogram: send.duration   │
+  │                                     │
+  │◀─────────────────────────────────   │
+```
+
+## See also
+
+- [Retry policies](retry-policies.md) — configure automatic retry and circuit breaker
+- [Advanced configuration](advanced.md) — health checks, performance, testing

--- a/src/Ratatosk.Connector.Abstractions/TelemetryOptions.cs
+++ b/src/Ratatosk.Connector.Abstractions/TelemetryOptions.cs
@@ -1,0 +1,25 @@
+namespace Ratatosk
+{
+    /// <summary>
+    /// Configures which telemetry signals are emitted by a connector or client.
+    /// </summary>
+    public class TelemetryOptions
+    {
+        /// <summary>
+        /// Gets or sets whether tracing (Activity) is enabled.
+        /// </summary>
+        public bool EnableTracing { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets whether metrics are enabled.
+        /// </summary>
+        public bool EnableMetrics { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets whether payload size metrics are collected.
+        /// Requires serializing the message to measure its size,
+        /// which may impact performance in high-throughput scenarios.
+        /// </summary>
+        public bool EnablePayloadSizeMetrics { get; set; } = false;
+    }
+}

--- a/src/Ratatosk.Connector.Abstractions/TelemetrySettingsKeys.cs
+++ b/src/Ratatosk.Connector.Abstractions/TelemetrySettingsKeys.cs
@@ -1,0 +1,9 @@
+namespace Ratatosk
+{
+    public static class TelemetrySettingsKeys
+    {
+        public const string EnableTracing = "Telemetry.EnableTracing";
+        public const string EnableMetrics = "Telemetry.EnableMetrics";
+        public const string EnablePayloadSizeMetrics = "Telemetry.EnablePayloadSizeMetrics";
+    }
+}

--- a/src/Ratatosk.Connectors/ChannelConnectorBase.cs
+++ b/src/Ratatosk.Connectors/ChannelConnectorBase.cs
@@ -634,7 +634,7 @@ namespace Ratatosk
             using var scope = BeginConnectorLoggerScope();
             using var messageScope = BeginMessageLoggerScope(message);
 
-            var activity = _telemetry.StartSendActivity(
+            using var activity = _telemetry.StartSendActivity(
                 Schema.ChannelType, message.Id);
             var sw = Stopwatch.StartNew();
 
@@ -849,7 +849,7 @@ namespace Ratatosk
                 var result = await SendBatchCoreAsync(batch, cancellationToken);
 
                 sw.Stop();
-                _telemetry.RecordSendSuccess(sw.ElapsedMilliseconds, batch.Messages.Count());
+                _telemetry.RecordSendSuccess(sw.ElapsedMilliseconds, messageCount: batch.Messages.Count());
                 activity?.SetStatus(ActivityStatusCode.Ok);
 
                 Logger.LogBatchSent(batch.Messages.Count());

--- a/src/Ratatosk.Connectors/ChannelConnectorBase.cs
+++ b/src/Ratatosk.Connectors/ChannelConnectorBase.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Polly;
 
 using System.ComponentModel.DataAnnotations;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
 namespace Ratatosk
@@ -28,6 +29,7 @@ namespace Ratatosk
         private readonly RetryPolicyOptions? _retryPolicy;
         private RetryPolicyOptions? _effectiveRetryPolicy;
         private readonly Lazy<ResiliencePipeline<SendResult>?> _sendPipeline;
+        private readonly ConnectorTelemetry _telemetry;
 
         /// <summary>
         /// Constructs the connector base with the given schema and optional settings.
@@ -54,6 +56,9 @@ namespace Ratatosk
                 _effectiveRetryPolicy = options;
                 return ResiliencePipelineFactory.BuildPipeline<SendResult>(options);
             });
+
+            var telemetryOptions = ReadTelemetryFromSettings();
+            _telemetry = new ConnectorTelemetry(Schema.ChannelType, ConnectorName, telemetryOptions);
         }
 
         /// <summary>
@@ -189,6 +194,22 @@ namespace Ratatosk
 
         protected virtual RetryPolicyOptions? GetDefaultRetryPolicy() => null;
 
+        private TelemetryOptions ReadTelemetryFromSettings()
+        {
+            var options = new TelemetryOptions();
+
+            if (ConnectionSettings.Parameters.TryGetValue(TelemetrySettingsKeys.EnableTracing, out var tracingRaw))
+                options.EnableTracing = Convert.ToBoolean(tracingRaw);
+
+            if (ConnectionSettings.Parameters.TryGetValue(TelemetrySettingsKeys.EnableMetrics, out var metricsRaw))
+                options.EnableMetrics = Convert.ToBoolean(metricsRaw);
+
+            if (ConnectionSettings.Parameters.TryGetValue(TelemetrySettingsKeys.EnablePayloadSizeMetrics, out var payloadRaw))
+                options.EnablePayloadSizeMetrics = Convert.ToBoolean(payloadRaw);
+
+            return options;
+        }
+
         private ResiliencePipeline<T>? BuildPipeline<T>()
         {
             if (typeof(T) == typeof(SendResult))
@@ -207,7 +228,12 @@ namespace Ratatosk
         /// Transitions the connector to <paramref name="newState"/> in a thread-safe manner.
         /// </summary>
         /// <param name="newState">The new state to set for the connector.</param>
-        protected void SetState(ConnectorState newState) => _stateManager.TransitionTo(newState);
+        protected void SetState(ConnectorState newState)
+        {
+            var oldState = State;
+            _stateManager.TransitionTo(newState);
+            _telemetry.RecordStateChange(oldState.ToString(), newState.ToString());
+        }
 
         /// <summary>
         /// Validates that the connector supports the given capability.
@@ -284,9 +310,11 @@ namespace Ratatosk
         public async ValueTask<OperationResult<bool>> InitializeAsync(CancellationToken cancellationToken)
         {
             using var scope = BeginConnectorLoggerScope();
+            using var activity = _telemetry.StartInitializeActivity();
 
             if (State != ConnectorState.Uninitialized)
             {
+                activity?.SetStatus(ActivityStatusCode.Error, "Already initialized");
                 return OperationResult<bool>.Fail(ConnectorErrorCodes.AlreadyInitialized,
                     MessagingErrorCodes.ErrorDomain,
                     "The connector has already been initialized.");
@@ -317,11 +345,14 @@ namespace Ratatosk
                 Logger.LogConnectorInitialized();
                 SetState(ConnectorState.Ready);
 
+                activity?.SetStatus(ActivityStatusCode.Ok);
+
                 return true;
             }
             catch (MessagingException ex)
             {
                 Logger.LogConnectorInitializationFailed(ex);
+                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
 
                 SetState(ConnectorState.Error);
                 return OperationResult<bool>.Fail(ex.ErrorCode, ex.ErrorDomain, ex.Message);
@@ -329,6 +360,7 @@ namespace Ratatosk
             catch (Exception ex)
             {
                 Logger.LogConnectorInitializationFailed(ex);
+                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
 
                 SetState(ConnectorState.Error);
                 return OperationResult<bool>.Fail(
@@ -602,6 +634,14 @@ namespace Ratatosk
             using var scope = BeginConnectorLoggerScope();
             using var messageScope = BeginMessageLoggerScope(message);
 
+            var activity = _telemetry.StartSendActivity(
+                Schema.ChannelType, message.Id);
+            var sw = Stopwatch.StartNew();
+
+            var payloadSize = _telemetry.IsPayloadSizeEnabled
+                ? (int)_telemetry.MeasurePayloadSize(message)
+                : 0;
+
             try
             {
                 Logger.LogValidatingMessage(message.Id!);
@@ -618,6 +658,9 @@ namespace Ratatosk
                 if (validationErrors.Count > 0)
                 {
                     Logger.LogMessageValidationFailed(message.Id!, validationErrors.Count);
+                    sw.Stop();
+                    _telemetry.RecordSendFailure(sw.ElapsedMilliseconds, "validation_failed");
+                    activity?.SetStatus(ActivityStatusCode.Error, "Validation failed");
 
                     return OperationResult<SendResult>.ValidationFailed(
                         ConnectorErrorCodes.MessageValidationFailed,
@@ -652,6 +695,10 @@ namespace Ratatosk
                     {
                         if (ex.GetType().Name == "BrokenCircuitException")
                         {
+                            sw.Stop();
+                            _telemetry.RecordSendFailure(sw.ElapsedMilliseconds, "circuit_breaker_open");
+                            activity?.SetStatus(ActivityStatusCode.Error, "Circuit breaker open");
+
                             Logger.LogCircuitBreakerOpened("SendMessage", _effectiveRetryPolicy?.CircuitBreakerBreakDuration ?? TimeSpan.FromSeconds(30));
                             return OperationResult<SendResult>.Fail(
                                 ConnectorErrorCodes.CircuitBreakerOpen,
@@ -669,6 +716,10 @@ namespace Ratatosk
                             }
                         }
 
+                        sw.Stop();
+                        _telemetry.RecordSendFailure(sw.ElapsedMilliseconds, "retry_exhausted");
+                        activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+
                         Logger.LogRetryExhausted(_effectiveRetryPolicy?.MaxRetryAttempts ?? 3, "SendMessage", ex.Message);
                         return OperationResult<SendResult>.Fail(
                             ConnectorErrorCodes.RetryAttemptsExhausted,
@@ -680,11 +731,19 @@ namespace Ratatosk
                 {
                     result = await SendMessageCoreAsync(message, cancellationToken);
 
+                    sw.Stop();
+                    _telemetry.RecordSendSuccess(sw.ElapsedMilliseconds, payloadSize);
+                    activity?.SetStatus(ActivityStatusCode.Ok);
+
                     result.AdditionalData[ResultMetadataKeys.RetryAttempts] = 1;
                     Logger.LogMessageSent(result.RemoteMessageId);
 
                     return OperationResult<SendResult>.Success(result);
                 }
+
+                sw.Stop();
+                _telemetry.RecordSendSuccess(sw.ElapsedMilliseconds, payloadSize);
+                activity?.SetStatus(ActivityStatusCode.Ok);
 
                 result.AdditionalData[ResultMetadataKeys.RetryAttempts] = attempts;
                 Logger.LogMessageSent(result.RemoteMessageId);
@@ -693,11 +752,19 @@ namespace Ratatosk
             }
             catch (MessagingException ex)
             {
+                sw.Stop();
+                _telemetry.RecordSendFailure(sw.ElapsedMilliseconds, ex.ErrorCode);
+                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+
                 Logger.LogMessageSendFailed(message.Id!, ex);
                 return OperationResult<SendResult>.Fail(ex.ErrorCode, ex.ErrorDomain, ex.Message);
             }
             catch (Exception ex)
             {
+                sw.Stop();
+                _telemetry.RecordSendFailure(sw.ElapsedMilliseconds, "unknown");
+                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+
                 Logger.LogMessageSendFailed(message.Id!, ex);
                 return OperationResult<SendResult>.Fail(ConnectorErrorCodes.SendMessageError, MessagingErrorCodes.ErrorDomain, ex.Message);
             }
@@ -734,6 +801,11 @@ namespace Ratatosk
             _idGenerator.EnsureBatchId(batch);
 
             using var scope = BeginConnectorLoggerScope();
+            using var activity = _telemetry.StartActivity(
+                MessagingSemanticConventions.OperationBatchSend,
+                Schema.ChannelType);
+
+            var sw = Stopwatch.StartNew();
 
             try
             {
@@ -762,6 +834,8 @@ namespace Ratatosk
 
                 if (allValidationErrors.Count > 0)
                 {
+                    sw.Stop();
+                    activity?.SetStatus(ActivityStatusCode.Error, "Batch validation failed");
                     Logger.LogBatchValidationFailed(batch.Messages.Count());
 
                     return OperationResult<BatchSendResult>.ValidationFailed(
@@ -774,17 +848,27 @@ namespace Ratatosk
 
                 var result = await SendBatchCoreAsync(batch, cancellationToken);
 
+                sw.Stop();
+                _telemetry.RecordSendSuccess(sw.ElapsedMilliseconds, batch.Messages.Count());
+                activity?.SetStatus(ActivityStatusCode.Ok);
+
                 Logger.LogBatchSent(batch.Messages.Count());
 
                 return result;
             }
             catch (MessagingException ex)
             {
+                sw.Stop();
+                _telemetry.RecordSendFailure(sw.ElapsedMilliseconds, ex.ErrorCode);
+                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
                 Logger.LogBatchSendFailed(batch.Messages.Count(), ex);
                 return OperationResult<BatchSendResult>.Fail(ex.ErrorCode, ex.ErrorDomain, ex.Message);
             }
             catch (Exception ex)
             {
+                sw.Stop();
+                _telemetry.RecordSendFailure(sw.ElapsedMilliseconds, "unknown");
+                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
                 Logger.LogBatchSendFailed(batch.Messages.Count(), ex);
                 return OperationResult<BatchSendResult>.Fail(ConnectorErrorCodes.SendBatchError, MessagingErrorCodes.ErrorDomain, ex.Message);
             }
@@ -817,6 +901,7 @@ namespace Ratatosk
         public async ValueTask<OperationResult<StatusInfo>> GetStatusAsync(CancellationToken cancellationToken)
         {
             using var scope = BeginConnectorLoggerScope();
+            using var activity = _telemetry.StartStatusQueryActivity();
 
             try
             {
@@ -824,17 +909,21 @@ namespace Ratatosk
 
                 var result = await GetConnectorStatusAsync(cancellationToken);
 
+                activity?.SetStatus(ActivityStatusCode.Ok);
+
                 Logger.LogStatusRead();
 
                 return result;
             }
             catch (MessagingException ex)
             {
+                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
                 Logger.LogStatusReadFailed(ex);
                 return OperationResult<StatusInfo>.Fail(ex.ErrorCode, ex.ErrorDomain, ex.Message);
             }
             catch (Exception ex)
             {
+                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
                 Logger.LogStatusReadFailed(ex);
                 return OperationResult<StatusInfo>.Fail(ConnectorErrorCodes.GetStatusError, MessagingErrorCodes.ErrorDomain, ex.Message);
             }
@@ -868,6 +957,7 @@ namespace Ratatosk
             await EnsureInitializedAsync(cancellationToken);
 
             using var scope = BeginConnectorLoggerScope();
+            using var activity = _telemetry.StartStatusQueryActivity(messageId);
 
             try
             {
@@ -875,17 +965,21 @@ namespace Ratatosk
 
                 var result = await GetMessageStatusCoreAsync(messageId, cancellationToken);
 
+                activity?.SetStatus(ActivityStatusCode.Ok);
+
                 Logger.LogMessageStatusRead(messageId);
 
                 return result;
             }
             catch (MessagingException ex)
             {
+                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
                 Logger.LogMessageStatusReadFailed(messageId, ex);
                 return OperationResult<StatusUpdatesResult>.Fail(ex.ErrorCode, ex.ErrorDomain, ex.Message);
             }
             catch (Exception ex)
             {
+                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
                 Logger.LogMessageStatusReadFailed(messageId, ex);
                 return OperationResult<StatusUpdatesResult>.Fail(ConnectorErrorCodes.GetMessageStatusError, MessagingErrorCodes.ErrorDomain, ex.Message);
             }
@@ -1014,6 +1108,7 @@ namespace Ratatosk
             await EnsureInitializedAsync(cancellationToken);
 
             using var scope = BeginConnectorLoggerScope();
+            using var activity = _telemetry.StartActivity("receive_status", Schema.ChannelType);
 
             try
             {
@@ -1021,17 +1116,21 @@ namespace Ratatosk
 
                 var result = await ReceiveMessageStatusCoreAsync(source, cancellationToken);
 
+                activity?.SetStatus(ActivityStatusCode.Ok);
+
                 Logger.LogMessageStatusReceived(result.MessageId);
 
                 return result;
             }
             catch (MessagingException ex)
             {
+                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
                 Logger.LogMessageStatusReceiveFailed(ex);
                 return OperationResult<StatusUpdateResult>.Fail(ex.ErrorCode, ex.ErrorDomain, ex.Message);
             }
             catch (Exception ex)
             {
+                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
                 Logger.LogMessageStatusReceiveFailed(ex);
                 return OperationResult<StatusUpdateResult>.Fail(ConnectorErrorCodes.ReceiveStatusError, MessagingErrorCodes.ErrorDomain, ex.Message);
             }
@@ -1069,11 +1168,19 @@ namespace Ratatosk
 
             using var scope = BeginConnectorLoggerScope();
 
+            using var activity = _telemetry.StartReceiveActivity(Schema.ChannelType);
+            var sw = Stopwatch.StartNew();
+
             try
             {
                 Logger.LogReceivingMessage();
 
                 var result = await ReceiveMessagesCoreAsync(source, cancellationToken);
+
+                sw.Stop();
+                var messageCount = result?.Messages?.Count ?? 0;
+                _telemetry.RecordReceiveSuccess(sw.ElapsedMilliseconds, messageCount);
+                activity?.SetStatus(ActivityStatusCode.Ok);
 
                 Logger.LogMessageReceived();
 
@@ -1081,11 +1188,19 @@ namespace Ratatosk
             }
             catch (MessagingException ex)
             {
+                sw.Stop();
+                _telemetry.RecordReceiveFailure(sw.ElapsedMilliseconds, ex.ErrorCode);
+                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+
                 Logger.LogMessageReceiveFailed(ex);
                 return OperationResult<ReceiveResult>.Fail(ex.ErrorCode, ex.ErrorDomain, ex.Message);
             }
             catch (Exception ex)
             {
+                sw.Stop();
+                _telemetry.RecordReceiveFailure(sw.ElapsedMilliseconds, "unknown");
+                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+
                 Logger.LogMessageReceiveFailed(ex);
                 return OperationResult<ReceiveResult>.Fail(
                     ConnectorErrorCodes.ReceiveMessagesError,
@@ -1122,6 +1237,9 @@ namespace Ratatosk
             ValidateCapability(ChannelCapability.HealthCheck);
 
             using var scope = BeginConnectorLoggerScope();
+            using var activity = _telemetry.StartActivity(
+                MessagingSemanticConventions.OperationHealthCheck,
+                Schema.ChannelType);
 
             try
             {
@@ -1129,17 +1247,21 @@ namespace Ratatosk
 
                 var result = await GetConnectorHealthAsync(cancellationToken);
 
+                activity?.SetStatus(ActivityStatusCode.Ok);
+
                 Logger.LogHealthCheckSuccessful();
 
                 return result;
             }
             catch (MessagingException ex)
             {
+                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
                 Logger.LogHealthCheckFailed(ex);
                 return OperationResult<ConnectorHealth>.Fail(ex.ErrorCode, ex.ErrorDomain, ex.Message);
             }
             catch (Exception ex)
             {
+                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
                 Logger.LogHealthCheckFailed(ex);
                 return OperationResult<ConnectorHealth>.Fail(ConnectorErrorCodes.GetHealthError, MessagingErrorCodes.ErrorDomain, ex.Message);
             }

--- a/src/Ratatosk.Connectors/ChannelConnectorBase.cs
+++ b/src/Ratatosk.Connectors/ChannelConnectorBase.cs
@@ -1318,6 +1318,7 @@ namespace Ratatosk
             finally
             {
                 SetState(ConnectorState.Shutdown);
+                _telemetry.Dispose();
             }
         }
 

--- a/src/Ratatosk.Connectors/ConnectorMeter.cs
+++ b/src/Ratatosk.Connectors/ConnectorMeter.cs
@@ -1,0 +1,14 @@
+namespace Ratatosk;
+
+/// <summary>
+/// An helper class for creating meter names.
+/// </summary>
+public static class ConnectorMeter
+{
+    /// <summary>
+    /// The base name for all connector meters.
+    /// </summary>
+    public const string Name = "Ratatosk.Connector";
+    
+    internal static string MakeConnectorName(string connectorType) => $"{Name}.{connectorType}";
+}

--- a/src/Ratatosk.Connectors/ConnectorTelemetry.cs
+++ b/src/Ratatosk.Connectors/ConnectorTelemetry.cs
@@ -1,0 +1,224 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using System.Reflection;
+
+namespace Ratatosk
+{
+    internal class ConnectorTelemetry : IDisposable
+    {
+        private readonly ActivitySource _activitySource;
+        private readonly Meter _meter;
+        private readonly TelemetryOptions _options;
+
+        private readonly Counter<int> _messagesSentTotal;
+        private readonly Counter<int> _messagesSentFailed;
+        private readonly Counter<int> _messagesReceivedTotal;
+        private readonly Counter<int> _messagesReceiveFailed;
+        private readonly Histogram<double> _sendDuration;
+        private readonly Histogram<double> _receiveDuration;
+        private readonly Histogram<double> _sendPayloadSize;
+        private readonly Counter<int> _connectorStateChanges;
+
+        private static readonly AssemblyVersionAttribute? _versionAttr =
+            typeof(ConnectorTelemetry).Assembly
+                .GetCustomAttributes(typeof(AssemblyVersionAttribute), false)
+                .Cast<AssemblyVersionAttribute>()
+                .FirstOrDefault();
+
+        private static readonly string _version = _versionAttr?.Version ?? "0.0.0";
+
+        public ConnectorTelemetry(string connectorType, string? connectorInstanceName = null, TelemetryOptions? options = null)
+        {
+            ConnectorType = connectorType ?? throw new ArgumentNullException(nameof(connectorType));
+            ConnectorInstanceName = connectorInstanceName;
+            _options = options ?? new TelemetryOptions();
+
+            var sourceName = $"Ratatosk.Connector.{connectorType}";
+            var meterName = $"Ratatosk.Connector.{connectorType}";
+
+            _activitySource = new ActivitySource(sourceName, _version);
+            _meter = new Meter(meterName, _version);
+
+            _messagesSentTotal = _meter.CreateCounter<int>(
+                MessagingSemanticConventions.MetricMessagesSent,
+                unit: "{message}",
+                description: "Total number of messages sent");
+
+            _messagesSentFailed = _meter.CreateCounter<int>(
+                MessagingSemanticConventions.MetricMessagesSendFailed,
+                unit: "{message}",
+                description: "Total number of messages that failed to send");
+
+            _messagesReceivedTotal = _meter.CreateCounter<int>(
+                MessagingSemanticConventions.MetricMessagesReceived,
+                unit: "{message}",
+                description: "Total number of messages received");
+
+            _messagesReceiveFailed = _meter.CreateCounter<int>(
+                MessagingSemanticConventions.MetricMessagesReceiveFailed,
+                unit: "{message}",
+                description: "Total number of messages that failed to receive");
+
+            _sendDuration = _meter.CreateHistogram<double>(
+                MessagingSemanticConventions.MetricSendDuration,
+                unit: "ms",
+                description: "Duration of message send operations");
+
+            _receiveDuration = _meter.CreateHistogram<double>(
+                MessagingSemanticConventions.MetricReceiveDuration,
+                unit: "ms",
+                description: "Duration of message receive operations");
+
+            _sendPayloadSize = _meter.CreateHistogram<double>(
+                MessagingSemanticConventions.MetricSendPayloadSize,
+                unit: "By",
+                description: "Size of message payloads sent");
+
+            _connectorStateChanges = _meter.CreateCounter<int>(
+                MessagingSemanticConventions.MetricConnectorStateChanges,
+                unit: "{change}",
+                description: "Number of connector state transitions");
+        }
+
+        public string ConnectorType { get; }
+
+        public string? ConnectorInstanceName { get; }
+
+        public bool IsPayloadSizeEnabled => _options.EnablePayloadSizeMetrics;
+
+        public Activity? StartActivity(string operation, string? channelName = null, string? messageId = null)
+        {
+            if (!_options.EnableTracing || !_activitySource.HasListeners())
+                return null;
+
+            var tags = MessagingSemanticConventions.CreateOperationTags(
+                ConnectorType, operation, channelName, messageId);
+
+            return _activitySource.StartActivity(
+                $"{ConnectorInstanceName ?? ConnectorType} {operation}",
+                ActivityKind.Client,
+                default(ActivityContext),
+                tags);
+        }
+
+        public Activity? StartSendActivity(string? channelName = null, string? messageId = null)
+        {
+            return StartActivity(MessagingSemanticConventions.OperationSend, channelName, messageId);
+        }
+
+        public Activity? StartReceiveActivity(string? channelName = null)
+        {
+            return StartActivity(MessagingSemanticConventions.OperationReceive, channelName);
+        }
+
+        public Activity? StartStatusQueryActivity(string? messageId = null)
+        {
+            return StartActivity(MessagingSemanticConventions.OperationStatusQuery, messageId: messageId);
+        }
+
+        public Activity? StartInitializeActivity()
+        {
+            return StartActivity(MessagingSemanticConventions.OperationInitialize);
+        }
+
+        public void RecordSendSuccess(long elapsedMs, int payloadSize = 0)
+        {
+            if (!_options.EnableMetrics)
+                return;
+
+            var tags = CreateConnectorMetricTags();
+
+            _messagesSentTotal.Add(1, tags);
+
+            _sendDuration.Record(elapsedMs, tags);
+
+            if (payloadSize > 0)
+                _sendPayloadSize.Record(payloadSize, tags);
+        }
+
+        public void RecordSendFailure(long elapsedMs, string? errorCode = null)
+        {
+            if (!_options.EnableMetrics)
+                return;
+
+            var tags = CreateConnectorMetricTags(errorCode);
+
+            _messagesSentFailed.Add(1, tags);
+            _sendDuration.Record(elapsedMs, tags);
+        }
+
+        public void RecordReceiveSuccess(long elapsedMs, int messageCount = 1)
+        {
+            if (!_options.EnableMetrics)
+                return;
+
+            var tags = CreateConnectorMetricTags();
+
+            _messagesReceivedTotal.Add(messageCount, tags);
+            _receiveDuration.Record(elapsedMs, tags);
+        }
+
+        public void RecordReceiveFailure(long elapsedMs, string? errorCode = null)
+        {
+            if (!_options.EnableMetrics)
+                return;
+
+            var tags = CreateConnectorMetricTags(errorCode);
+
+            _messagesReceiveFailed.Add(1, tags);
+            _receiveDuration.Record(elapsedMs, tags);
+        }
+
+        public void RecordStateChange(string fromState, string toState)
+        {
+            if (!_options.EnableMetrics)
+                return;
+
+            var tags = new TagList
+            {
+                { MessagingSemanticConventions.AttributeMessagingSystem, MessagingSemanticConventions.SystemName },
+                { MessagingSemanticConventions.AttributeConnectorType, ConnectorType },
+                { "ratatosk.connector.state.from", fromState },
+                { "ratatosk.connector.state.to", toState }
+            };
+
+            _connectorStateChanges.Add(1, tags);
+        }
+
+        public long MeasurePayloadSize<T>(T message)
+        {
+            try
+            {
+                var json = System.Text.Json.JsonSerializer.Serialize(message);
+                return System.Text.Encoding.UTF8.GetByteCount(json);
+            }
+            catch
+            {
+                return 0;
+            }
+        }
+
+        private TagList CreateConnectorMetricTags(string? errorCode = null)
+        {
+            var tags = new TagList
+            {
+                { MessagingSemanticConventions.AttributeMessagingSystem, MessagingSemanticConventions.SystemName },
+                { MessagingSemanticConventions.AttributeConnectorType, ConnectorType }
+            };
+
+            if (ConnectorInstanceName != null)
+                tags.Add(MessagingSemanticConventions.AttributeConnectorName, ConnectorInstanceName);
+
+            if (errorCode != null)
+                tags.Add(MessagingSemanticConventions.AttributeErrorType, errorCode);
+
+            return tags;
+        }
+
+        public void Dispose()
+        {
+            _activitySource.Dispose();
+            _meter.Dispose();
+        }
+    }
+}

--- a/src/Ratatosk.Connectors/ConnectorTelemetry.cs
+++ b/src/Ratatosk.Connectors/ConnectorTelemetry.cs
@@ -97,7 +97,7 @@ namespace Ratatosk
             return _activitySource.StartActivity(
                 $"{ConnectorInstanceName ?? ConnectorType} {operation}",
                 ActivityKind.Client,
-                default(ActivityContext),
+                Activity.Current?.Context ?? default,
                 tags);
         }
 

--- a/src/Ratatosk.Connectors/ConnectorTelemetry.cs
+++ b/src/Ratatosk.Connectors/ConnectorTelemetry.cs
@@ -33,8 +33,8 @@ namespace Ratatosk
             ConnectorInstanceName = connectorInstanceName;
             _options = options ?? new TelemetryOptions();
 
-            var sourceName = $"Ratatosk.Connector.{connectorType}";
-            var meterName = $"Ratatosk.Connector.{connectorType}";
+            var sourceName = ConnectorMeter.MakeConnectorName(connectorType);
+            var meterName = ConnectorMeter.MakeConnectorName(connectorType);
 
             _activitySource = new ActivitySource(sourceName, _version);
             _meter = new Meter(meterName, _version);

--- a/src/Ratatosk.Connectors/ConnectorTelemetry.cs
+++ b/src/Ratatosk.Connectors/ConnectorTelemetry.cs
@@ -121,14 +121,14 @@ namespace Ratatosk
             return StartActivity(MessagingSemanticConventions.OperationInitialize);
         }
 
-        public void RecordSendSuccess(long elapsedMs, int payloadSize = 0)
+        public void RecordSendSuccess(long elapsedMs, int payloadSize = 0, int messageCount = 1)
         {
             if (!_options.EnableMetrics)
                 return;
 
             var tags = CreateConnectorMetricTags();
 
-            _messagesSentTotal.Add(1, tags);
+            _messagesSentTotal.Add(messageCount, tags);
 
             _sendDuration.Record(elapsedMs, tags);
 

--- a/src/Ratatosk.Connectors/MessagingSemanticConventions.cs
+++ b/src/Ratatosk.Connectors/MessagingSemanticConventions.cs
@@ -35,20 +35,6 @@ namespace Ratatosk
         public const string MetricSendPayloadSize = "ratatosk.messages.send.payload_size";
         public const string MetricConnectorStateChanges = "ratatosk.connector.state_changes";
 
-        public static ActivityTagsCollection CreateConnectorTags(string connectorType, string? connectorName = null)
-        {
-            var tags = new Dictionary<string, object?>
-            {
-                [AttributeMessagingSystem] = SystemName,
-                [AttributeConnectorType] = connectorType
-            };
-
-            if (connectorName != null)
-                tags[AttributeConnectorName] = connectorName;
-
-            return new ActivityTagsCollection(tags);
-        }
-
         public static ActivityTagsCollection CreateOperationTags(
             string connectorType,
             string operation,

--- a/src/Ratatosk.Connectors/MessagingSemanticConventions.cs
+++ b/src/Ratatosk.Connectors/MessagingSemanticConventions.cs
@@ -1,0 +1,74 @@
+using System.Diagnostics;
+
+namespace Ratatosk
+{
+    internal static class MessagingSemanticConventions
+    {
+        public const string SystemName = "ratatosk";
+
+        public const string OperationSend = "send";
+        public const string OperationReceive = "receive";
+        public const string OperationStatusQuery = "status_query";
+        public const string OperationInitialize = "initialize";
+        public const string OperationBatchSend = "batch_send";
+        public const string OperationHealthCheck = "health_check";
+
+        public const string AttributeMessagingSystem = "messaging.system";
+        public const string AttributeMessagingOperation = "messaging.operation";
+        public const string AttributeMessagingDestination = "messaging.destination";
+        public const string AttributeMessagingMessageId = "messaging.message.id";
+        public const string AttributeMessagingPayloadSize = "messaging.message.payload_size_bytes";
+        public const string AttributeMessagingBatchSize = "messaging.batch.message_count";
+
+        public const string AttributeConnectorName = "ratatosk.connector.name";
+        public const string AttributeConnectorType = "ratatosk.connector.type";
+        public const string AttributeConnectorState = "ratatosk.connector.state";
+
+        public const string AttributeErrorType = "error.type";
+
+        public const string MetricMessagesSent = "ratatosk.messages.sent";
+        public const string MetricMessagesSendFailed = "ratatosk.messages.send_failed";
+        public const string MetricMessagesReceived = "ratatosk.messages.received";
+        public const string MetricMessagesReceiveFailed = "ratatosk.messages.receive_failed";
+        public const string MetricSendDuration = "ratatosk.messages.send.duration";
+        public const string MetricReceiveDuration = "ratatosk.messages.receive.duration";
+        public const string MetricSendPayloadSize = "ratatosk.messages.send.payload_size";
+        public const string MetricConnectorStateChanges = "ratatosk.connector.state_changes";
+
+        public static ActivityTagsCollection CreateConnectorTags(string connectorType, string? connectorName = null)
+        {
+            var tags = new Dictionary<string, object?>
+            {
+                [AttributeMessagingSystem] = SystemName,
+                [AttributeConnectorType] = connectorType
+            };
+
+            if (connectorName != null)
+                tags[AttributeConnectorName] = connectorName;
+
+            return new ActivityTagsCollection(tags);
+        }
+
+        public static ActivityTagsCollection CreateOperationTags(
+            string connectorType,
+            string operation,
+            string? channelName = null,
+            string? messageId = null)
+        {
+            var tags = new Dictionary<string, object?>
+            {
+                [AttributeMessagingSystem] = SystemName,
+                [AttributeConnectorType] = connectorType,
+                [AttributeMessagingOperation] = operation
+            };
+
+            if (channelName != null)
+                tags[AttributeMessagingDestination] = channelName;
+
+            if (messageId != null)
+                tags[AttributeMessagingMessageId] = messageId;
+
+            return new ActivityTagsCollection(tags);
+        }
+    }
+}

--- a/src/Ratatosk.Connectors/Ratatosk.Connectors.csproj
+++ b/src/Ratatosk.Connectors/Ratatosk.Connectors.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Resilience" Version="8.0.0" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net9.0'">
@@ -20,6 +21,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.8" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.8" />
     <PackageReference Include="Microsoft.Extensions.Resilience" Version="9.0.0" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net10.0'">
@@ -27,6 +29,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Resilience" Version="10.0.0" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="10.0.0" />
   </ItemGroup>
 
 

--- a/src/Ratatosk.Extensions.OpenTelemetry/MessagingBuilderExtensions.cs
+++ b/src/Ratatosk.Extensions.OpenTelemetry/MessagingBuilderExtensions.cs
@@ -1,0 +1,41 @@
+using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry;
+
+namespace Ratatosk
+{
+    /// <summary>
+    /// Provides extension methods for <see cref="MessagingBuilder"/> to
+    /// enable OpenTelemetry instrumentation.
+    /// </summary>
+    public static class MessagingBuilderExtensions
+    {
+        /// <summary>
+        /// Configures OpenTelemetry tracing and metrics for all Ratatosk
+        /// sources registered in the application.
+        /// </summary>
+        /// <param name="builder">The <see cref="MessagingBuilder"/> to configure.</param>
+        /// <returns>The builder instance for chaining.</returns>
+        /// <remarks>
+        /// This is a convenience method that internally calls
+        /// <c>AddOpenTelemetry()</c> on the service collection and
+        /// invokes <c>AddRatatoskInstrumentation()</c> on both the
+        /// tracer and meter providers.
+        ///
+        /// If you need fine-grained control over OpenTelemetry configuration,
+        /// use <c>AddRatatoskInstrumentation()</c> on
+        /// <c>TracerProviderBuilder</c> and <c>MeterProviderBuilder</c>
+        /// directly instead.
+        /// </remarks>
+        public static MessagingBuilder WithOpenTelemetry(
+            this MessagingBuilder builder)
+        {
+            ArgumentNullException.ThrowIfNull(builder);
+
+            builder.Services.AddOpenTelemetry()
+                .WithTracing(tracing => tracing.AddRatatoskInstrumentation())
+                .WithMetrics(metrics => metrics.AddRatatoskInstrumentation());
+
+            return builder;
+        }
+    }
+}

--- a/src/Ratatosk.Extensions.OpenTelemetry/OpenTelemetryBuilderExtensions.cs
+++ b/src/Ratatosk.Extensions.OpenTelemetry/OpenTelemetryBuilderExtensions.cs
@@ -1,0 +1,60 @@
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
+namespace Ratatosk
+{
+    /// <summary>
+    /// Provides extension methods for registering Ratatosk telemetry sources
+    /// with OpenTelemetry.
+    /// </summary>
+    public static class OpenTelemetryBuilderExtensions
+    {
+        /// <summary>
+        /// Adds Ratatosk ActivitySources to the tracer provider, enabling
+        /// distributed tracing for messaging operations.
+        /// </summary>
+        /// <param name="builder">The <see cref="TracerProviderBuilder"/> to configure.</param>
+        /// <returns>The builder instance for chaining.</returns>
+        /// <remarks>
+        /// This registers the following sources:
+        /// <list type="bullet">
+        ///   <item><c>Ratatosk.Client</c> — spans from the <c>IMessagingClient</c> facade</item>
+        ///   <item><c>Ratatosk.Connector.*</c> — spans from all channel connectors (Twilio, SendGrid, etc.)</item>
+        /// </list>
+        /// </remarks>
+        public static TracerProviderBuilder AddRatatoskInstrumentation(
+            this TracerProviderBuilder builder)
+        {
+            ArgumentNullException.ThrowIfNull(builder);
+
+            builder.AddSource("Ratatosk.Client");
+            builder.AddSource("Ratatosk.Connector.*");
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Adds Ratatosk Meters to the meter provider, enabling metrics
+        /// collection for messaging operations.
+        /// </summary>
+        /// <param name="builder">The <see cref="MeterProviderBuilder"/> to configure.</param>
+        /// <returns>The builder instance for chaining.</returns>
+        /// <remarks>
+        /// This registers the following meters:
+        /// <list type="bullet">
+        ///   <item><c>Ratatosk.Client</c> — client-level metrics (sent count, send duration)</item>
+        ///   <item><c>Ratatosk.Connector.*</c> — per-connector metrics (sent/received/failed counts, latency histograms)</item>
+        /// </list>
+        /// </remarks>
+        public static MeterProviderBuilder AddRatatoskInstrumentation(
+            this MeterProviderBuilder builder)
+        {
+            ArgumentNullException.ThrowIfNull(builder);
+
+            builder.AddMeter("Ratatosk.Client");
+            builder.AddMeter("Ratatosk.Connector.*");
+
+            return builder;
+        }
+    }
+}

--- a/src/Ratatosk.Extensions.OpenTelemetry/Ratatosk.Extensions.OpenTelemetry.csproj
+++ b/src/Ratatosk.Extensions.OpenTelemetry/Ratatosk.Extensions.OpenTelemetry.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Title>Ratatosk OpenTelemetry</Title>
+    <Description>OpenTelemetry instrumentation for the Ratatosk messaging framework,
+      providing simplified registration of tracing and metrics sources.</Description>
+    <PackageTags>ratatosk;messaging;opentelemetry;tracing;metrics;instrumentation</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Ratatosk\Ratatosk.csproj" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Ratatosk" />
+  </ItemGroup>
+</Project>

--- a/src/Ratatosk/BatchSendRequest.cs
+++ b/src/Ratatosk/BatchSendRequest.cs
@@ -1,0 +1,18 @@
+namespace Ratatosk;
+
+public class BatchSendRequest
+{
+    public string ChannelName { get; }
+    public IMessageBatch Batch { get; }
+    public ConnectionSettings? ConnectionSettings { get; init; }
+    public Type? ConnectorType { get; init; }
+    public MessageContext? Context { get; init; }
+
+    public BatchSendRequest(string channelName, IMessageBatch batch)
+    {
+        ArgumentNullException.ThrowIfNull(channelName);
+        ArgumentNullException.ThrowIfNull(batch);
+        ChannelName = channelName;
+        Batch = batch;
+    }
+}

--- a/src/Ratatosk/ChannelConnectorBuilder.cs
+++ b/src/Ratatosk/ChannelConnectorBuilder.cs
@@ -214,6 +214,33 @@ namespace Ratatosk
         }
 
         /// <summary>
+        /// Configures the telemetry options for the connector, controlling which
+        /// metrics and traces are emitted.
+        /// </summary>
+        /// <param name="configure">
+        /// A delegate that configures the <see cref="TelemetryOptions"/> instance.
+        /// </param>
+        /// <returns>
+        /// Returns the current builder instance to allow chaining.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown if <paramref name="configure"/> is <c>null</c>.
+        /// </exception>
+        public ChannelConnectorBuilder<TConnector> WithTelemetry(Action<TelemetryOptions> configure)
+        {
+            ArgumentNullException.ThrowIfNull(configure, nameof(configure));
+
+            var options = new TelemetryOptions();
+            configure(options);
+
+            _fluentSettings[TelemetrySettingsKeys.EnableTracing] = options.EnableTracing;
+            _fluentSettings[TelemetrySettingsKeys.EnableMetrics] = options.EnableMetrics;
+            _fluentSettings[TelemetrySettingsKeys.EnablePayloadSizeMetrics] = options.EnablePayloadSizeMetrics;
+
+            return this;
+        }
+
+        /// <summary>
         /// Overrides the default factory used to create the connector
         /// with a custom factory type.
         /// </summary>

--- a/src/Ratatosk/ClientTelemetry.cs
+++ b/src/Ratatosk/ClientTelemetry.cs
@@ -18,22 +18,18 @@ namespace Ratatosk
         private readonly Meter _meter;
         private readonly TelemetryOptions _options;
 
-        // Send metrics
         private readonly Counter<int> _messagesSentTotal;
         private readonly Counter<int> _messagesSentFailed;
         private readonly Histogram<double> _sendDuration;
 
-        // Receive metrics
         private readonly Counter<int> _messagesReceivedTotal;
         private readonly Counter<int> _messagesReceiveFailed;
         private readonly Histogram<double> _receiveDuration;
 
-        // Status query metrics
         private readonly Counter<int> _statusQueriesTotal;
         private readonly Counter<int> _statusQueriesFailed;
         private readonly Histogram<double> _statusQueryDuration;
 
-        // Receive status metrics
         private readonly Counter<int> _statusReceivesTotal;
         private readonly Counter<int> _statusReceivesFailed;
         private readonly Histogram<double> _statusReceiveDuration;
@@ -117,161 +113,108 @@ namespace Ratatosk
                 description: "Duration of status receive operations through the client");
         }
 
-        public Activity? StartSendActivity(string channelName, string? messageId = null)
+        private static ActivityTagsCollection BuildBaseTags(string operation, string channelName, string? messageId, MessageContext? context)
         {
-            if (!_options.EnableTracing || !_activitySource.HasListeners())
-                return null;
-
             var tags = new ActivityTagsCollection
             {
                 { AttrMessagingSystem, ClientSystemName },
-                { AttrMessagingOperation, "send" },
+                { AttrMessagingOperation, operation },
                 { AttrChannelName, channelName }
             };
 
             if (messageId != null)
                 tags[AttrMessagingMessageId] = messageId;
 
-            return _activitySource.StartActivity(
-                $"{channelName} send",
-                ActivityKind.Client,
-                default(ActivityContext),
-                tags);
+            if (context != null)
+            {
+                foreach (var (key, value) in context.Data)
+                {
+                    if (!string.IsNullOrWhiteSpace(key))
+                        tags[key] = value;
+                }
+            }
+
+            return tags;
         }
 
-        public Activity? StartReceiveActivity(string channelName)
+        private Activity? StartActivity(string name, string operation, string channelName, string? messageId, MessageContext? context)
         {
             if (!_options.EnableTracing || !_activitySource.HasListeners())
                 return null;
 
-            var tags = new ActivityTagsCollection
-            {
-                { AttrMessagingSystem, ClientSystemName },
-                { AttrMessagingOperation, "receive" },
-                { AttrChannelName, channelName }
-            };
+            var tags = BuildBaseTags(operation, channelName, messageId, context);
 
             return _activitySource.StartActivity(
-                $"{channelName} receive",
+                name,
                 ActivityKind.Client,
-                default(ActivityContext),
+                Activity.Current?.Context ?? default,
                 tags);
         }
 
-        public Activity? StartStatusActivity(string channelName)
-        {
-            if (!_options.EnableTracing || !_activitySource.HasListeners())
-                return null;
+        public Activity? StartSendActivity(string channelName, string? messageId = null, MessageContext? context = null)
+            => StartActivity($"{channelName} send", "send", channelName, messageId, context);
 
-            var tags = new ActivityTagsCollection
-            {
-                { AttrMessagingSystem, ClientSystemName },
-                { AttrMessagingOperation, "status_query" },
-                { AttrChannelName, channelName }
-            };
+        public Activity? StartReceiveActivity(string channelName, MessageContext? context = null)
+            => StartActivity($"{channelName} receive", "receive", channelName, null, context);
 
-            return _activitySource.StartActivity(
-                $"{channelName} status_query",
-                ActivityKind.Client,
-                default(ActivityContext),
-                tags);
-        }
+        public Activity? StartStatusActivity(string channelName, MessageContext? context = null)
+            => StartActivity($"{channelName} status_query", "status_query", channelName, null, context);
 
-        public Activity? StartReceiveStatusActivity(string channelName)
-        {
-            if (!_options.EnableTracing || !_activitySource.HasListeners())
-                return null;
-
-            var tags = new ActivityTagsCollection
-            {
-                { AttrMessagingSystem, ClientSystemName },
-                { AttrMessagingOperation, "receive_status" },
-                { AttrChannelName, channelName }
-            };
-
-            return _activitySource.StartActivity(
-                $"{channelName} receive_status",
-                ActivityKind.Client,
-                default(ActivityContext),
-                tags);
-        }
-
-        // ── Send metrics ──────────────────────────────────────────────────────
+        public Activity? StartReceiveStatusActivity(string channelName, MessageContext? context = null)
+            => StartActivity($"{channelName} receive_status", "receive_status", channelName, null, context);
 
         public void RecordSendSuccess(long elapsedMs)
         {
-            if (!_options.EnableMetrics)
-                return;
-
+            if (!_options.EnableMetrics) return;
             _messagesSentTotal.Add(1);
             _sendDuration.Record(elapsedMs);
         }
 
         public void RecordSendFailure(long elapsedMs)
         {
-            if (!_options.EnableMetrics)
-                return;
-
+            if (!_options.EnableMetrics) return;
             _messagesSentFailed.Add(1);
             _sendDuration.Record(elapsedMs);
         }
 
-        // ── Receive metrics ───────────────────────────────────────────────────
-
         public void RecordReceiveSuccess(long elapsedMs)
         {
-            if (!_options.EnableMetrics)
-                return;
-
+            if (!_options.EnableMetrics) return;
             _messagesReceivedTotal.Add(1);
             _receiveDuration.Record(elapsedMs);
         }
 
         public void RecordReceiveFailure(long elapsedMs)
         {
-            if (!_options.EnableMetrics)
-                return;
-
+            if (!_options.EnableMetrics) return;
             _messagesReceiveFailed.Add(1);
             _receiveDuration.Record(elapsedMs);
         }
 
-        // ── Status query metrics ──────────────────────────────────────────────
-
         public void RecordStatusSuccess(long elapsedMs)
         {
-            if (!_options.EnableMetrics)
-                return;
-
+            if (!_options.EnableMetrics) return;
             _statusQueriesTotal.Add(1);
             _statusQueryDuration.Record(elapsedMs);
         }
 
         public void RecordStatusFailure(long elapsedMs)
         {
-            if (!_options.EnableMetrics)
-                return;
-
+            if (!_options.EnableMetrics) return;
             _statusQueriesFailed.Add(1);
             _statusQueryDuration.Record(elapsedMs);
         }
 
-        // ── Receive status metrics ────────────────────────────────────────────
-
         public void RecordReceiveStatusSuccess(long elapsedMs)
         {
-            if (!_options.EnableMetrics)
-                return;
-
+            if (!_options.EnableMetrics) return;
             _statusReceivesTotal.Add(1);
             _statusReceiveDuration.Record(elapsedMs);
         }
 
         public void RecordReceiveStatusFailure(long elapsedMs)
         {
-            if (!_options.EnableMetrics)
-                return;
-
+            if (!_options.EnableMetrics) return;
             _statusReceivesFailed.Add(1);
             _statusReceiveDuration.Record(elapsedMs);
         }

--- a/src/Ratatosk/ClientTelemetry.cs
+++ b/src/Ratatosk/ClientTelemetry.cs
@@ -1,0 +1,135 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using System.Reflection;
+
+namespace Ratatosk
+{
+    internal class ClientTelemetry : IDisposable
+    {
+        private readonly ActivitySource _activitySource;
+        private readonly Meter _meter;
+        private readonly TelemetryOptions _options;
+
+        private readonly Counter<int> _messagesSentTotal;
+        private readonly Counter<int> _messagesSentFailed;
+        private readonly Histogram<double> _sendDuration;
+
+        private static readonly AssemblyVersionAttribute? _versionAttr =
+            typeof(ClientTelemetry).Assembly
+                .GetCustomAttributes(typeof(AssemblyVersionAttribute), false)
+                .Cast<AssemblyVersionAttribute>()
+                .FirstOrDefault();
+
+        private static readonly string _version = _versionAttr?.Version ?? "0.0.0";
+
+        public ClientTelemetry(TelemetryOptions? options = null)
+        {
+            _options = options ?? new TelemetryOptions();
+
+            const string sourceName = "Ratatosk.Client";
+            const string meterName = "Ratatosk.Client";
+
+            _activitySource = new ActivitySource(sourceName, _version);
+            _meter = new Meter(meterName, _version);
+
+            _messagesSentTotal = _meter.CreateCounter<int>(
+                "ratatosk.client.messages.sent",
+                unit: "{message}",
+                description: "Total number of messages sent through the client");
+
+            _messagesSentFailed = _meter.CreateCounter<int>(
+                "ratatosk.client.messages.send_failed",
+                unit: "{message}",
+                description: "Total number of messages that failed to send through the client");
+
+            _sendDuration = _meter.CreateHistogram<double>(
+                "ratatosk.client.messages.send.duration",
+                unit: "ms",
+                description: "Duration of message send operations through the client");
+        }
+
+        public Activity? StartSendActivity(string channelName, string? messageId = null)
+        {
+            if (!_options.EnableTracing || !_activitySource.HasListeners())
+                return null;
+
+            var tags = new ActivityTagsCollection
+            {
+                { "messaging.system", "ratatosk" },
+                { "messaging.operation", "send" },
+                { "ratatosk.channel.name", channelName }
+            };
+
+            if (messageId != null)
+                tags["messaging.message.id"] = messageId;
+
+            return _activitySource.StartActivity(
+                $"MessagingClient send",
+                ActivityKind.Client,
+                default(ActivityContext),
+                tags);
+        }
+
+        public Activity? StartReceiveActivity(string channelName)
+        {
+            if (!_options.EnableTracing || !_activitySource.HasListeners())
+                return null;
+
+            var tags = new ActivityTagsCollection
+            {
+                { "messaging.system", "ratatosk" },
+                { "messaging.operation", "receive" },
+                { "ratatosk.channel.name", channelName }
+            };
+
+            return _activitySource.StartActivity(
+                $"MessagingClient receive",
+                ActivityKind.Client,
+                default(ActivityContext),
+                tags);
+        }
+
+        public Activity? StartStatusActivity(string channelName)
+        {
+            if (!_options.EnableTracing || !_activitySource.HasListeners())
+                return null;
+
+            var tags = new ActivityTagsCollection
+            {
+                { "messaging.system", "ratatosk" },
+                { "messaging.operation", "status_query" },
+                { "ratatosk.channel.name", channelName }
+            };
+
+            return _activitySource.StartActivity(
+                $"MessagingClient status_query",
+                ActivityKind.Client,
+                default(ActivityContext),
+                tags);
+        }
+
+        public void RecordSendSuccess(long elapsedMs)
+        {
+            if (!_options.EnableMetrics)
+                return;
+
+            _messagesSentTotal.Add(1);
+            _sendDuration.Record(elapsedMs);
+        }
+
+        public void RecordSendFailure(long elapsedMs)
+        {
+            if (!_options.EnableMetrics)
+                return;
+
+            _messagesSentFailed.Add(1);
+            _sendDuration.Record(elapsedMs);
+        }
+
+        public void Dispose()
+        {
+            _activitySource.Dispose();
+            _meter.Dispose();
+        }
+    }
+}

--- a/src/Ratatosk/ClientTelemetry.cs
+++ b/src/Ratatosk/ClientTelemetry.cs
@@ -9,7 +9,8 @@ namespace Ratatosk
         private const string AttrMessagingSystem = "messaging.system";
         private const string AttrMessagingOperation = "messaging.operation";
         private const string AttrMessagingMessageId = "messaging.message.id";
-        private const string AttrChannelName = "ratatosk.channel.name";
+        private const string AttrChannelName = "messaging.destination";
+        private const string AttrErrorType = "error.type";
 
         private static readonly string ClientSystemName = "ratatosk";
 
@@ -17,9 +18,25 @@ namespace Ratatosk
         private readonly Meter _meter;
         private readonly TelemetryOptions _options;
 
+        // Send metrics
         private readonly Counter<int> _messagesSentTotal;
         private readonly Counter<int> _messagesSentFailed;
         private readonly Histogram<double> _sendDuration;
+
+        // Receive metrics
+        private readonly Counter<int> _messagesReceivedTotal;
+        private readonly Counter<int> _messagesReceiveFailed;
+        private readonly Histogram<double> _receiveDuration;
+
+        // Status query metrics
+        private readonly Counter<int> _statusQueriesTotal;
+        private readonly Counter<int> _statusQueriesFailed;
+        private readonly Histogram<double> _statusQueryDuration;
+
+        // Receive status metrics
+        private readonly Counter<int> _statusReceivesTotal;
+        private readonly Counter<int> _statusReceivesFailed;
+        private readonly Histogram<double> _statusReceiveDuration;
 
         private static readonly AssemblyVersionAttribute? _versionAttr =
             typeof(ClientTelemetry).Assembly
@@ -53,6 +70,51 @@ namespace Ratatosk
                 "ratatosk.client.messages.send.duration",
                 unit: "ms",
                 description: "Duration of message send operations through the client");
+
+            _messagesReceivedTotal = _meter.CreateCounter<int>(
+                "ratatosk.client.messages.received",
+                unit: "{message}",
+                description: "Total number of messages received through the client");
+
+            _messagesReceiveFailed = _meter.CreateCounter<int>(
+                "ratatosk.client.messages.receive_failed",
+                unit: "{message}",
+                description: "Total number of messages that failed to receive through the client");
+
+            _receiveDuration = _meter.CreateHistogram<double>(
+                "ratatosk.client.messages.receive.duration",
+                unit: "ms",
+                description: "Duration of message receive operations through the client");
+
+            _statusQueriesTotal = _meter.CreateCounter<int>(
+                "ratatosk.client.status.queries",
+                unit: "{query}",
+                description: "Total number of status queries through the client");
+
+            _statusQueriesFailed = _meter.CreateCounter<int>(
+                "ratatosk.client.status.query_failed",
+                unit: "{query}",
+                description: "Total number of status queries that failed through the client");
+
+            _statusQueryDuration = _meter.CreateHistogram<double>(
+                "ratatosk.client.status.query.duration",
+                unit: "ms",
+                description: "Duration of status query operations through the client");
+
+            _statusReceivesTotal = _meter.CreateCounter<int>(
+                "ratatosk.client.status.received",
+                unit: "{update}",
+                description: "Total number of status updates received through the client");
+
+            _statusReceivesFailed = _meter.CreateCounter<int>(
+                "ratatosk.client.status.receive_failed",
+                unit: "{update}",
+                description: "Total number of status updates that failed to receive through the client");
+
+            _statusReceiveDuration = _meter.CreateHistogram<double>(
+                "ratatosk.client.status.receive.duration",
+                unit: "ms",
+                description: "Duration of status receive operations through the client");
         }
 
         public Activity? StartSendActivity(string channelName, string? messageId = null)
@@ -71,7 +133,7 @@ namespace Ratatosk
                 tags[AttrMessagingMessageId] = messageId;
 
             return _activitySource.StartActivity(
-                $"MessagingClient send",
+                $"{channelName} send",
                 ActivityKind.Client,
                 default(ActivityContext),
                 tags);
@@ -90,7 +152,7 @@ namespace Ratatosk
             };
 
             return _activitySource.StartActivity(
-                $"MessagingClient receive",
+                $"{channelName} receive",
                 ActivityKind.Client,
                 default(ActivityContext),
                 tags);
@@ -109,7 +171,7 @@ namespace Ratatosk
             };
 
             return _activitySource.StartActivity(
-                $"MessagingClient status_query",
+                $"{channelName} status_query",
                 ActivityKind.Client,
                 default(ActivityContext),
                 tags);
@@ -128,11 +190,13 @@ namespace Ratatosk
             };
 
             return _activitySource.StartActivity(
-                $"MessagingClient receive_status",
+                $"{channelName} receive_status",
                 ActivityKind.Client,
                 default(ActivityContext),
                 tags);
         }
+
+        // ── Send metrics ──────────────────────────────────────────────────────
 
         public void RecordSendSuccess(long elapsedMs)
         {
@@ -150,6 +214,66 @@ namespace Ratatosk
 
             _messagesSentFailed.Add(1);
             _sendDuration.Record(elapsedMs);
+        }
+
+        // ── Receive metrics ───────────────────────────────────────────────────
+
+        public void RecordReceiveSuccess(long elapsedMs)
+        {
+            if (!_options.EnableMetrics)
+                return;
+
+            _messagesReceivedTotal.Add(1);
+            _receiveDuration.Record(elapsedMs);
+        }
+
+        public void RecordReceiveFailure(long elapsedMs)
+        {
+            if (!_options.EnableMetrics)
+                return;
+
+            _messagesReceiveFailed.Add(1);
+            _receiveDuration.Record(elapsedMs);
+        }
+
+        // ── Status query metrics ──────────────────────────────────────────────
+
+        public void RecordStatusSuccess(long elapsedMs)
+        {
+            if (!_options.EnableMetrics)
+                return;
+
+            _statusQueriesTotal.Add(1);
+            _statusQueryDuration.Record(elapsedMs);
+        }
+
+        public void RecordStatusFailure(long elapsedMs)
+        {
+            if (!_options.EnableMetrics)
+                return;
+
+            _statusQueriesFailed.Add(1);
+            _statusQueryDuration.Record(elapsedMs);
+        }
+
+        // ── Receive status metrics ────────────────────────────────────────────
+
+        public void RecordReceiveStatusSuccess(long elapsedMs)
+        {
+            if (!_options.EnableMetrics)
+                return;
+
+            _statusReceivesTotal.Add(1);
+            _statusReceiveDuration.Record(elapsedMs);
+        }
+
+        public void RecordReceiveStatusFailure(long elapsedMs)
+        {
+            if (!_options.EnableMetrics)
+                return;
+
+            _statusReceivesFailed.Add(1);
+            _statusReceiveDuration.Record(elapsedMs);
         }
 
         public void Dispose()

--- a/src/Ratatosk/ClientTelemetry.cs
+++ b/src/Ratatosk/ClientTelemetry.cs
@@ -6,6 +6,13 @@ namespace Ratatosk
 {
     internal class ClientTelemetry : IDisposable
     {
+        private const string AttrMessagingSystem = "messaging.system";
+        private const string AttrMessagingOperation = "messaging.operation";
+        private const string AttrMessagingMessageId = "messaging.message.id";
+        private const string AttrChannelName = "ratatosk.channel.name";
+
+        private static readonly string ClientSystemName = "ratatosk";
+
         private readonly ActivitySource _activitySource;
         private readonly Meter _meter;
         private readonly TelemetryOptions _options;
@@ -55,13 +62,13 @@ namespace Ratatosk
 
             var tags = new ActivityTagsCollection
             {
-                { "messaging.system", "ratatosk" },
-                { "messaging.operation", "send" },
-                { "ratatosk.channel.name", channelName }
+                { AttrMessagingSystem, ClientSystemName },
+                { AttrMessagingOperation, "send" },
+                { AttrChannelName, channelName }
             };
 
             if (messageId != null)
-                tags["messaging.message.id"] = messageId;
+                tags[AttrMessagingMessageId] = messageId;
 
             return _activitySource.StartActivity(
                 $"MessagingClient send",
@@ -77,9 +84,9 @@ namespace Ratatosk
 
             var tags = new ActivityTagsCollection
             {
-                { "messaging.system", "ratatosk" },
-                { "messaging.operation", "receive" },
-                { "ratatosk.channel.name", channelName }
+                { AttrMessagingSystem, ClientSystemName },
+                { AttrMessagingOperation, "receive" },
+                { AttrChannelName, channelName }
             };
 
             return _activitySource.StartActivity(
@@ -96,13 +103,32 @@ namespace Ratatosk
 
             var tags = new ActivityTagsCollection
             {
-                { "messaging.system", "ratatosk" },
-                { "messaging.operation", "status_query" },
-                { "ratatosk.channel.name", channelName }
+                { AttrMessagingSystem, ClientSystemName },
+                { AttrMessagingOperation, "status_query" },
+                { AttrChannelName, channelName }
             };
 
             return _activitySource.StartActivity(
                 $"MessagingClient status_query",
+                ActivityKind.Client,
+                default(ActivityContext),
+                tags);
+        }
+
+        public Activity? StartReceiveStatusActivity(string channelName)
+        {
+            if (!_options.EnableTracing || !_activitySource.HasListeners())
+                return null;
+
+            var tags = new ActivityTagsCollection
+            {
+                { AttrMessagingSystem, ClientSystemName },
+                { AttrMessagingOperation, "receive_status" },
+                { AttrChannelName, channelName }
+            };
+
+            return _activitySource.StartActivity(
+                $"MessagingClient receive_status",
                 ActivityKind.Client,
                 default(ActivityContext),
                 tags);

--- a/src/Ratatosk/IMessagingClient.cs
+++ b/src/Ratatosk/IMessagingClient.cs
@@ -4,23 +4,12 @@ namespace Ratatosk
     /// Provides a high-level facade for sending and receiving messages through
     /// registered messaging channels.
     /// </summary>
-    /// <remarks>
-    /// <para>
-    /// Channels are resolved by name from the service provider (registered via
-    /// <see cref="MessagingBuilder.AddConnector{TConnector}(string, Action{ChannelConnectorBuilder{TConnector}})"/>
-    /// or through runtime overloads that accept connection settings directly.
-    /// </para>
-    /// </remarks>
     public interface IMessagingClient : IDisposable, IAsyncDisposable
     {
         /// <summary>
-        /// Sends a message through the specified named channel.
+        /// Sends a message through the specified channel.
         /// </summary>
-        /// <param name="channelName">
-        /// The name of the channel to send the message through, as registered
-        /// at startup with <c>AddConnector&lt;T&gt;(name, ...)</c>.
-        /// </param>
-        /// <param name="message">The message to send.</param>
+        /// <param name="request">The send request containing the message and optional context.</param>
         /// <param name="cancellationToken">
         /// A token that can be used to cancel the operation.
         /// </param>
@@ -28,38 +17,25 @@ namespace Ratatosk
         /// Returns an <see cref="OperationResult{SendResult}"/> that indicates
         /// whether the send succeeded and carries the result details.
         /// </returns>
-        Task<OperationResult<SendResult>> SendAsync(string channelName, IMessage message, CancellationToken cancellationToken = default);
+        Task<OperationResult<SendResult>> SendAsync(SendRequest request, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Sends a message through a dynamically resolved channel, using
-        /// runtime-provided connection settings.
+        /// Sends a batch of messages through the specified channel.
         /// </summary>
-        /// <param name="channelName">
-        /// The name of the channel type to use, as registered via
-        /// <c>AddConnectorType&lt;T&gt;(name)</c>.
-        /// </param>
-        /// <param name="settings">
-        /// The connection settings to use for creating the connector at runtime.
-        /// </param>
-        /// <param name="message">The message to send.</param>
+        /// <param name="request">The batch send request containing the batch and optional context.</param>
         /// <param name="cancellationToken">
         /// A token that can be used to cancel the operation.
         /// </param>
         /// <returns>
-        /// Returns an <see cref="OperationResult{SendResult}"/> that indicates
-        /// whether the send succeeded and carries the result details.
+        /// Returns an <see cref="OperationResult{BatchSendResult}"/> that indicates
+        /// whether the batch send succeeded and carries the result details.
         /// </returns>
-        Task<OperationResult<SendResult>> SendAsync(string channelName, ConnectionSettings settings, IMessage message, CancellationToken cancellationToken = default);
+        Task<OperationResult<BatchSendResult>> SendBatchAsync(BatchSendRequest request, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Receives messages from the specified named channel.
+        /// Receives messages from the specified channel.
         /// </summary>
-        /// <param name="channelName">
-        /// The name of the channel to receive messages from.
-        /// </param>
-        /// <param name="source">
-        /// The source containing the raw payload to parse into messages.
-        /// </param>
+        /// <param name="request">The receive request containing the source and optional context.</param>
         /// <param name="cancellationToken">
         /// A token that can be used to cancel the operation.
         /// </param>
@@ -67,76 +43,26 @@ namespace Ratatosk
         /// Returns an <see cref="OperationResult{ReceiveResult}"/> containing
         /// the parsed messages.
         /// </returns>
-        Task<OperationResult<ReceiveResult>> ReceiveAsync(string channelName, MessageSource source, CancellationToken cancellationToken = default);
+        Task<OperationResult<ReceiveResult>> ReceiveAsync(ReceiveRequest request, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Receives messages from a dynamically resolved channel, using
-        /// runtime-provided connection settings.
+        /// Gets the current operational status of the specified channel.
         /// </summary>
-        /// <param name="channelName">
-        /// The name of the channel type to use, as registered via
-        /// <c>AddConnectorType&lt;T&gt;(name)</c>.
-        /// </param>
-        /// <param name="settings">
-        /// The connection settings to use for creating the connector at runtime.
-        /// </param>
-        /// <param name="source">
-        /// The source containing the raw payload to parse into messages.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A token that can be used to cancel the operation.
-        /// </param>
-        /// <returns>
-        /// Returns an <see cref="OperationResult{ReceiveResult}"/> containing
-        /// the parsed messages.
-        /// </returns>
-        Task<OperationResult<ReceiveResult>> ReceiveAsync(string channelName, ConnectionSettings settings, MessageSource source, CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Gets the current operational status of the specified named channel.
-        /// </summary>
-        /// <param name="channelName">
-        /// The name of the channel to query.
-        /// </param>
+        /// <param name="request">The status request containing the channel name and optional context.</param>
         /// <param name="cancellationToken">
         /// A token that can be used to cancel the operation.
         /// </param>
         /// <returns>
         /// Returns an <see cref="OperationResult{StatusInfo}"/> containing
-        /// the connector's status information.
+        /// the channel's status information.
         /// </returns>
-        Task<OperationResult<StatusInfo>> GetStatusAsync(string channelName, CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Gets the status of a dynamically resolved channel, using
-        /// runtime-provided connection settings.
-        /// </summary>
-        /// <param name="channelName">
-        /// The name of the channel type to use, as registered via
-        /// <c>AddConnectorType&lt;T&gt;(name)</c>.
-        /// </param>
-        /// <param name="settings">
-        /// The connection settings to use for creating the connector at runtime.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A token that can be used to cancel the operation.
-        /// </param>
-        /// <returns>
-        /// Returns an <see cref="OperationResult{StatusInfo}"/> containing
-        /// the connector's status information.
-        /// </returns>
-        Task<OperationResult<StatusInfo>> GetStatusAsync(string channelName, ConnectionSettings settings, CancellationToken cancellationToken = default);
+        Task<OperationResult<StatusInfo>> GetStatusAsync(StatusRequest request, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Receives a status update (e.g., delivery receipt) for a message
-        /// sent through the specified named channel.
+        /// sent through the specified channel.
         /// </summary>
-        /// <param name="channelName">
-        /// The name of the channel that received the status callback.
-        /// </param>
-        /// <param name="source">
-        /// The source containing the raw status callback payload.
-        /// </param>
+        /// <param name="request">The receive status request containing the source and optional context.</param>
         /// <param name="cancellationToken">
         /// A token that can be used to cancel the operation.
         /// </param>
@@ -144,197 +70,6 @@ namespace Ratatosk
         /// Returns an <see cref="OperationResult{StatusUpdateResult}"/> containing
         /// the parsed status update.
         /// </returns>
-        Task<OperationResult<StatusUpdateResult>> ReceiveMessageStatusAsync(string channelName, MessageSource source, CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Receives a status update for a dynamically resolved channel, using
-        /// runtime-provided connection settings.
-        /// </summary>
-        /// <param name="channelName">
-        /// The name of the channel type to use, as registered via
-        /// <c>AddConnectorType&lt;T&gt;(name)</c>.
-        /// </param>
-        /// <param name="settings">
-        /// The connection settings to use for creating the connector at runtime.
-        /// </param>
-        /// <param name="source">
-        /// The source containing the raw status callback payload.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A token that can be used to cancel the operation.
-        /// </param>
-        /// <returns>
-        /// Returns an <see cref="OperationResult{StatusUpdateResult}"/> containing
-        /// the parsed status update.
-        /// </returns>
-        Task<OperationResult<StatusUpdateResult>> ReceiveMessageStatusAsync(string channelName, ConnectionSettings settings, MessageSource source, CancellationToken cancellationToken = default);
-
-        // ── Type-parameterized overloads ─────────────────────────────────────
-
-        /// <summary>
-        /// Sends a message through the channel connector of the specified type,
-        /// resolved from the dependency injection container.
-        /// </summary>
-        /// <typeparam name="TConnector">
-        /// The type of the connector to use, as registered via
-        /// <c>AddConnector&lt;TConnector&gt;()</c>.
-        /// </typeparam>
-        /// <param name="message">The message to send.</param>
-        /// <param name="cancellationToken">
-        /// A token that can be used to cancel the operation.
-        /// </param>
-        /// <returns>
-        /// Returns an <see cref="OperationResult{SendResult}"/> that indicates
-        /// whether the send succeeded and carries the result details.
-        /// </returns>
-        Task<OperationResult<SendResult>> SendAsync<TConnector>(IMessage message, CancellationToken cancellationToken = default)
-            where TConnector : class, IChannelConnector;
-
-        /// <summary>
-        /// Sends a message through a dynamically created connector of the
-        /// specified type, using runtime-provided connection settings.
-        /// </summary>
-        /// <typeparam name="TConnector">
-        /// The type of the connector to create at runtime.
-        /// </typeparam>
-        /// <param name="settings">
-        /// The connection settings to use for creating the connector.
-        /// </param>
-        /// <param name="message">The message to send.</param>
-        /// <param name="cancellationToken">
-        /// A token that can be used to cancel the operation.
-        /// </param>
-        /// <returns>
-        /// Returns an <see cref="OperationResult{SendResult}"/> that indicates
-        /// whether the send succeeded and carries the result details.
-        /// </returns>
-        Task<OperationResult<SendResult>> SendAsync<TConnector>(ConnectionSettings settings, IMessage message, CancellationToken cancellationToken = default)
-            where TConnector : class, IChannelConnector;
-
-        /// <summary>
-        /// Receives messages from the channel connector of the specified type,
-        /// resolved from the dependency injection container.
-        /// </summary>
-        /// <typeparam name="TConnector">
-        /// The type of the connector to use, as registered via
-        /// <c>AddConnector&lt;TConnector&gt;()</c>.
-        /// </typeparam>
-        /// <param name="source">
-        /// The source containing the raw payload to parse into messages.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A token that can be used to cancel the operation.
-        /// </param>
-        /// <returns>
-        /// Returns an <see cref="OperationResult{ReceiveResult}"/> containing
-        /// the parsed messages.
-        /// </returns>
-        Task<OperationResult<ReceiveResult>> ReceiveAsync<TConnector>(MessageSource source, CancellationToken cancellationToken = default)
-            where TConnector : class, IChannelConnector;
-
-        /// <summary>
-        /// Receives messages from a dynamically created connector of the
-        /// specified type, using runtime-provided connection settings.
-        /// </summary>
-        /// <typeparam name="TConnector">
-        /// The type of the connector to create at runtime.
-        /// </typeparam>
-        /// <param name="settings">
-        /// The connection settings to use for creating the connector.
-        /// </param>
-        /// <param name="source">
-        /// The source containing the raw payload to parse into messages.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A token that can be used to cancel the operation.
-        /// </param>
-        /// <returns>
-        /// Returns an <see cref="OperationResult{ReceiveResult}"/> containing
-        /// the parsed messages.
-        /// </returns>
-        Task<OperationResult<ReceiveResult>> ReceiveAsync<TConnector>(ConnectionSettings settings, MessageSource source, CancellationToken cancellationToken = default)
-            where TConnector : class, IChannelConnector;
-
-        /// <summary>
-        /// Gets the status of the channel connector of the specified type,
-        /// resolved from the dependency injection container.
-        /// </summary>
-        /// <typeparam name="TConnector">
-        /// The type of the connector to use, as registered via
-        /// <c>AddConnector&lt;TConnector&gt;()</c>.
-        /// </typeparam>
-        /// <param name="cancellationToken">
-        /// A token that can be used to cancel the operation.
-        /// </param>
-        /// <returns>
-        /// Returns an <see cref="OperationResult{StatusInfo}"/> containing
-        /// the connector's status information.
-        /// </returns>
-        Task<OperationResult<StatusInfo>> GetStatusAsync<TConnector>(CancellationToken cancellationToken = default)
-            where TConnector : class, IChannelConnector;
-
-        /// <summary>
-        /// Gets the status of a dynamically created connector of the
-        /// specified type, using runtime-provided connection settings.
-        /// </summary>
-        /// <typeparam name="TConnector">
-        /// The type of the connector to create at runtime.
-        /// </typeparam>
-        /// <param name="settings">
-        /// The connection settings to use for creating the connector.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A token that can be used to cancel the operation.
-        /// </param>
-        /// <returns>
-        /// Returns an <see cref="OperationResult{StatusInfo}"/> containing
-        /// the connector's status information.
-        /// </returns>
-        Task<OperationResult<StatusInfo>> GetStatusAsync<TConnector>(ConnectionSettings settings, CancellationToken cancellationToken = default)
-            where TConnector : class, IChannelConnector;
-
-        /// <summary>
-        /// Receives a message status update using the channel connector of the
-        /// specified type, resolved from the dependency injection container.
-        /// </summary>
-        /// <typeparam name="TConnector">
-        /// The type of the connector to use, as registered via
-        /// <c>AddConnector&lt;TConnector&gt;()</c>.
-        /// </typeparam>
-        /// <param name="source">
-        /// The source containing the raw status callback payload.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A token that can be used to cancel the operation.
-        /// </param>
-        /// <returns>
-        /// Returns an <see cref="OperationResult{StatusUpdateResult}"/> containing
-        /// the parsed status update.
-        /// </returns>
-        Task<OperationResult<StatusUpdateResult>> ReceiveMessageStatusAsync<TConnector>(MessageSource source, CancellationToken cancellationToken = default)
-            where TConnector : class, IChannelConnector;
-
-        /// <summary>
-        /// Receives a message status update from a dynamically created connector
-        /// of the specified type, using runtime-provided connection settings.
-        /// </summary>
-        /// <typeparam name="TConnector">
-        /// The type of the connector to create at runtime.
-        /// </typeparam>
-        /// <param name="settings">
-        /// The connection settings to use for creating the connector.
-        /// </param>
-        /// <param name="source">
-        /// The source containing the raw status callback payload.
-        /// </param>
-        /// <param name="cancellationToken">
-        /// A token that can be used to cancel the operation.
-        /// </param>
-        /// <returns>
-        /// Returns an <see cref="OperationResult{StatusUpdateResult}"/> containing
-        /// the parsed status update.
-        /// </returns>
-        Task<OperationResult<StatusUpdateResult>> ReceiveMessageStatusAsync<TConnector>(ConnectionSettings settings, MessageSource source, CancellationToken cancellationToken = default)
-            where TConnector : class, IChannelConnector;
+        Task<OperationResult<StatusUpdateResult>> ReceiveMessageStatusAsync(ReceiveStatusRequest request, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Ratatosk/MessageContext.cs
+++ b/src/Ratatosk/MessageContext.cs
@@ -1,0 +1,41 @@
+namespace Ratatosk;
+
+public class MessageContext
+{
+    public IDictionary<string, object?> Data { get; }
+        = new Dictionary<string, object?>(StringComparer.OrdinalIgnoreCase);
+
+    public MessageContext()
+    {
+    }
+
+    public MessageContext(params (string key, object? value)[] entries)
+    {
+        foreach (var (key, value) in entries)
+            this[key] = value;
+    }
+
+    public MessageContext With(string key, object? value)
+    {
+        ValidateKey(key);
+        Data[key] = value;
+        return this;
+    }
+
+    public object? this[string key]
+    {
+        get => Data.TryGetValue(key, out var v) ? v : null;
+        set
+        {
+            ValidateKey(key);
+            Data[key] = value;
+        }
+    }
+
+    public static void ValidateKey(string key)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        if (key.Contains(' '))
+            throw new ArgumentException($"Key '{key}' must not contain spaces.", nameof(key));
+    }
+}

--- a/src/Ratatosk/MessagingClient.cs
+++ b/src/Ratatosk/MessagingClient.cs
@@ -2,6 +2,8 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
+using System.Diagnostics;
+
 namespace Ratatosk
 {
     /// <summary>
@@ -21,6 +23,7 @@ namespace Ratatosk
         private readonly SemaphoreSlim _lock = new(1, 1);
         private readonly List<IChannelConnector> _runtimeConnectors = new();
         private readonly object _runtimeLock = new();
+        private readonly ClientTelemetry _clientTelemetry;
 
         /// <summary>
         /// Constructs a new <see cref="MessagingClient"/> instance.
@@ -37,6 +40,7 @@ namespace Ratatosk
             _logger = logger ?? NullLogger<MessagingClient>.Instance;
             _resolver = resolver;
             _catalog = catalog;
+            _clientTelemetry = new ClientTelemetry(_options.Telemetry);
         }
 
         /// <inheritdoc/>
@@ -44,17 +48,35 @@ namespace Ratatosk
         {
             _logger.LogSendingMessage(channelName);
 
+            using var activity = _clientTelemetry.StartSendActivity(channelName, message.Id);
+            var sw = Stopwatch.StartNew();
+
             var connector = await ResolveConnectorAsync(channelName, cancellationToken);
             if (connector == null)
+            {
+                sw.Stop();
+                _clientTelemetry.RecordSendFailure(sw.ElapsedMilliseconds);
+                activity?.SetStatus(ActivityStatusCode.Error, "Connector not found");
                 return OperationResult<SendResult>.Fail(MessagingErrorCodes.ConnectorNotFound, MessagingErrorCodes.ErrorDomain, $"No connector registered for channel '{channelName}'.");
+            }
 
             await ResolveSenderAsync(message, connector.ConnectionSettings, cancellationToken);
 
             var result = await connector.SendMessageAsync(message, cancellationToken);
+            sw.Stop();
+
             if (result.IsSuccess())
+            {
+                _clientTelemetry.RecordSendSuccess(sw.ElapsedMilliseconds);
+                activity?.SetStatus(ActivityStatusCode.Ok);
                 _logger.LogMessageSent(channelName);
+            }
             else
+            {
+                _clientTelemetry.RecordSendFailure(sw.ElapsedMilliseconds);
+                activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
                 _logger.LogMessageSendFailed(channelName, result.Error?.Message);
+            }
 
             return result;
         }
@@ -64,15 +86,30 @@ namespace Ratatosk
         {
             _logger.LogReceivingMessage(channelName);
 
+            using var activity = _clientTelemetry.StartReceiveActivity(channelName);
+            var sw = Stopwatch.StartNew();
+
             var connector = await ResolveConnectorAsync(channelName, cancellationToken);
             if (connector == null)
+            {
+                sw.Stop();
+                activity?.SetStatus(ActivityStatusCode.Error, "Connector not found");
                 return OperationResult<ReceiveResult>.Fail(MessagingErrorCodes.ConnectorNotFound, MessagingErrorCodes.ErrorDomain, $"No connector registered for channel '{channelName}'.");
+            }
 
             var result = await connector.ReceiveMessagesAsync(source, cancellationToken);
+            sw.Stop();
+
             if (result.IsSuccess())
+            {
+                activity?.SetStatus(ActivityStatusCode.Ok);
                 _logger.LogMessageReceived(channelName);
+            }
             else
+            {
+                activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
                 _logger.LogMessageReceiveFailed(channelName, result.Error?.Message);
+            }
 
             return result;
         }
@@ -82,15 +119,26 @@ namespace Ratatosk
         {
             _logger.LogReadingStatus(channelName);
 
+            using var activity = _clientTelemetry.StartStatusActivity(channelName);
+
             var connector = await ResolveConnectorAsync(channelName, cancellationToken);
             if (connector == null)
+            {
+                activity?.SetStatus(ActivityStatusCode.Error, "Connector not found");
                 return OperationResult<StatusInfo>.Fail(MessagingErrorCodes.ConnectorNotFound, MessagingErrorCodes.ErrorDomain, $"No connector registered for channel '{channelName}'.");
+            }
 
             var result = await connector.GetStatusAsync(cancellationToken);
             if (result.IsSuccess())
+            {
+                activity?.SetStatus(ActivityStatusCode.Ok);
                 _logger.LogStatusRead(channelName);
+            }
             else
+            {
+                activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
                 _logger.LogStatusReadFailed(channelName, result.Error?.Message);
+            }
 
             return result;
         }
@@ -100,15 +148,26 @@ namespace Ratatosk
         {
             _logger.LogReceivingMessageStatus(channelName);
 
+            using var activity = _clientTelemetry.StartReceiveActivity(channelName);
+
             var connector = await ResolveConnectorAsync(channelName, cancellationToken);
             if (connector == null)
+            {
+                activity?.SetStatus(ActivityStatusCode.Error, "Connector not found");
                 return OperationResult<StatusUpdateResult>.Fail(MessagingErrorCodes.ConnectorNotFound, MessagingErrorCodes.ErrorDomain, $"No connector registered for channel '{channelName}'.");
+            }
 
             var result = await connector.ReceiveMessageStatusAsync(source, cancellationToken);
             if (result.IsSuccess())
+            {
+                activity?.SetStatus(ActivityStatusCode.Ok);
                 _logger.LogMessageStatusReceived(channelName);
+            }
             else
+            {
+                activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
                 _logger.LogMessageStatusReceiveFailed(channelName, result.Error?.Message);
+            }
 
             return result;
         }
@@ -556,6 +615,7 @@ namespace Ratatosk
             }
 
             _lock.Dispose();
+            _clientTelemetry.Dispose();
         }
 
         /// <inheritdoc/>
@@ -585,6 +645,7 @@ namespace Ratatosk
             }
 
             _lock.Dispose();
+            _clientTelemetry.Dispose();
         }
     }
 }

--- a/src/Ratatosk/MessagingClient.cs
+++ b/src/Ratatosk/MessagingClient.cs
@@ -145,7 +145,7 @@ namespace Ratatosk
         {
             _logger.LogReceivingMessageStatus(channelName);
 
-            using var activity = _clientTelemetry.StartReceiveActivity(channelName);
+            using var activity = _clientTelemetry.StartReceiveStatusActivity(channelName);
 
             var connector = await ResolveConnectorAsync(channelName, cancellationToken);
             if (connector == null)
@@ -177,17 +177,35 @@ namespace Ratatosk
         {
             var channelName = typeof(TConnector).Name;
 
+            using var activity = _clientTelemetry.StartSendActivity(channelName, message.Id);
+            var sw = Stopwatch.StartNew();
+
             var connector = await ResolveConnectorAsync<TConnector>(cancellationToken);
             if (connector == null)
+            {
+                sw.Stop();
+                _clientTelemetry.RecordSendFailure(sw.ElapsedMilliseconds);
+                activity?.SetStatus(ActivityStatusCode.Error, "Connector not found");
                 return OperationResult<SendResult>.Fail(MessagingErrorCodes.ConnectorNotFound, MessagingErrorCodes.ErrorDomain, $"No connector registered for type '{channelName}'.");
+            }
 
             await ResolveSenderAsync(message, connector.ConnectionSettings, cancellationToken);
 
             var result = await connector.SendMessageAsync(message, cancellationToken);
+            sw.Stop();
+
             if (result.IsSuccess())
+            {
+                _clientTelemetry.RecordSendSuccess(sw.ElapsedMilliseconds);
+                activity?.SetStatus(ActivityStatusCode.Ok);
                 _logger.LogMessageSent(channelName);
+            }
             else
+            {
+                _clientTelemetry.RecordSendFailure(sw.ElapsedMilliseconds);
+                activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
                 _logger.LogMessageSendFailed(channelName, result.Error?.Message);
+            }
 
             return result;
         }
@@ -198,15 +216,26 @@ namespace Ratatosk
         {
             var channelName = typeof(TConnector).Name;
 
+            using var activity = _clientTelemetry.StartReceiveActivity(channelName);
+
             var connector = await ResolveConnectorAsync<TConnector>(cancellationToken);
             if (connector == null)
+            {
+                activity?.SetStatus(ActivityStatusCode.Error, "Connector not found");
                 return OperationResult<ReceiveResult>.Fail(MessagingErrorCodes.ConnectorNotFound, MessagingErrorCodes.ErrorDomain, $"No connector registered for type '{channelName}'.");
+            }
 
             var result = await connector.ReceiveMessagesAsync(source, cancellationToken);
             if (result.IsSuccess())
+            {
+                activity?.SetStatus(ActivityStatusCode.Ok);
                 _logger.LogMessageReceived(channelName);
+            }
             else
+            {
+                activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
                 _logger.LogMessageReceiveFailed(channelName, result.Error?.Message);
+            }
 
             return result;
         }
@@ -217,15 +246,26 @@ namespace Ratatosk
         {
             var channelName = typeof(TConnector).Name;
 
+            using var activity = _clientTelemetry.StartStatusActivity(channelName);
+
             var connector = await ResolveConnectorAsync<TConnector>(cancellationToken);
             if (connector == null)
+            {
+                activity?.SetStatus(ActivityStatusCode.Error, "Connector not found");
                 return OperationResult<StatusInfo>.Fail(MessagingErrorCodes.ConnectorNotFound, MessagingErrorCodes.ErrorDomain, $"No connector registered for type '{channelName}'.");
+            }
 
             var result = await connector.GetStatusAsync(cancellationToken);
             if (result.IsSuccess())
+            {
+                activity?.SetStatus(ActivityStatusCode.Ok);
                 _logger.LogStatusRead(channelName);
+            }
             else
+            {
+                activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
                 _logger.LogStatusReadFailed(channelName, result.Error?.Message);
+            }
 
             return result;
         }
@@ -236,15 +276,26 @@ namespace Ratatosk
         {
             var channelName = typeof(TConnector).Name;
 
+            using var activity = _clientTelemetry.StartReceiveStatusActivity(channelName);
+
             var connector = await ResolveConnectorAsync<TConnector>(cancellationToken);
             if (connector == null)
+            {
+                activity?.SetStatus(ActivityStatusCode.Error, "Connector not found");
                 return OperationResult<StatusUpdateResult>.Fail(MessagingErrorCodes.ConnectorNotFound, MessagingErrorCodes.ErrorDomain, $"No connector registered for type '{channelName}'.");
+            }
 
             var result = await connector.ReceiveMessageStatusAsync(source, cancellationToken);
             if (result.IsSuccess())
+            {
+                activity?.SetStatus(ActivityStatusCode.Ok);
                 _logger.LogMessageStatusReceived(channelName);
+            }
             else
+            {
+                activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
                 _logger.LogMessageStatusReceiveFailed(channelName, result.Error?.Message);
+            }
 
             return result;
         }
@@ -256,17 +307,35 @@ namespace Ratatosk
         {
             _logger.LogSendingMessage(channelName);
 
+            using var activity = _clientTelemetry.StartSendActivity(channelName, message.Id);
+            var sw = Stopwatch.StartNew();
+
             var connector = await CreateRuntimeConnectorAsync(channelName, settings, cancellationToken);
             if (connector == null)
+            {
+                sw.Stop();
+                _clientTelemetry.RecordSendFailure(sw.ElapsedMilliseconds);
+                activity?.SetStatus(ActivityStatusCode.Error, "Connector not found");
                 return OperationResult<SendResult>.Fail(MessagingErrorCodes.ConnectorNotFound, MessagingErrorCodes.ErrorDomain, $"No connector type registered for channel '{channelName}'.");
+            }
 
             await ResolveSenderAsync(message, settings, cancellationToken);
 
             var result = await connector.SendMessageAsync(message, cancellationToken);
+            sw.Stop();
+
             if (result.IsSuccess())
+            {
+                _clientTelemetry.RecordSendSuccess(sw.ElapsedMilliseconds);
+                activity?.SetStatus(ActivityStatusCode.Ok);
                 _logger.LogMessageSent(channelName);
+            }
             else
+            {
+                _clientTelemetry.RecordSendFailure(sw.ElapsedMilliseconds);
+                activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
                 _logger.LogMessageSendFailed(channelName, result.Error?.Message);
+            }
 
             return result;
         }
@@ -276,15 +345,26 @@ namespace Ratatosk
         {
             _logger.LogReceivingMessage(channelName);
 
+            using var activity = _clientTelemetry.StartReceiveActivity(channelName);
+
             var connector = await CreateRuntimeConnectorAsync(channelName, settings, cancellationToken);
             if (connector == null)
+            {
+                activity?.SetStatus(ActivityStatusCode.Error, "Connector not found");
                 return OperationResult<ReceiveResult>.Fail(MessagingErrorCodes.ConnectorNotFound, MessagingErrorCodes.ErrorDomain, $"No connector type registered for channel '{channelName}'.");
+            }
 
             var result = await connector.ReceiveMessagesAsync(source, cancellationToken);
             if (result.IsSuccess())
+            {
+                activity?.SetStatus(ActivityStatusCode.Ok);
                 _logger.LogMessageReceived(channelName);
+            }
             else
+            {
+                activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
                 _logger.LogMessageReceiveFailed(channelName, result.Error?.Message);
+            }
 
             return result;
         }
@@ -294,15 +374,26 @@ namespace Ratatosk
         {
             _logger.LogReadingStatus(channelName);
 
+            using var activity = _clientTelemetry.StartStatusActivity(channelName);
+
             var connector = await CreateRuntimeConnectorAsync(channelName, settings, cancellationToken);
             if (connector == null)
+            {
+                activity?.SetStatus(ActivityStatusCode.Error, "Connector not found");
                 return OperationResult<StatusInfo>.Fail(MessagingErrorCodes.ConnectorNotFound, MessagingErrorCodes.ErrorDomain, $"No connector type registered for channel '{channelName}'.");
+            }
 
             var result = await connector.GetStatusAsync(cancellationToken);
             if (result.IsSuccess())
+            {
+                activity?.SetStatus(ActivityStatusCode.Ok);
                 _logger.LogStatusRead(channelName);
+            }
             else
+            {
+                activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
                 _logger.LogStatusReadFailed(channelName, result.Error?.Message);
+            }
 
             return result;
         }
@@ -312,15 +403,26 @@ namespace Ratatosk
         {
             _logger.LogReceivingMessageStatus(channelName);
 
+            using var activity = _clientTelemetry.StartReceiveStatusActivity(channelName);
+
             var connector = await CreateRuntimeConnectorAsync(channelName, settings, cancellationToken);
             if (connector == null)
+            {
+                activity?.SetStatus(ActivityStatusCode.Error, "Connector not found");
                 return OperationResult<StatusUpdateResult>.Fail(MessagingErrorCodes.ConnectorNotFound, MessagingErrorCodes.ErrorDomain, $"No connector type registered for channel '{channelName}'.");
+            }
 
             var result = await connector.ReceiveMessageStatusAsync(source, cancellationToken);
             if (result.IsSuccess())
+            {
+                activity?.SetStatus(ActivityStatusCode.Ok);
                 _logger.LogMessageStatusReceived(channelName);
+            }
             else
+            {
+                activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
                 _logger.LogMessageStatusReceiveFailed(channelName, result.Error?.Message);
+            }
 
             return result;
         }
@@ -333,17 +435,35 @@ namespace Ratatosk
         {
             var channelName = typeof(TConnector).Name;
 
+            using var activity = _clientTelemetry.StartSendActivity(channelName, message.Id);
+            var sw = Stopwatch.StartNew();
+
             var connector = await CreateRuntimeConnectorAsync<TConnector>(settings, cancellationToken);
             if (connector == null)
+            {
+                sw.Stop();
+                _clientTelemetry.RecordSendFailure(sw.ElapsedMilliseconds);
+                activity?.SetStatus(ActivityStatusCode.Error, "Connector not found");
                 return OperationResult<SendResult>.Fail(MessagingErrorCodes.ConnectorNotFound, MessagingErrorCodes.ErrorDomain, $"No connector type registered for '{channelName}'.");
+            }
 
             await ResolveSenderAsync(message, settings, cancellationToken);
 
             var result = await connector.SendMessageAsync(message, cancellationToken);
+            sw.Stop();
+
             if (result.IsSuccess())
+            {
+                _clientTelemetry.RecordSendSuccess(sw.ElapsedMilliseconds);
+                activity?.SetStatus(ActivityStatusCode.Ok);
                 _logger.LogMessageSent(channelName);
+            }
             else
+            {
+                _clientTelemetry.RecordSendFailure(sw.ElapsedMilliseconds);
+                activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
                 _logger.LogMessageSendFailed(channelName, result.Error?.Message);
+            }
 
             return result;
         }
@@ -354,15 +474,26 @@ namespace Ratatosk
         {
             var channelName = typeof(TConnector).Name;
 
+            using var activity = _clientTelemetry.StartReceiveActivity(channelName);
+
             var connector = await CreateRuntimeConnectorAsync<TConnector>(settings, cancellationToken);
             if (connector == null)
+            {
+                activity?.SetStatus(ActivityStatusCode.Error, "Connector not found");
                 return OperationResult<ReceiveResult>.Fail(MessagingErrorCodes.ConnectorNotFound, MessagingErrorCodes.ErrorDomain, $"No connector type registered for '{channelName}'.");
+            }
 
             var result = await connector.ReceiveMessagesAsync(source, cancellationToken);
             if (result.IsSuccess())
+            {
+                activity?.SetStatus(ActivityStatusCode.Ok);
                 _logger.LogMessageReceived(channelName);
+            }
             else
+            {
+                activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
                 _logger.LogMessageReceiveFailed(channelName, result.Error?.Message);
+            }
 
             return result;
         }
@@ -373,15 +504,26 @@ namespace Ratatosk
         {
             var channelName = typeof(TConnector).Name;
 
+            using var activity = _clientTelemetry.StartStatusActivity(channelName);
+
             var connector = await CreateRuntimeConnectorAsync<TConnector>(settings, cancellationToken);
             if (connector == null)
+            {
+                activity?.SetStatus(ActivityStatusCode.Error, "Connector not found");
                 return OperationResult<StatusInfo>.Fail(MessagingErrorCodes.ConnectorNotFound, MessagingErrorCodes.ErrorDomain, $"No connector type registered for '{channelName}'.");
+            }
 
             var result = await connector.GetStatusAsync(cancellationToken);
             if (result.IsSuccess())
+            {
+                activity?.SetStatus(ActivityStatusCode.Ok);
                 _logger.LogStatusRead(channelName);
+            }
             else
+            {
+                activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
                 _logger.LogStatusReadFailed(channelName, result.Error?.Message);
+            }
 
             return result;
         }
@@ -392,15 +534,26 @@ namespace Ratatosk
         {
             var channelName = typeof(TConnector).Name;
 
+            using var activity = _clientTelemetry.StartReceiveStatusActivity(channelName);
+
             var connector = await CreateRuntimeConnectorAsync<TConnector>(settings, cancellationToken);
             if (connector == null)
+            {
+                activity?.SetStatus(ActivityStatusCode.Error, "Connector not found");
                 return OperationResult<StatusUpdateResult>.Fail(MessagingErrorCodes.ConnectorNotFound, MessagingErrorCodes.ErrorDomain, $"No connector type registered for '{channelName}'.");
+            }
 
             var result = await connector.ReceiveMessageStatusAsync(source, cancellationToken);
             if (result.IsSuccess())
+            {
+                activity?.SetStatus(ActivityStatusCode.Ok);
                 _logger.LogMessageStatusReceived(channelName);
+            }
             else
+            {
+                activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
                 _logger.LogMessageStatusReceiveFailed(channelName, result.Error?.Message);
+            }
 
             return result;
         }

--- a/src/Ratatosk/MessagingClient.cs
+++ b/src/Ratatosk/MessagingClient.cs
@@ -87,18 +87,15 @@ namespace Ratatosk
             _logger.LogReceivingMessage(channelName);
 
             using var activity = _clientTelemetry.StartReceiveActivity(channelName);
-            var sw = Stopwatch.StartNew();
 
             var connector = await ResolveConnectorAsync(channelName, cancellationToken);
             if (connector == null)
             {
-                sw.Stop();
                 activity?.SetStatus(ActivityStatusCode.Error, "Connector not found");
                 return OperationResult<ReceiveResult>.Fail(MessagingErrorCodes.ConnectorNotFound, MessagingErrorCodes.ErrorDomain, $"No connector registered for channel '{channelName}'.");
             }
 
             var result = await connector.ReceiveMessagesAsync(source, cancellationToken);
-            sw.Stop();
 
             if (result.IsSuccess())
             {

--- a/src/Ratatosk/MessagingClient.cs
+++ b/src/Ratatosk/MessagingClient.cs
@@ -6,11 +6,6 @@ using System.Diagnostics;
 
 namespace Ratatosk
 {
-    /// <summary>
-    /// Default implementation of <see cref="IMessagingClient"/> that resolves
-    /// channel connectors from the dependency injection container and manages
-    /// their initialization and lifecycle.
-    /// </summary>
     public class MessagingClient : IMessagingClient
     {
         private readonly IServiceProvider _serviceProvider;
@@ -25,9 +20,6 @@ namespace Ratatosk
         private readonly object _runtimeLock = new();
         private readonly ClientTelemetry _clientTelemetry;
 
-        /// <summary>
-        /// Constructs a new <see cref="MessagingClient"/> instance.
-        /// </summary>
         public MessagingClient(
             IServiceProvider serviceProvider,
             MessagingClientOptions? options = null,
@@ -43,15 +35,20 @@ namespace Ratatosk
             _clientTelemetry = new ClientTelemetry(_options.Telemetry);
         }
 
-        /// <inheritdoc/>
-        public async Task<OperationResult<SendResult>> SendAsync(string channelName, IMessage message, CancellationToken cancellationToken = default)
+        // ── Core methods ──────────────────────────────────────────────────────
+
+        public async Task<OperationResult<SendResult>> SendAsync(SendRequest request, CancellationToken cancellationToken = default)
         {
+            var channelName = request.ChannelName;
+            var message = request.Message;
+
             _logger.LogSendingMessage(channelName);
 
-            using var activity = _clientTelemetry.StartSendActivity(channelName, message.Id);
+            using var scope = BeginContextScope(request.Context);
+            using var activity = _clientTelemetry.StartSendActivity(channelName, message.Id, request.Context);
             var sw = Stopwatch.StartNew();
 
-            var connector = await ResolveConnectorAsync(channelName, cancellationToken);
+            var connector = await ResolveConnectorAsync(request.ConnectorType, channelName, request.ConnectionSettings, cancellationToken);
             if (connector == null)
             {
                 sw.Stop();
@@ -61,6 +58,7 @@ namespace Ratatosk
             }
 
             await ResolveSenderAsync(message, connector.ConnectionSettings, cancellationToken);
+            StampMessageContext(message, request.Context);
 
             try
             {
@@ -91,15 +89,66 @@ namespace Ratatosk
             }
         }
 
-        /// <inheritdoc/>
-        public async Task<OperationResult<ReceiveResult>> ReceiveAsync(string channelName, MessageSource source, CancellationToken cancellationToken = default)
+        public async Task<OperationResult<BatchSendResult>> SendBatchAsync(BatchSendRequest request, CancellationToken cancellationToken = default)
         {
-            _logger.LogReceivingMessage(channelName);
+            var channelName = request.ChannelName;
+            var batch = request.Batch;
 
-            using var activity = _clientTelemetry.StartReceiveActivity(channelName);
+            _logger.LogSendingMessage(channelName);
+
+            using var scope = BeginContextScope(request.Context);
+            using var activity = _clientTelemetry.StartSendActivity(channelName, batch.Id, request.Context);
             var sw = Stopwatch.StartNew();
 
-            var connector = await ResolveConnectorAsync(channelName, cancellationToken);
+            var connector = await ResolveConnectorAsync(request.ConnectorType, channelName, request.ConnectionSettings, cancellationToken);
+            if (connector == null)
+            {
+                sw.Stop();
+                _clientTelemetry.RecordSendFailure(sw.ElapsedMilliseconds);
+                activity?.SetStatus(ActivityStatusCode.Error, "Connector not found");
+                return OperationResult<BatchSendResult>.Fail(MessagingErrorCodes.ConnectorNotFound, MessagingErrorCodes.ErrorDomain, $"No connector registered for channel '{channelName}'.");
+            }
+
+            try
+            {
+                var result = await connector.SendBatchAsync(batch, cancellationToken);
+                sw.Stop();
+
+                if (result.IsSuccess())
+                {
+                    _clientTelemetry.RecordSendSuccess(sw.ElapsedMilliseconds);
+                    activity?.SetStatus(ActivityStatusCode.Ok);
+                    _logger.LogMessageSent(channelName);
+                }
+                else
+                {
+                    _clientTelemetry.RecordSendFailure(sw.ElapsedMilliseconds);
+                    activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
+                    _logger.LogMessageSendFailed(channelName, result.Error?.Message);
+                }
+
+                return result;
+            }
+            catch (Exception ex)
+            {
+                sw.Stop();
+                _clientTelemetry.RecordSendFailure(sw.ElapsedMilliseconds);
+                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+                throw;
+            }
+        }
+
+        public async Task<OperationResult<ReceiveResult>> ReceiveAsync(ReceiveRequest request, CancellationToken cancellationToken = default)
+        {
+            var channelName = request.ChannelName;
+
+            _logger.LogReceivingMessage(channelName);
+
+            using var scope = BeginContextScope(request.Context);
+            using var activity = _clientTelemetry.StartReceiveActivity(channelName, request.Context);
+            var sw = Stopwatch.StartNew();
+
+            var connector = await ResolveConnectorAsync(request.ConnectorType, channelName, request.ConnectionSettings, cancellationToken);
             if (connector == null)
             {
                 sw.Stop();
@@ -110,7 +159,7 @@ namespace Ratatosk
 
             try
             {
-                var result = await connector.ReceiveMessagesAsync(source, cancellationToken);
+                var result = await connector.ReceiveMessagesAsync(request.Source, cancellationToken);
                 sw.Stop();
 
                 if (result.IsSuccess())
@@ -137,15 +186,17 @@ namespace Ratatosk
             }
         }
 
-        /// <inheritdoc/>
-        public async Task<OperationResult<StatusInfo>> GetStatusAsync(string channelName, CancellationToken cancellationToken = default)
+        public async Task<OperationResult<StatusInfo>> GetStatusAsync(StatusRequest request, CancellationToken cancellationToken = default)
         {
+            var channelName = request.ChannelName;
+
             _logger.LogReadingStatus(channelName);
 
-            using var activity = _clientTelemetry.StartStatusActivity(channelName);
+            using var scope = BeginContextScope(request.Context);
+            using var activity = _clientTelemetry.StartStatusActivity(channelName, request.Context);
             var sw = Stopwatch.StartNew();
 
-            var connector = await ResolveConnectorAsync(channelName, cancellationToken);
+            var connector = await ResolveConnectorAsync(request.ConnectorType, channelName, request.ConnectionSettings, cancellationToken);
             if (connector == null)
             {
                 sw.Stop();
@@ -183,15 +234,17 @@ namespace Ratatosk
             }
         }
 
-        /// <inheritdoc/>
-        public async Task<OperationResult<StatusUpdateResult>> ReceiveMessageStatusAsync(string channelName, MessageSource source, CancellationToken cancellationToken = default)
+        public async Task<OperationResult<StatusUpdateResult>> ReceiveMessageStatusAsync(ReceiveStatusRequest request, CancellationToken cancellationToken = default)
         {
+            var channelName = request.ChannelName;
+
             _logger.LogReceivingMessageStatus(channelName);
 
-            using var activity = _clientTelemetry.StartReceiveStatusActivity(channelName);
+            using var scope = BeginContextScope(request.Context);
+            using var activity = _clientTelemetry.StartReceiveStatusActivity(channelName, request.Context);
             var sw = Stopwatch.StartNew();
 
-            var connector = await ResolveConnectorAsync(channelName, cancellationToken);
+            var connector = await ResolveConnectorAsync(request.ConnectorType, channelName, request.ConnectionSettings, cancellationToken);
             if (connector == null)
             {
                 sw.Stop();
@@ -202,7 +255,7 @@ namespace Ratatosk
 
             try
             {
-                var result = await connector.ReceiveMessageStatusAsync(source, cancellationToken);
+                var result = await connector.ReceiveMessageStatusAsync(request.Source, cancellationToken);
                 sw.Stop();
 
                 if (result.IsSuccess())
@@ -229,718 +282,25 @@ namespace Ratatosk
             }
         }
 
-        // ── Type-parameterized standard overloads ────────────────────────────
+        // ── Connector resolution ──────────────────────────────────────────
 
-        /// <inheritdoc/>
-        public async Task<OperationResult<SendResult>> SendAsync<TConnector>(IMessage message, CancellationToken cancellationToken = default)
-            where TConnector : class, IChannelConnector
+        private async Task<IChannelConnector?> ResolveConnectorAsync(Type? connectorType, string channelName, ConnectionSettings? settings, CancellationToken cancellationToken)
         {
-            var channelName = typeof(TConnector).Name;
-
-            using var activity = _clientTelemetry.StartSendActivity(channelName, message.Id);
-            var sw = Stopwatch.StartNew();
-
-            var connector = await ResolveConnectorAsync<TConnector>(cancellationToken);
-            if (connector == null)
+            if (connectorType != null)
             {
-                sw.Stop();
-                _clientTelemetry.RecordSendFailure(sw.ElapsedMilliseconds);
-                activity?.SetStatus(ActivityStatusCode.Error, "Connector not found");
-                return OperationResult<SendResult>.Fail(MessagingErrorCodes.ConnectorNotFound, MessagingErrorCodes.ErrorDomain, $"No connector registered for type '{channelName}'.");
+                if (settings != null)
+                    return await CreateRuntimeConnectorAsync(connectorType, channelName, settings, cancellationToken);
+
+                return await ResolveConnectorByTypeAsync(channelName, connectorType, cancellationToken);
             }
 
-            await ResolveSenderAsync(message, connector.ConnectionSettings, cancellationToken);
+            if (settings != null)
+                return await CreateRuntimeConnectorAsync(channelName, settings, cancellationToken);
 
-            try
-            {
-                var result = await connector.SendMessageAsync(message, cancellationToken);
-                sw.Stop();
-
-                if (result.IsSuccess())
-                {
-                    _clientTelemetry.RecordSendSuccess(sw.ElapsedMilliseconds);
-                    activity?.SetStatus(ActivityStatusCode.Ok);
-                    _logger.LogMessageSent(channelName);
-                }
-                else
-                {
-                    _clientTelemetry.RecordSendFailure(sw.ElapsedMilliseconds);
-                    activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
-                    _logger.LogMessageSendFailed(channelName, result.Error?.Message);
-                }
-
-                return result;
-            }
-            catch (Exception ex)
-            {
-                sw.Stop();
-                _clientTelemetry.RecordSendFailure(sw.ElapsedMilliseconds);
-                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
-                throw;
-            }
+            return await ResolveConnectorByNameAsync(channelName, cancellationToken);
         }
 
-        /// <inheritdoc/>
-        public async Task<OperationResult<ReceiveResult>> ReceiveAsync<TConnector>(MessageSource source, CancellationToken cancellationToken = default)
-            where TConnector : class, IChannelConnector
-        {
-            var channelName = typeof(TConnector).Name;
-
-            using var activity = _clientTelemetry.StartReceiveActivity(channelName);
-            var sw = Stopwatch.StartNew();
-
-            var connector = await ResolveConnectorAsync<TConnector>(cancellationToken);
-            if (connector == null)
-            {
-                sw.Stop();
-                _clientTelemetry.RecordReceiveFailure(sw.ElapsedMilliseconds);
-                activity?.SetStatus(ActivityStatusCode.Error, "Connector not found");
-                return OperationResult<ReceiveResult>.Fail(MessagingErrorCodes.ConnectorNotFound, MessagingErrorCodes.ErrorDomain, $"No connector registered for type '{channelName}'.");
-            }
-
-            try
-            {
-                var result = await connector.ReceiveMessagesAsync(source, cancellationToken);
-                sw.Stop();
-
-                if (result.IsSuccess())
-                {
-                    _clientTelemetry.RecordReceiveSuccess(sw.ElapsedMilliseconds);
-                    activity?.SetStatus(ActivityStatusCode.Ok);
-                    _logger.LogMessageReceived(channelName);
-                }
-                else
-                {
-                    _clientTelemetry.RecordReceiveFailure(sw.ElapsedMilliseconds);
-                    activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
-                    _logger.LogMessageReceiveFailed(channelName, result.Error?.Message);
-                }
-
-                return result;
-            }
-            catch (Exception ex)
-            {
-                sw.Stop();
-                _clientTelemetry.RecordReceiveFailure(sw.ElapsedMilliseconds);
-                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
-                throw;
-            }
-        }
-
-        /// <inheritdoc/>
-        public async Task<OperationResult<StatusInfo>> GetStatusAsync<TConnector>(CancellationToken cancellationToken = default)
-            where TConnector : class, IChannelConnector
-        {
-            var channelName = typeof(TConnector).Name;
-
-            using var activity = _clientTelemetry.StartStatusActivity(channelName);
-            var sw = Stopwatch.StartNew();
-
-            var connector = await ResolveConnectorAsync<TConnector>(cancellationToken);
-            if (connector == null)
-            {
-                sw.Stop();
-                _clientTelemetry.RecordStatusFailure(sw.ElapsedMilliseconds);
-                activity?.SetStatus(ActivityStatusCode.Error, "Connector not found");
-                return OperationResult<StatusInfo>.Fail(MessagingErrorCodes.ConnectorNotFound, MessagingErrorCodes.ErrorDomain, $"No connector registered for type '{channelName}'.");
-            }
-
-            try
-            {
-                var result = await connector.GetStatusAsync(cancellationToken);
-                sw.Stop();
-
-                if (result.IsSuccess())
-                {
-                    _clientTelemetry.RecordStatusSuccess(sw.ElapsedMilliseconds);
-                    activity?.SetStatus(ActivityStatusCode.Ok);
-                    _logger.LogStatusRead(channelName);
-                }
-                else
-                {
-                    _clientTelemetry.RecordStatusFailure(sw.ElapsedMilliseconds);
-                    activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
-                    _logger.LogStatusReadFailed(channelName, result.Error?.Message);
-                }
-
-                return result;
-            }
-            catch (Exception ex)
-            {
-                sw.Stop();
-                _clientTelemetry.RecordStatusFailure(sw.ElapsedMilliseconds);
-                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
-                throw;
-            }
-        }
-
-        /// <inheritdoc/>
-        public async Task<OperationResult<StatusUpdateResult>> ReceiveMessageStatusAsync<TConnector>(MessageSource source, CancellationToken cancellationToken = default)
-            where TConnector : class, IChannelConnector
-        {
-            var channelName = typeof(TConnector).Name;
-
-            using var activity = _clientTelemetry.StartReceiveStatusActivity(channelName);
-            var sw = Stopwatch.StartNew();
-
-            var connector = await ResolveConnectorAsync<TConnector>(cancellationToken);
-            if (connector == null)
-            {
-                sw.Stop();
-                _clientTelemetry.RecordReceiveStatusFailure(sw.ElapsedMilliseconds);
-                activity?.SetStatus(ActivityStatusCode.Error, "Connector not found");
-                return OperationResult<StatusUpdateResult>.Fail(MessagingErrorCodes.ConnectorNotFound, MessagingErrorCodes.ErrorDomain, $"No connector registered for type '{channelName}'.");
-            }
-
-            try
-            {
-                var result = await connector.ReceiveMessageStatusAsync(source, cancellationToken);
-                sw.Stop();
-
-                if (result.IsSuccess())
-                {
-                    _clientTelemetry.RecordReceiveStatusSuccess(sw.ElapsedMilliseconds);
-                    activity?.SetStatus(ActivityStatusCode.Ok);
-                    _logger.LogMessageStatusReceived(channelName);
-                }
-                else
-                {
-                    _clientTelemetry.RecordReceiveStatusFailure(sw.ElapsedMilliseconds);
-                    activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
-                    _logger.LogMessageStatusReceiveFailed(channelName, result.Error?.Message);
-                }
-
-                return result;
-            }
-            catch (Exception ex)
-            {
-                sw.Stop();
-                _clientTelemetry.RecordReceiveStatusFailure(sw.ElapsedMilliseconds);
-                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
-                throw;
-            }
-        }
-
-        // ── Runtime overloads ────────────────────────────────────────────────
-
-        /// <inheritdoc/>
-        public async Task<OperationResult<SendResult>> SendAsync(string channelName, ConnectionSettings settings, IMessage message, CancellationToken cancellationToken = default)
-        {
-            _logger.LogSendingMessage(channelName);
-
-            using var activity = _clientTelemetry.StartSendActivity(channelName, message.Id);
-            var sw = Stopwatch.StartNew();
-
-            var connector = await CreateRuntimeConnectorAsync(channelName, settings, cancellationToken);
-            if (connector == null)
-            {
-                sw.Stop();
-                _clientTelemetry.RecordSendFailure(sw.ElapsedMilliseconds);
-                activity?.SetStatus(ActivityStatusCode.Error, "Connector not found");
-                return OperationResult<SendResult>.Fail(MessagingErrorCodes.ConnectorNotFound, MessagingErrorCodes.ErrorDomain, $"No connector type registered for channel '{channelName}'.");
-            }
-
-            await ResolveSenderAsync(message, settings, cancellationToken);
-
-            try
-            {
-                var result = await connector.SendMessageAsync(message, cancellationToken);
-                sw.Stop();
-
-                if (result.IsSuccess())
-                {
-                    _clientTelemetry.RecordSendSuccess(sw.ElapsedMilliseconds);
-                    activity?.SetStatus(ActivityStatusCode.Ok);
-                    _logger.LogMessageSent(channelName);
-                }
-                else
-                {
-                    _clientTelemetry.RecordSendFailure(sw.ElapsedMilliseconds);
-                    activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
-                    _logger.LogMessageSendFailed(channelName, result.Error?.Message);
-                }
-
-                return result;
-            }
-            catch (Exception ex)
-            {
-                sw.Stop();
-                _clientTelemetry.RecordSendFailure(sw.ElapsedMilliseconds);
-                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
-                throw;
-            }
-        }
-
-        /// <inheritdoc/>
-        public async Task<OperationResult<ReceiveResult>> ReceiveAsync(string channelName, ConnectionSettings settings, MessageSource source, CancellationToken cancellationToken = default)
-        {
-            _logger.LogReceivingMessage(channelName);
-
-            using var activity = _clientTelemetry.StartReceiveActivity(channelName);
-            var sw = Stopwatch.StartNew();
-
-            var connector = await CreateRuntimeConnectorAsync(channelName, settings, cancellationToken);
-            if (connector == null)
-            {
-                sw.Stop();
-                _clientTelemetry.RecordReceiveFailure(sw.ElapsedMilliseconds);
-                activity?.SetStatus(ActivityStatusCode.Error, "Connector not found");
-                return OperationResult<ReceiveResult>.Fail(MessagingErrorCodes.ConnectorNotFound, MessagingErrorCodes.ErrorDomain, $"No connector type registered for channel '{channelName}'.");
-            }
-
-            try
-            {
-                var result = await connector.ReceiveMessagesAsync(source, cancellationToken);
-                sw.Stop();
-
-                if (result.IsSuccess())
-                {
-                    _clientTelemetry.RecordReceiveSuccess(sw.ElapsedMilliseconds);
-                    activity?.SetStatus(ActivityStatusCode.Ok);
-                    _logger.LogMessageReceived(channelName);
-                }
-                else
-                {
-                    _clientTelemetry.RecordReceiveFailure(sw.ElapsedMilliseconds);
-                    activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
-                    _logger.LogMessageReceiveFailed(channelName, result.Error?.Message);
-                }
-
-                return result;
-            }
-            catch (Exception ex)
-            {
-                sw.Stop();
-                _clientTelemetry.RecordReceiveFailure(sw.ElapsedMilliseconds);
-                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
-                throw;
-            }
-        }
-
-        /// <inheritdoc/>
-        public async Task<OperationResult<StatusInfo>> GetStatusAsync(string channelName, ConnectionSettings settings, CancellationToken cancellationToken = default)
-        {
-            _logger.LogReadingStatus(channelName);
-
-            using var activity = _clientTelemetry.StartStatusActivity(channelName);
-            var sw = Stopwatch.StartNew();
-
-            var connector = await CreateRuntimeConnectorAsync(channelName, settings, cancellationToken);
-            if (connector == null)
-            {
-                sw.Stop();
-                _clientTelemetry.RecordStatusFailure(sw.ElapsedMilliseconds);
-                activity?.SetStatus(ActivityStatusCode.Error, "Connector not found");
-                return OperationResult<StatusInfo>.Fail(MessagingErrorCodes.ConnectorNotFound, MessagingErrorCodes.ErrorDomain, $"No connector type registered for channel '{channelName}'.");
-            }
-
-            try
-            {
-                var result = await connector.GetStatusAsync(cancellationToken);
-                sw.Stop();
-
-                if (result.IsSuccess())
-                {
-                    _clientTelemetry.RecordStatusSuccess(sw.ElapsedMilliseconds);
-                    activity?.SetStatus(ActivityStatusCode.Ok);
-                    _logger.LogStatusRead(channelName);
-                }
-                else
-                {
-                    _clientTelemetry.RecordStatusFailure(sw.ElapsedMilliseconds);
-                    activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
-                    _logger.LogStatusReadFailed(channelName, result.Error?.Message);
-                }
-
-                return result;
-            }
-            catch (Exception ex)
-            {
-                sw.Stop();
-                _clientTelemetry.RecordStatusFailure(sw.ElapsedMilliseconds);
-                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
-                throw;
-            }
-        }
-
-        /// <inheritdoc/>
-        public async Task<OperationResult<StatusUpdateResult>> ReceiveMessageStatusAsync(string channelName, ConnectionSettings settings, MessageSource source, CancellationToken cancellationToken = default)
-        {
-            _logger.LogReceivingMessageStatus(channelName);
-
-            using var activity = _clientTelemetry.StartReceiveStatusActivity(channelName);
-            var sw = Stopwatch.StartNew();
-
-            var connector = await CreateRuntimeConnectorAsync(channelName, settings, cancellationToken);
-            if (connector == null)
-            {
-                sw.Stop();
-                _clientTelemetry.RecordReceiveStatusFailure(sw.ElapsedMilliseconds);
-                activity?.SetStatus(ActivityStatusCode.Error, "Connector not found");
-                return OperationResult<StatusUpdateResult>.Fail(MessagingErrorCodes.ConnectorNotFound, MessagingErrorCodes.ErrorDomain, $"No connector type registered for channel '{channelName}'.");
-            }
-
-            try
-            {
-                var result = await connector.ReceiveMessageStatusAsync(source, cancellationToken);
-                sw.Stop();
-
-                if (result.IsSuccess())
-                {
-                    _clientTelemetry.RecordReceiveStatusSuccess(sw.ElapsedMilliseconds);
-                    activity?.SetStatus(ActivityStatusCode.Ok);
-                    _logger.LogMessageStatusReceived(channelName);
-                }
-                else
-                {
-                    _clientTelemetry.RecordReceiveStatusFailure(sw.ElapsedMilliseconds);
-                    activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
-                    _logger.LogMessageStatusReceiveFailed(channelName, result.Error?.Message);
-                }
-
-                return result;
-            }
-            catch (Exception ex)
-            {
-                sw.Stop();
-                _clientTelemetry.RecordReceiveStatusFailure(sw.ElapsedMilliseconds);
-                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
-                throw;
-            }
-        }
-
-        // ── Type-parameterized runtime overloads ────────────────────────────
-
-        /// <inheritdoc/>
-        public async Task<OperationResult<SendResult>> SendAsync<TConnector>(ConnectionSettings settings, IMessage message, CancellationToken cancellationToken = default)
-            where TConnector : class, IChannelConnector
-        {
-            var channelName = typeof(TConnector).Name;
-
-            using var activity = _clientTelemetry.StartSendActivity(channelName, message.Id);
-            var sw = Stopwatch.StartNew();
-
-            var connector = await CreateRuntimeConnectorAsync<TConnector>(settings, cancellationToken);
-            if (connector == null)
-            {
-                sw.Stop();
-                _clientTelemetry.RecordSendFailure(sw.ElapsedMilliseconds);
-                activity?.SetStatus(ActivityStatusCode.Error, "Connector not found");
-                return OperationResult<SendResult>.Fail(MessagingErrorCodes.ConnectorNotFound, MessagingErrorCodes.ErrorDomain, $"No connector type registered for '{channelName}'.");
-            }
-
-            await ResolveSenderAsync(message, settings, cancellationToken);
-
-            try
-            {
-                var result = await connector.SendMessageAsync(message, cancellationToken);
-                sw.Stop();
-
-                if (result.IsSuccess())
-                {
-                    _clientTelemetry.RecordSendSuccess(sw.ElapsedMilliseconds);
-                    activity?.SetStatus(ActivityStatusCode.Ok);
-                    _logger.LogMessageSent(channelName);
-                }
-                else
-                {
-                    _clientTelemetry.RecordSendFailure(sw.ElapsedMilliseconds);
-                    activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
-                    _logger.LogMessageSendFailed(channelName, result.Error?.Message);
-                }
-
-                return result;
-            }
-            catch (Exception ex)
-            {
-                sw.Stop();
-                _clientTelemetry.RecordSendFailure(sw.ElapsedMilliseconds);
-                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
-                throw;
-            }
-        }
-
-        /// <inheritdoc/>
-        public async Task<OperationResult<ReceiveResult>> ReceiveAsync<TConnector>(ConnectionSettings settings, MessageSource source, CancellationToken cancellationToken = default)
-            where TConnector : class, IChannelConnector
-        {
-            var channelName = typeof(TConnector).Name;
-
-            using var activity = _clientTelemetry.StartReceiveActivity(channelName);
-            var sw = Stopwatch.StartNew();
-
-            var connector = await CreateRuntimeConnectorAsync<TConnector>(settings, cancellationToken);
-            if (connector == null)
-            {
-                sw.Stop();
-                _clientTelemetry.RecordReceiveFailure(sw.ElapsedMilliseconds);
-                activity?.SetStatus(ActivityStatusCode.Error, "Connector not found");
-                return OperationResult<ReceiveResult>.Fail(MessagingErrorCodes.ConnectorNotFound, MessagingErrorCodes.ErrorDomain, $"No connector type registered for '{channelName}'.");
-            }
-
-            try
-            {
-                var result = await connector.ReceiveMessagesAsync(source, cancellationToken);
-                sw.Stop();
-
-                if (result.IsSuccess())
-                {
-                    _clientTelemetry.RecordReceiveSuccess(sw.ElapsedMilliseconds);
-                    activity?.SetStatus(ActivityStatusCode.Ok);
-                    _logger.LogMessageReceived(channelName);
-                }
-                else
-                {
-                    _clientTelemetry.RecordReceiveFailure(sw.ElapsedMilliseconds);
-                    activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
-                    _logger.LogMessageReceiveFailed(channelName, result.Error?.Message);
-                }
-
-                return result;
-            }
-            catch (Exception ex)
-            {
-                sw.Stop();
-                _clientTelemetry.RecordReceiveFailure(sw.ElapsedMilliseconds);
-                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
-                throw;
-            }
-        }
-
-        /// <inheritdoc/>
-        public async Task<OperationResult<StatusInfo>> GetStatusAsync<TConnector>(ConnectionSettings settings, CancellationToken cancellationToken = default)
-            where TConnector : class, IChannelConnector
-        {
-            var channelName = typeof(TConnector).Name;
-
-            using var activity = _clientTelemetry.StartStatusActivity(channelName);
-            var sw = Stopwatch.StartNew();
-
-            var connector = await CreateRuntimeConnectorAsync<TConnector>(settings, cancellationToken);
-            if (connector == null)
-            {
-                sw.Stop();
-                _clientTelemetry.RecordStatusFailure(sw.ElapsedMilliseconds);
-                activity?.SetStatus(ActivityStatusCode.Error, "Connector not found");
-                return OperationResult<StatusInfo>.Fail(MessagingErrorCodes.ConnectorNotFound, MessagingErrorCodes.ErrorDomain, $"No connector type registered for '{channelName}'.");
-            }
-
-            try
-            {
-                var result = await connector.GetStatusAsync(cancellationToken);
-                sw.Stop();
-
-                if (result.IsSuccess())
-                {
-                    _clientTelemetry.RecordStatusSuccess(sw.ElapsedMilliseconds);
-                    activity?.SetStatus(ActivityStatusCode.Ok);
-                    _logger.LogStatusRead(channelName);
-                }
-                else
-                {
-                    _clientTelemetry.RecordStatusFailure(sw.ElapsedMilliseconds);
-                    activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
-                    _logger.LogStatusReadFailed(channelName, result.Error?.Message);
-                }
-
-                return result;
-            }
-            catch (Exception ex)
-            {
-                sw.Stop();
-                _clientTelemetry.RecordStatusFailure(sw.ElapsedMilliseconds);
-                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
-                throw;
-            }
-        }
-
-        /// <inheritdoc/>
-        public async Task<OperationResult<StatusUpdateResult>> ReceiveMessageStatusAsync<TConnector>(ConnectionSettings settings, MessageSource source, CancellationToken cancellationToken = default)
-            where TConnector : class, IChannelConnector
-        {
-            var channelName = typeof(TConnector).Name;
-
-            using var activity = _clientTelemetry.StartReceiveStatusActivity(channelName);
-            var sw = Stopwatch.StartNew();
-
-            var connector = await CreateRuntimeConnectorAsync<TConnector>(settings, cancellationToken);
-            if (connector == null)
-            {
-                sw.Stop();
-                _clientTelemetry.RecordReceiveStatusFailure(sw.ElapsedMilliseconds);
-                activity?.SetStatus(ActivityStatusCode.Error, "Connector not found");
-                return OperationResult<StatusUpdateResult>.Fail(MessagingErrorCodes.ConnectorNotFound, MessagingErrorCodes.ErrorDomain, $"No connector type registered for '{channelName}'.");
-            }
-
-            try
-            {
-                var result = await connector.ReceiveMessageStatusAsync(source, cancellationToken);
-                sw.Stop();
-
-                if (result.IsSuccess())
-                {
-                    _clientTelemetry.RecordReceiveStatusSuccess(sw.ElapsedMilliseconds);
-                    activity?.SetStatus(ActivityStatusCode.Ok);
-                    _logger.LogMessageStatusReceived(channelName);
-                }
-                else
-                {
-                    _clientTelemetry.RecordReceiveStatusFailure(sw.ElapsedMilliseconds);
-                    activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
-                    _logger.LogMessageStatusReceiveFailed(channelName, result.Error?.Message);
-                }
-
-                return result;
-            }
-            catch (Exception ex)
-            {
-                sw.Stop();
-                _clientTelemetry.RecordReceiveStatusFailure(sw.ElapsedMilliseconds);
-                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
-                throw;
-            }
-        }
-
-        // ── Sender resolution ────────────────────────────────────────────────
-
-        private async ValueTask ResolveSenderAsync(IMessage message, ConnectionSettings settings, CancellationToken cancellationToken)
-        {
-            var resolver = _serviceProvider.GetService<ISenderResolver>();
-            if (resolver == null)
-                return;
-
-            var context = new SenderResolutionContext(message.Sender, settings);
-            var resolved = await resolver.ResolveAsync(context, cancellationToken);
-
-            if (resolved != null && message is Message msg)
-            {
-                msg.Sender = resolved;
-            }
-        }
-
-        // ── Runtime connector creation ──────────────────────────────────────
-
-        private async Task<IChannelConnector?> CreateRuntimeConnectorAsync(string channelName, ConnectionSettings settings, CancellationToken cancellationToken)
-        {
-            if (_catalog == null || !_catalog.TryGetEntry(channelName, out var entry))
-            {
-                _logger.LogChannelNotFound(channelName);
-                return null;
-            }
-
-            _logger.LogResolvingChannel(channelName);
-
-            var schema = entry!.GetSchema(_serviceProvider);
-            var connector = (IChannelConnector)ActivatorUtilities.CreateInstance(
-                _serviceProvider, entry.ConnectorType, schema, settings);
-
-            if (_options.AutoInitialize && connector.State == ConnectorState.Uninitialized)
-            {
-                _logger.LogInitializingConnector(channelName);
-
-                var initResult = await connector.InitializeAsync(cancellationToken);
-                if (!initResult.IsSuccess())
-                {
-                    _logger.LogConnectorInitializationFailed(channelName, initResult.Error?.Message);
-                    return null;
-                }
-
-                _logger.LogConnectorInitialized(channelName);
-            }
-
-            TrackRuntimeConnector(connector);
-            return connector;
-        }
-
-        private async Task<IChannelConnector?> CreateRuntimeConnectorAsync<TConnector>(ConnectionSettings settings, CancellationToken cancellationToken)
-            where TConnector : class, IChannelConnector
-        {
-            var channelName = typeof(TConnector).Name;
-
-            _logger.LogResolvingChannel(channelName);
-
-            var connectorType = typeof(TConnector);
-            var schema = ConnectorSchemaHelper.DiscoverConnectorSchema(_serviceProvider, connectorType);
-            var connector = (IChannelConnector)ActivatorUtilities.CreateInstance(
-                _serviceProvider, connectorType, schema, settings);
-
-            if (_options.AutoInitialize && connector.State == ConnectorState.Uninitialized)
-            {
-                _logger.LogInitializingConnector(channelName);
-
-                var initResult = await connector.InitializeAsync(cancellationToken);
-                if (!initResult.IsSuccess())
-                {
-                    _logger.LogConnectorInitializationFailed(channelName, initResult.Error?.Message);
-                    return null;
-                }
-
-                _logger.LogConnectorInitialized(channelName);
-            }
-
-            TrackRuntimeConnector(connector);
-            return connector;
-        }
-
-        private async Task<IChannelConnector?> ResolveConnectorAsync<TConnector>(CancellationToken cancellationToken)
-            where TConnector : class, IChannelConnector
-        {
-            var channelName = typeof(TConnector).Name;
-
-            if (_connectors.TryGetValue(channelName, out var existing))
-                return existing;
-
-            await _lock.WaitAsync(cancellationToken);
-            try
-            {
-                if (_connectors.TryGetValue(channelName, out existing))
-                    return existing;
-
-                _logger.LogResolvingChannel(channelName);
-
-                var connector = _serviceProvider.GetService<TConnector>();
-                if (connector == null)
-                {
-                    _logger.LogChannelNotFound(channelName);
-                    return null;
-                }
-
-                if (_options.AutoInitialize && connector.State == ConnectorState.Uninitialized)
-                {
-                    _logger.LogInitializingConnector(channelName);
-
-                    var initResult = await connector.InitializeAsync(cancellationToken);
-                    if (!initResult.IsSuccess())
-                    {
-                        _logger.LogConnectorInitializationFailed(channelName, initResult.Error?.Message);
-                        return null;
-                    }
-
-                    _logger.LogConnectorInitialized(channelName);
-                }
-
-                _logger.LogChannelResolved(channelName);
-
-                _connectors[channelName] = connector;
-                return connector;
-            }
-            finally
-            {
-                _lock.Release();
-            }
-        }
-
-        private void TrackRuntimeConnector(IChannelConnector connector)
-        {
-            lock (_runtimeLock)
-                _runtimeConnectors.Add(connector);
-        }
-
-        /// <summary>
-        /// Resolves a channel connector by name, with lazy initialization
-        /// and thread-safe caching.
-        /// </summary>
-        private async Task<IChannelConnector?> ResolveConnectorAsync(string channelName, CancellationToken cancellationToken)
+        private async Task<IChannelConnector?> ResolveConnectorByNameAsync(string channelName, CancellationToken cancellationToken)
         {
             if (_connectors.TryGetValue(channelName, out var existing))
                 return existing;
@@ -988,7 +348,165 @@ namespace Ratatosk
             }
         }
 
-        /// <inheritdoc/>
+        private async Task<IChannelConnector?> ResolveConnectorByTypeAsync(string channelName, Type connectorType, CancellationToken cancellationToken)
+        {
+            if (_connectors.TryGetValue(channelName, out var existing))
+                return existing;
+
+            await _lock.WaitAsync(cancellationToken);
+            try
+            {
+                if (_connectors.TryGetValue(channelName, out existing))
+                    return existing;
+
+                _logger.LogResolvingChannel(channelName);
+
+                var connector = _serviceProvider.GetService(connectorType) as IChannelConnector;
+                if (connector == null)
+                {
+                    _logger.LogChannelNotFound(channelName);
+                    return null;
+                }
+
+                if (_options.AutoInitialize && connector.State == ConnectorState.Uninitialized)
+                {
+                    _logger.LogInitializingConnector(channelName);
+
+                    var initResult = await connector.InitializeAsync(cancellationToken);
+                    if (!initResult.IsSuccess())
+                    {
+                        _logger.LogConnectorInitializationFailed(channelName, initResult.Error?.Message);
+                        return null;
+                    }
+
+                    _logger.LogConnectorInitialized(channelName);
+                }
+
+                _logger.LogChannelResolved(channelName);
+
+                _connectors[channelName] = connector;
+                return connector;
+            }
+            finally
+            {
+                _lock.Release();
+            }
+        }
+
+        private async Task<IChannelConnector?> CreateRuntimeConnectorAsync(Type connectorType, string channelName, ConnectionSettings settings, CancellationToken cancellationToken)
+        {
+            _logger.LogResolvingChannel(channelName);
+
+            var schema = ConnectorSchemaHelper.DiscoverConnectorSchema(_serviceProvider, connectorType);
+            var connector = (IChannelConnector)ActivatorUtilities.CreateInstance(
+                _serviceProvider, connectorType, schema, settings);
+
+            if (_options.AutoInitialize && connector.State == ConnectorState.Uninitialized)
+            {
+                _logger.LogInitializingConnector(channelName);
+
+                var initResult = await connector.InitializeAsync(cancellationToken);
+                if (!initResult.IsSuccess())
+                {
+                    _logger.LogConnectorInitializationFailed(channelName, initResult.Error?.Message);
+                    return null;
+                }
+
+                _logger.LogConnectorInitialized(channelName);
+            }
+
+            TrackRuntimeConnector(connector);
+            return connector;
+        }
+
+        private async Task<IChannelConnector?> CreateRuntimeConnectorAsync(string channelName, ConnectionSettings settings, CancellationToken cancellationToken)
+        {
+            if (_catalog == null || !_catalog.TryGetEntry(channelName, out var entry))
+            {
+                _logger.LogChannelNotFound(channelName);
+                return null;
+            }
+
+            _logger.LogResolvingChannel(channelName);
+
+            var schema = entry!.GetSchema(_serviceProvider);
+            var connector = (IChannelConnector)ActivatorUtilities.CreateInstance(
+                _serviceProvider, entry.ConnectorType, schema, settings);
+
+            if (_options.AutoInitialize && connector.State == ConnectorState.Uninitialized)
+            {
+                _logger.LogInitializingConnector(channelName);
+
+                var initResult = await connector.InitializeAsync(cancellationToken);
+                if (!initResult.IsSuccess())
+                {
+                    _logger.LogConnectorInitializationFailed(channelName, initResult.Error?.Message);
+                    return null;
+                }
+
+                _logger.LogConnectorInitialized(channelName);
+            }
+
+            TrackRuntimeConnector(connector);
+            return connector;
+        }
+
+        // ── Sender resolution ────────────────────────────────────────────
+
+        private async ValueTask ResolveSenderAsync(IMessage message, ConnectionSettings settings, CancellationToken cancellationToken)
+        {
+            var resolver = _serviceProvider.GetService<ISenderResolver>();
+            if (resolver == null)
+                return;
+
+            var context = new SenderResolutionContext(message.Sender, settings);
+            var resolved = await resolver.ResolveAsync(context, cancellationToken);
+
+            if (resolved != null && message is Message msg)
+            {
+                msg.Sender = resolved;
+            }
+        }
+
+        // ── Context enrichment ───────────────────────────────────────────
+
+        private static void StampMessageContext(IMessage message, MessageContext? context)
+        {
+            if (context == null || context.Data.Count == 0)
+                return;
+
+            if (message is not Message msg)
+                return;
+
+            msg.Properties ??= new Dictionary<string, MessageProperty>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var (key, value) in context.Data)
+            {
+                if (!string.IsNullOrWhiteSpace(key))
+                    msg.Properties[key] = new MessageProperty(key, value);
+            }
+        }
+
+        private IDisposable? BeginContextScope(MessageContext? context)
+        {
+            if (context == null || context.Data.Count == 0)
+                return null;
+
+            return _logger.BeginScope(context.Data.ToDictionary(
+                kvp => kvp.Key,
+                kvp => kvp.Value ?? "<null>"));
+        }
+
+        // ── Runtime connector tracking ───────────────────────────────────
+
+        private void TrackRuntimeConnector(IChannelConnector connector)
+        {
+            lock (_runtimeLock)
+                _runtimeConnectors.Add(connector);
+        }
+
+        // ── Dispose ──────────────────────────────────────────────────────
+
         public void Dispose()
         {
             foreach (var connector in _connectors.Values)
@@ -1011,7 +529,6 @@ namespace Ratatosk
             _clientTelemetry.Dispose();
         }
 
-        /// <inheritdoc/>
         public async ValueTask DisposeAsync()
         {
             foreach (var connector in _connectors.Values)

--- a/src/Ratatosk/MessagingClient.cs
+++ b/src/Ratatosk/MessagingClient.cs
@@ -62,23 +62,33 @@ namespace Ratatosk
 
             await ResolveSenderAsync(message, connector.ConnectionSettings, cancellationToken);
 
-            var result = await connector.SendMessageAsync(message, cancellationToken);
-            sw.Stop();
+            try
+            {
+                var result = await connector.SendMessageAsync(message, cancellationToken);
+                sw.Stop();
 
-            if (result.IsSuccess())
-            {
-                _clientTelemetry.RecordSendSuccess(sw.ElapsedMilliseconds);
-                activity?.SetStatus(ActivityStatusCode.Ok);
-                _logger.LogMessageSent(channelName);
+                if (result.IsSuccess())
+                {
+                    _clientTelemetry.RecordSendSuccess(sw.ElapsedMilliseconds);
+                    activity?.SetStatus(ActivityStatusCode.Ok);
+                    _logger.LogMessageSent(channelName);
+                }
+                else
+                {
+                    _clientTelemetry.RecordSendFailure(sw.ElapsedMilliseconds);
+                    activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
+                    _logger.LogMessageSendFailed(channelName, result.Error?.Message);
+                }
+
+                return result;
             }
-            else
+            catch (Exception ex)
             {
+                sw.Stop();
                 _clientTelemetry.RecordSendFailure(sw.ElapsedMilliseconds);
-                activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
-                _logger.LogMessageSendFailed(channelName, result.Error?.Message);
+                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+                throw;
             }
-
-            return result;
         }
 
         /// <inheritdoc/>
@@ -87,28 +97,44 @@ namespace Ratatosk
             _logger.LogReceivingMessage(channelName);
 
             using var activity = _clientTelemetry.StartReceiveActivity(channelName);
+            var sw = Stopwatch.StartNew();
 
             var connector = await ResolveConnectorAsync(channelName, cancellationToken);
             if (connector == null)
             {
+                sw.Stop();
+                _clientTelemetry.RecordReceiveFailure(sw.ElapsedMilliseconds);
                 activity?.SetStatus(ActivityStatusCode.Error, "Connector not found");
                 return OperationResult<ReceiveResult>.Fail(MessagingErrorCodes.ConnectorNotFound, MessagingErrorCodes.ErrorDomain, $"No connector registered for channel '{channelName}'.");
             }
 
-            var result = await connector.ReceiveMessagesAsync(source, cancellationToken);
-
-            if (result.IsSuccess())
+            try
             {
-                activity?.SetStatus(ActivityStatusCode.Ok);
-                _logger.LogMessageReceived(channelName);
-            }
-            else
-            {
-                activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
-                _logger.LogMessageReceiveFailed(channelName, result.Error?.Message);
-            }
+                var result = await connector.ReceiveMessagesAsync(source, cancellationToken);
+                sw.Stop();
 
-            return result;
+                if (result.IsSuccess())
+                {
+                    _clientTelemetry.RecordReceiveSuccess(sw.ElapsedMilliseconds);
+                    activity?.SetStatus(ActivityStatusCode.Ok);
+                    _logger.LogMessageReceived(channelName);
+                }
+                else
+                {
+                    _clientTelemetry.RecordReceiveFailure(sw.ElapsedMilliseconds);
+                    activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
+                    _logger.LogMessageReceiveFailed(channelName, result.Error?.Message);
+                }
+
+                return result;
+            }
+            catch (Exception ex)
+            {
+                sw.Stop();
+                _clientTelemetry.RecordReceiveFailure(sw.ElapsedMilliseconds);
+                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+                throw;
+            }
         }
 
         /// <inheritdoc/>
@@ -117,27 +143,44 @@ namespace Ratatosk
             _logger.LogReadingStatus(channelName);
 
             using var activity = _clientTelemetry.StartStatusActivity(channelName);
+            var sw = Stopwatch.StartNew();
 
             var connector = await ResolveConnectorAsync(channelName, cancellationToken);
             if (connector == null)
             {
+                sw.Stop();
+                _clientTelemetry.RecordStatusFailure(sw.ElapsedMilliseconds);
                 activity?.SetStatus(ActivityStatusCode.Error, "Connector not found");
                 return OperationResult<StatusInfo>.Fail(MessagingErrorCodes.ConnectorNotFound, MessagingErrorCodes.ErrorDomain, $"No connector registered for channel '{channelName}'.");
             }
 
-            var result = await connector.GetStatusAsync(cancellationToken);
-            if (result.IsSuccess())
+            try
             {
-                activity?.SetStatus(ActivityStatusCode.Ok);
-                _logger.LogStatusRead(channelName);
-            }
-            else
-            {
-                activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
-                _logger.LogStatusReadFailed(channelName, result.Error?.Message);
-            }
+                var result = await connector.GetStatusAsync(cancellationToken);
+                sw.Stop();
 
-            return result;
+                if (result.IsSuccess())
+                {
+                    _clientTelemetry.RecordStatusSuccess(sw.ElapsedMilliseconds);
+                    activity?.SetStatus(ActivityStatusCode.Ok);
+                    _logger.LogStatusRead(channelName);
+                }
+                else
+                {
+                    _clientTelemetry.RecordStatusFailure(sw.ElapsedMilliseconds);
+                    activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
+                    _logger.LogStatusReadFailed(channelName, result.Error?.Message);
+                }
+
+                return result;
+            }
+            catch (Exception ex)
+            {
+                sw.Stop();
+                _clientTelemetry.RecordStatusFailure(sw.ElapsedMilliseconds);
+                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+                throw;
+            }
         }
 
         /// <inheritdoc/>
@@ -146,27 +189,44 @@ namespace Ratatosk
             _logger.LogReceivingMessageStatus(channelName);
 
             using var activity = _clientTelemetry.StartReceiveStatusActivity(channelName);
+            var sw = Stopwatch.StartNew();
 
             var connector = await ResolveConnectorAsync(channelName, cancellationToken);
             if (connector == null)
             {
+                sw.Stop();
+                _clientTelemetry.RecordReceiveStatusFailure(sw.ElapsedMilliseconds);
                 activity?.SetStatus(ActivityStatusCode.Error, "Connector not found");
                 return OperationResult<StatusUpdateResult>.Fail(MessagingErrorCodes.ConnectorNotFound, MessagingErrorCodes.ErrorDomain, $"No connector registered for channel '{channelName}'.");
             }
 
-            var result = await connector.ReceiveMessageStatusAsync(source, cancellationToken);
-            if (result.IsSuccess())
+            try
             {
-                activity?.SetStatus(ActivityStatusCode.Ok);
-                _logger.LogMessageStatusReceived(channelName);
-            }
-            else
-            {
-                activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
-                _logger.LogMessageStatusReceiveFailed(channelName, result.Error?.Message);
-            }
+                var result = await connector.ReceiveMessageStatusAsync(source, cancellationToken);
+                sw.Stop();
 
-            return result;
+                if (result.IsSuccess())
+                {
+                    _clientTelemetry.RecordReceiveStatusSuccess(sw.ElapsedMilliseconds);
+                    activity?.SetStatus(ActivityStatusCode.Ok);
+                    _logger.LogMessageStatusReceived(channelName);
+                }
+                else
+                {
+                    _clientTelemetry.RecordReceiveStatusFailure(sw.ElapsedMilliseconds);
+                    activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
+                    _logger.LogMessageStatusReceiveFailed(channelName, result.Error?.Message);
+                }
+
+                return result;
+            }
+            catch (Exception ex)
+            {
+                sw.Stop();
+                _clientTelemetry.RecordReceiveStatusFailure(sw.ElapsedMilliseconds);
+                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+                throw;
+            }
         }
 
         // ── Type-parameterized standard overloads ────────────────────────────
@@ -191,23 +251,33 @@ namespace Ratatosk
 
             await ResolveSenderAsync(message, connector.ConnectionSettings, cancellationToken);
 
-            var result = await connector.SendMessageAsync(message, cancellationToken);
-            sw.Stop();
+            try
+            {
+                var result = await connector.SendMessageAsync(message, cancellationToken);
+                sw.Stop();
 
-            if (result.IsSuccess())
-            {
-                _clientTelemetry.RecordSendSuccess(sw.ElapsedMilliseconds);
-                activity?.SetStatus(ActivityStatusCode.Ok);
-                _logger.LogMessageSent(channelName);
+                if (result.IsSuccess())
+                {
+                    _clientTelemetry.RecordSendSuccess(sw.ElapsedMilliseconds);
+                    activity?.SetStatus(ActivityStatusCode.Ok);
+                    _logger.LogMessageSent(channelName);
+                }
+                else
+                {
+                    _clientTelemetry.RecordSendFailure(sw.ElapsedMilliseconds);
+                    activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
+                    _logger.LogMessageSendFailed(channelName, result.Error?.Message);
+                }
+
+                return result;
             }
-            else
+            catch (Exception ex)
             {
+                sw.Stop();
                 _clientTelemetry.RecordSendFailure(sw.ElapsedMilliseconds);
-                activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
-                _logger.LogMessageSendFailed(channelName, result.Error?.Message);
+                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+                throw;
             }
-
-            return result;
         }
 
         /// <inheritdoc/>
@@ -217,27 +287,44 @@ namespace Ratatosk
             var channelName = typeof(TConnector).Name;
 
             using var activity = _clientTelemetry.StartReceiveActivity(channelName);
+            var sw = Stopwatch.StartNew();
 
             var connector = await ResolveConnectorAsync<TConnector>(cancellationToken);
             if (connector == null)
             {
+                sw.Stop();
+                _clientTelemetry.RecordReceiveFailure(sw.ElapsedMilliseconds);
                 activity?.SetStatus(ActivityStatusCode.Error, "Connector not found");
                 return OperationResult<ReceiveResult>.Fail(MessagingErrorCodes.ConnectorNotFound, MessagingErrorCodes.ErrorDomain, $"No connector registered for type '{channelName}'.");
             }
 
-            var result = await connector.ReceiveMessagesAsync(source, cancellationToken);
-            if (result.IsSuccess())
+            try
             {
-                activity?.SetStatus(ActivityStatusCode.Ok);
-                _logger.LogMessageReceived(channelName);
-            }
-            else
-            {
-                activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
-                _logger.LogMessageReceiveFailed(channelName, result.Error?.Message);
-            }
+                var result = await connector.ReceiveMessagesAsync(source, cancellationToken);
+                sw.Stop();
 
-            return result;
+                if (result.IsSuccess())
+                {
+                    _clientTelemetry.RecordReceiveSuccess(sw.ElapsedMilliseconds);
+                    activity?.SetStatus(ActivityStatusCode.Ok);
+                    _logger.LogMessageReceived(channelName);
+                }
+                else
+                {
+                    _clientTelemetry.RecordReceiveFailure(sw.ElapsedMilliseconds);
+                    activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
+                    _logger.LogMessageReceiveFailed(channelName, result.Error?.Message);
+                }
+
+                return result;
+            }
+            catch (Exception ex)
+            {
+                sw.Stop();
+                _clientTelemetry.RecordReceiveFailure(sw.ElapsedMilliseconds);
+                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+                throw;
+            }
         }
 
         /// <inheritdoc/>
@@ -247,27 +334,44 @@ namespace Ratatosk
             var channelName = typeof(TConnector).Name;
 
             using var activity = _clientTelemetry.StartStatusActivity(channelName);
+            var sw = Stopwatch.StartNew();
 
             var connector = await ResolveConnectorAsync<TConnector>(cancellationToken);
             if (connector == null)
             {
+                sw.Stop();
+                _clientTelemetry.RecordStatusFailure(sw.ElapsedMilliseconds);
                 activity?.SetStatus(ActivityStatusCode.Error, "Connector not found");
                 return OperationResult<StatusInfo>.Fail(MessagingErrorCodes.ConnectorNotFound, MessagingErrorCodes.ErrorDomain, $"No connector registered for type '{channelName}'.");
             }
 
-            var result = await connector.GetStatusAsync(cancellationToken);
-            if (result.IsSuccess())
+            try
             {
-                activity?.SetStatus(ActivityStatusCode.Ok);
-                _logger.LogStatusRead(channelName);
-            }
-            else
-            {
-                activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
-                _logger.LogStatusReadFailed(channelName, result.Error?.Message);
-            }
+                var result = await connector.GetStatusAsync(cancellationToken);
+                sw.Stop();
 
-            return result;
+                if (result.IsSuccess())
+                {
+                    _clientTelemetry.RecordStatusSuccess(sw.ElapsedMilliseconds);
+                    activity?.SetStatus(ActivityStatusCode.Ok);
+                    _logger.LogStatusRead(channelName);
+                }
+                else
+                {
+                    _clientTelemetry.RecordStatusFailure(sw.ElapsedMilliseconds);
+                    activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
+                    _logger.LogStatusReadFailed(channelName, result.Error?.Message);
+                }
+
+                return result;
+            }
+            catch (Exception ex)
+            {
+                sw.Stop();
+                _clientTelemetry.RecordStatusFailure(sw.ElapsedMilliseconds);
+                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+                throw;
+            }
         }
 
         /// <inheritdoc/>
@@ -277,27 +381,44 @@ namespace Ratatosk
             var channelName = typeof(TConnector).Name;
 
             using var activity = _clientTelemetry.StartReceiveStatusActivity(channelName);
+            var sw = Stopwatch.StartNew();
 
             var connector = await ResolveConnectorAsync<TConnector>(cancellationToken);
             if (connector == null)
             {
+                sw.Stop();
+                _clientTelemetry.RecordReceiveStatusFailure(sw.ElapsedMilliseconds);
                 activity?.SetStatus(ActivityStatusCode.Error, "Connector not found");
                 return OperationResult<StatusUpdateResult>.Fail(MessagingErrorCodes.ConnectorNotFound, MessagingErrorCodes.ErrorDomain, $"No connector registered for type '{channelName}'.");
             }
 
-            var result = await connector.ReceiveMessageStatusAsync(source, cancellationToken);
-            if (result.IsSuccess())
+            try
             {
-                activity?.SetStatus(ActivityStatusCode.Ok);
-                _logger.LogMessageStatusReceived(channelName);
-            }
-            else
-            {
-                activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
-                _logger.LogMessageStatusReceiveFailed(channelName, result.Error?.Message);
-            }
+                var result = await connector.ReceiveMessageStatusAsync(source, cancellationToken);
+                sw.Stop();
 
-            return result;
+                if (result.IsSuccess())
+                {
+                    _clientTelemetry.RecordReceiveStatusSuccess(sw.ElapsedMilliseconds);
+                    activity?.SetStatus(ActivityStatusCode.Ok);
+                    _logger.LogMessageStatusReceived(channelName);
+                }
+                else
+                {
+                    _clientTelemetry.RecordReceiveStatusFailure(sw.ElapsedMilliseconds);
+                    activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
+                    _logger.LogMessageStatusReceiveFailed(channelName, result.Error?.Message);
+                }
+
+                return result;
+            }
+            catch (Exception ex)
+            {
+                sw.Stop();
+                _clientTelemetry.RecordReceiveStatusFailure(sw.ElapsedMilliseconds);
+                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+                throw;
+            }
         }
 
         // ── Runtime overloads ────────────────────────────────────────────────
@@ -321,23 +442,33 @@ namespace Ratatosk
 
             await ResolveSenderAsync(message, settings, cancellationToken);
 
-            var result = await connector.SendMessageAsync(message, cancellationToken);
-            sw.Stop();
+            try
+            {
+                var result = await connector.SendMessageAsync(message, cancellationToken);
+                sw.Stop();
 
-            if (result.IsSuccess())
-            {
-                _clientTelemetry.RecordSendSuccess(sw.ElapsedMilliseconds);
-                activity?.SetStatus(ActivityStatusCode.Ok);
-                _logger.LogMessageSent(channelName);
+                if (result.IsSuccess())
+                {
+                    _clientTelemetry.RecordSendSuccess(sw.ElapsedMilliseconds);
+                    activity?.SetStatus(ActivityStatusCode.Ok);
+                    _logger.LogMessageSent(channelName);
+                }
+                else
+                {
+                    _clientTelemetry.RecordSendFailure(sw.ElapsedMilliseconds);
+                    activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
+                    _logger.LogMessageSendFailed(channelName, result.Error?.Message);
+                }
+
+                return result;
             }
-            else
+            catch (Exception ex)
             {
+                sw.Stop();
                 _clientTelemetry.RecordSendFailure(sw.ElapsedMilliseconds);
-                activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
-                _logger.LogMessageSendFailed(channelName, result.Error?.Message);
+                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+                throw;
             }
-
-            return result;
         }
 
         /// <inheritdoc/>
@@ -346,27 +477,44 @@ namespace Ratatosk
             _logger.LogReceivingMessage(channelName);
 
             using var activity = _clientTelemetry.StartReceiveActivity(channelName);
+            var sw = Stopwatch.StartNew();
 
             var connector = await CreateRuntimeConnectorAsync(channelName, settings, cancellationToken);
             if (connector == null)
             {
+                sw.Stop();
+                _clientTelemetry.RecordReceiveFailure(sw.ElapsedMilliseconds);
                 activity?.SetStatus(ActivityStatusCode.Error, "Connector not found");
                 return OperationResult<ReceiveResult>.Fail(MessagingErrorCodes.ConnectorNotFound, MessagingErrorCodes.ErrorDomain, $"No connector type registered for channel '{channelName}'.");
             }
 
-            var result = await connector.ReceiveMessagesAsync(source, cancellationToken);
-            if (result.IsSuccess())
+            try
             {
-                activity?.SetStatus(ActivityStatusCode.Ok);
-                _logger.LogMessageReceived(channelName);
-            }
-            else
-            {
-                activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
-                _logger.LogMessageReceiveFailed(channelName, result.Error?.Message);
-            }
+                var result = await connector.ReceiveMessagesAsync(source, cancellationToken);
+                sw.Stop();
 
-            return result;
+                if (result.IsSuccess())
+                {
+                    _clientTelemetry.RecordReceiveSuccess(sw.ElapsedMilliseconds);
+                    activity?.SetStatus(ActivityStatusCode.Ok);
+                    _logger.LogMessageReceived(channelName);
+                }
+                else
+                {
+                    _clientTelemetry.RecordReceiveFailure(sw.ElapsedMilliseconds);
+                    activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
+                    _logger.LogMessageReceiveFailed(channelName, result.Error?.Message);
+                }
+
+                return result;
+            }
+            catch (Exception ex)
+            {
+                sw.Stop();
+                _clientTelemetry.RecordReceiveFailure(sw.ElapsedMilliseconds);
+                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+                throw;
+            }
         }
 
         /// <inheritdoc/>
@@ -375,27 +523,44 @@ namespace Ratatosk
             _logger.LogReadingStatus(channelName);
 
             using var activity = _clientTelemetry.StartStatusActivity(channelName);
+            var sw = Stopwatch.StartNew();
 
             var connector = await CreateRuntimeConnectorAsync(channelName, settings, cancellationToken);
             if (connector == null)
             {
+                sw.Stop();
+                _clientTelemetry.RecordStatusFailure(sw.ElapsedMilliseconds);
                 activity?.SetStatus(ActivityStatusCode.Error, "Connector not found");
                 return OperationResult<StatusInfo>.Fail(MessagingErrorCodes.ConnectorNotFound, MessagingErrorCodes.ErrorDomain, $"No connector type registered for channel '{channelName}'.");
             }
 
-            var result = await connector.GetStatusAsync(cancellationToken);
-            if (result.IsSuccess())
+            try
             {
-                activity?.SetStatus(ActivityStatusCode.Ok);
-                _logger.LogStatusRead(channelName);
-            }
-            else
-            {
-                activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
-                _logger.LogStatusReadFailed(channelName, result.Error?.Message);
-            }
+                var result = await connector.GetStatusAsync(cancellationToken);
+                sw.Stop();
 
-            return result;
+                if (result.IsSuccess())
+                {
+                    _clientTelemetry.RecordStatusSuccess(sw.ElapsedMilliseconds);
+                    activity?.SetStatus(ActivityStatusCode.Ok);
+                    _logger.LogStatusRead(channelName);
+                }
+                else
+                {
+                    _clientTelemetry.RecordStatusFailure(sw.ElapsedMilliseconds);
+                    activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
+                    _logger.LogStatusReadFailed(channelName, result.Error?.Message);
+                }
+
+                return result;
+            }
+            catch (Exception ex)
+            {
+                sw.Stop();
+                _clientTelemetry.RecordStatusFailure(sw.ElapsedMilliseconds);
+                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+                throw;
+            }
         }
 
         /// <inheritdoc/>
@@ -404,27 +569,44 @@ namespace Ratatosk
             _logger.LogReceivingMessageStatus(channelName);
 
             using var activity = _clientTelemetry.StartReceiveStatusActivity(channelName);
+            var sw = Stopwatch.StartNew();
 
             var connector = await CreateRuntimeConnectorAsync(channelName, settings, cancellationToken);
             if (connector == null)
             {
+                sw.Stop();
+                _clientTelemetry.RecordReceiveStatusFailure(sw.ElapsedMilliseconds);
                 activity?.SetStatus(ActivityStatusCode.Error, "Connector not found");
                 return OperationResult<StatusUpdateResult>.Fail(MessagingErrorCodes.ConnectorNotFound, MessagingErrorCodes.ErrorDomain, $"No connector type registered for channel '{channelName}'.");
             }
 
-            var result = await connector.ReceiveMessageStatusAsync(source, cancellationToken);
-            if (result.IsSuccess())
+            try
             {
-                activity?.SetStatus(ActivityStatusCode.Ok);
-                _logger.LogMessageStatusReceived(channelName);
-            }
-            else
-            {
-                activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
-                _logger.LogMessageStatusReceiveFailed(channelName, result.Error?.Message);
-            }
+                var result = await connector.ReceiveMessageStatusAsync(source, cancellationToken);
+                sw.Stop();
 
-            return result;
+                if (result.IsSuccess())
+                {
+                    _clientTelemetry.RecordReceiveStatusSuccess(sw.ElapsedMilliseconds);
+                    activity?.SetStatus(ActivityStatusCode.Ok);
+                    _logger.LogMessageStatusReceived(channelName);
+                }
+                else
+                {
+                    _clientTelemetry.RecordReceiveStatusFailure(sw.ElapsedMilliseconds);
+                    activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
+                    _logger.LogMessageStatusReceiveFailed(channelName, result.Error?.Message);
+                }
+
+                return result;
+            }
+            catch (Exception ex)
+            {
+                sw.Stop();
+                _clientTelemetry.RecordReceiveStatusFailure(sw.ElapsedMilliseconds);
+                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+                throw;
+            }
         }
 
         // ── Type-parameterized runtime overloads ────────────────────────────
@@ -449,23 +631,33 @@ namespace Ratatosk
 
             await ResolveSenderAsync(message, settings, cancellationToken);
 
-            var result = await connector.SendMessageAsync(message, cancellationToken);
-            sw.Stop();
+            try
+            {
+                var result = await connector.SendMessageAsync(message, cancellationToken);
+                sw.Stop();
 
-            if (result.IsSuccess())
-            {
-                _clientTelemetry.RecordSendSuccess(sw.ElapsedMilliseconds);
-                activity?.SetStatus(ActivityStatusCode.Ok);
-                _logger.LogMessageSent(channelName);
+                if (result.IsSuccess())
+                {
+                    _clientTelemetry.RecordSendSuccess(sw.ElapsedMilliseconds);
+                    activity?.SetStatus(ActivityStatusCode.Ok);
+                    _logger.LogMessageSent(channelName);
+                }
+                else
+                {
+                    _clientTelemetry.RecordSendFailure(sw.ElapsedMilliseconds);
+                    activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
+                    _logger.LogMessageSendFailed(channelName, result.Error?.Message);
+                }
+
+                return result;
             }
-            else
+            catch (Exception ex)
             {
+                sw.Stop();
                 _clientTelemetry.RecordSendFailure(sw.ElapsedMilliseconds);
-                activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
-                _logger.LogMessageSendFailed(channelName, result.Error?.Message);
+                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+                throw;
             }
-
-            return result;
         }
 
         /// <inheritdoc/>
@@ -475,27 +667,44 @@ namespace Ratatosk
             var channelName = typeof(TConnector).Name;
 
             using var activity = _clientTelemetry.StartReceiveActivity(channelName);
+            var sw = Stopwatch.StartNew();
 
             var connector = await CreateRuntimeConnectorAsync<TConnector>(settings, cancellationToken);
             if (connector == null)
             {
+                sw.Stop();
+                _clientTelemetry.RecordReceiveFailure(sw.ElapsedMilliseconds);
                 activity?.SetStatus(ActivityStatusCode.Error, "Connector not found");
                 return OperationResult<ReceiveResult>.Fail(MessagingErrorCodes.ConnectorNotFound, MessagingErrorCodes.ErrorDomain, $"No connector type registered for '{channelName}'.");
             }
 
-            var result = await connector.ReceiveMessagesAsync(source, cancellationToken);
-            if (result.IsSuccess())
+            try
             {
-                activity?.SetStatus(ActivityStatusCode.Ok);
-                _logger.LogMessageReceived(channelName);
-            }
-            else
-            {
-                activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
-                _logger.LogMessageReceiveFailed(channelName, result.Error?.Message);
-            }
+                var result = await connector.ReceiveMessagesAsync(source, cancellationToken);
+                sw.Stop();
 
-            return result;
+                if (result.IsSuccess())
+                {
+                    _clientTelemetry.RecordReceiveSuccess(sw.ElapsedMilliseconds);
+                    activity?.SetStatus(ActivityStatusCode.Ok);
+                    _logger.LogMessageReceived(channelName);
+                }
+                else
+                {
+                    _clientTelemetry.RecordReceiveFailure(sw.ElapsedMilliseconds);
+                    activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
+                    _logger.LogMessageReceiveFailed(channelName, result.Error?.Message);
+                }
+
+                return result;
+            }
+            catch (Exception ex)
+            {
+                sw.Stop();
+                _clientTelemetry.RecordReceiveFailure(sw.ElapsedMilliseconds);
+                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+                throw;
+            }
         }
 
         /// <inheritdoc/>
@@ -505,27 +714,44 @@ namespace Ratatosk
             var channelName = typeof(TConnector).Name;
 
             using var activity = _clientTelemetry.StartStatusActivity(channelName);
+            var sw = Stopwatch.StartNew();
 
             var connector = await CreateRuntimeConnectorAsync<TConnector>(settings, cancellationToken);
             if (connector == null)
             {
+                sw.Stop();
+                _clientTelemetry.RecordStatusFailure(sw.ElapsedMilliseconds);
                 activity?.SetStatus(ActivityStatusCode.Error, "Connector not found");
                 return OperationResult<StatusInfo>.Fail(MessagingErrorCodes.ConnectorNotFound, MessagingErrorCodes.ErrorDomain, $"No connector type registered for '{channelName}'.");
             }
 
-            var result = await connector.GetStatusAsync(cancellationToken);
-            if (result.IsSuccess())
+            try
             {
-                activity?.SetStatus(ActivityStatusCode.Ok);
-                _logger.LogStatusRead(channelName);
-            }
-            else
-            {
-                activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
-                _logger.LogStatusReadFailed(channelName, result.Error?.Message);
-            }
+                var result = await connector.GetStatusAsync(cancellationToken);
+                sw.Stop();
 
-            return result;
+                if (result.IsSuccess())
+                {
+                    _clientTelemetry.RecordStatusSuccess(sw.ElapsedMilliseconds);
+                    activity?.SetStatus(ActivityStatusCode.Ok);
+                    _logger.LogStatusRead(channelName);
+                }
+                else
+                {
+                    _clientTelemetry.RecordStatusFailure(sw.ElapsedMilliseconds);
+                    activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
+                    _logger.LogStatusReadFailed(channelName, result.Error?.Message);
+                }
+
+                return result;
+            }
+            catch (Exception ex)
+            {
+                sw.Stop();
+                _clientTelemetry.RecordStatusFailure(sw.ElapsedMilliseconds);
+                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+                throw;
+            }
         }
 
         /// <inheritdoc/>
@@ -535,27 +761,44 @@ namespace Ratatosk
             var channelName = typeof(TConnector).Name;
 
             using var activity = _clientTelemetry.StartReceiveStatusActivity(channelName);
+            var sw = Stopwatch.StartNew();
 
             var connector = await CreateRuntimeConnectorAsync<TConnector>(settings, cancellationToken);
             if (connector == null)
             {
+                sw.Stop();
+                _clientTelemetry.RecordReceiveStatusFailure(sw.ElapsedMilliseconds);
                 activity?.SetStatus(ActivityStatusCode.Error, "Connector not found");
                 return OperationResult<StatusUpdateResult>.Fail(MessagingErrorCodes.ConnectorNotFound, MessagingErrorCodes.ErrorDomain, $"No connector type registered for '{channelName}'.");
             }
 
-            var result = await connector.ReceiveMessageStatusAsync(source, cancellationToken);
-            if (result.IsSuccess())
+            try
             {
-                activity?.SetStatus(ActivityStatusCode.Ok);
-                _logger.LogMessageStatusReceived(channelName);
-            }
-            else
-            {
-                activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
-                _logger.LogMessageStatusReceiveFailed(channelName, result.Error?.Message);
-            }
+                var result = await connector.ReceiveMessageStatusAsync(source, cancellationToken);
+                sw.Stop();
 
-            return result;
+                if (result.IsSuccess())
+                {
+                    _clientTelemetry.RecordReceiveStatusSuccess(sw.ElapsedMilliseconds);
+                    activity?.SetStatus(ActivityStatusCode.Ok);
+                    _logger.LogMessageStatusReceived(channelName);
+                }
+                else
+                {
+                    _clientTelemetry.RecordReceiveStatusFailure(sw.ElapsedMilliseconds);
+                    activity?.SetStatus(ActivityStatusCode.Error, result.Error?.Message);
+                    _logger.LogMessageStatusReceiveFailed(channelName, result.Error?.Message);
+                }
+
+                return result;
+            }
+            catch (Exception ex)
+            {
+                sw.Stop();
+                _clientTelemetry.RecordReceiveStatusFailure(sw.ElapsedMilliseconds);
+                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+                throw;
+            }
         }
 
         // ── Sender resolution ────────────────────────────────────────────────

--- a/src/Ratatosk/MessagingClientExtensions.cs
+++ b/src/Ratatosk/MessagingClientExtensions.cs
@@ -1,0 +1,233 @@
+namespace Ratatosk;
+
+/// <summary>
+/// Extension methods for <see cref="IMessagingClient"/> that provide
+/// the legacy flat-parameter overloads, delegating to the request-object
+/// core methods.
+/// </summary>
+public static class MessagingClientExtensions
+{
+    // ── SendAsync ────────────────────────────────────────────────────────
+
+    /// <inheritdoc cref="IMessagingClient.SendAsync(SendRequest, CancellationToken)"/>
+    public static Task<OperationResult<SendResult>> SendAsync(
+        this IMessagingClient client,
+        string channelName, IMessage message,
+        CancellationToken cancellationToken = default)
+        => client.SendAsync(new SendRequest(channelName, message), cancellationToken);
+
+    /// <inheritdoc cref="IMessagingClient.SendAsync(SendRequest, CancellationToken)"/>
+    public static Task<OperationResult<SendResult>> SendAsync(
+        this IMessagingClient client,
+        string channelName, ConnectionSettings settings, IMessage message,
+        CancellationToken cancellationToken = default)
+        => client.SendAsync(
+            new SendRequest(channelName, message) { ConnectionSettings = settings },
+            cancellationToken);
+
+    /// <inheritdoc cref="IMessagingClient.SendAsync(SendRequest, CancellationToken)"/>
+    public static Task<OperationResult<SendResult>> SendAsync<TConnector>(
+        this IMessagingClient client,
+        IMessage message,
+        CancellationToken cancellationToken = default)
+        where TConnector : class, IChannelConnector
+        => client.SendAsync(
+            new SendRequest(typeof(TConnector).Name, message)
+            {
+                ConnectorType = typeof(TConnector)
+            },
+            cancellationToken);
+
+    /// <inheritdoc cref="IMessagingClient.SendAsync(SendRequest, CancellationToken)"/>
+    public static Task<OperationResult<SendResult>> SendAsync<TConnector>(
+        this IMessagingClient client,
+        ConnectionSettings settings, IMessage message,
+        CancellationToken cancellationToken = default)
+        where TConnector : class, IChannelConnector
+        => client.SendAsync(
+            new SendRequest(typeof(TConnector).Name, message)
+            {
+                ConnectionSettings = settings,
+                ConnectorType = typeof(TConnector)
+            },
+            cancellationToken);
+
+    // ── SendBatchAsync (new) ─────────────────────────────────────────────
+
+    /// <inheritdoc cref="IMessagingClient.SendBatchAsync(BatchSendRequest, CancellationToken)"/>
+    public static Task<OperationResult<BatchSendResult>> SendBatchAsync(
+        this IMessagingClient client,
+        string channelName, IMessageBatch batch,
+        CancellationToken cancellationToken = default)
+        => client.SendBatchAsync(new BatchSendRequest(channelName, batch), cancellationToken);
+
+    /// <inheritdoc cref="IMessagingClient.SendBatchAsync(BatchSendRequest, CancellationToken)"/>
+    public static Task<OperationResult<BatchSendResult>> SendBatchAsync(
+        this IMessagingClient client,
+        string channelName, ConnectionSettings settings, IMessageBatch batch,
+        CancellationToken cancellationToken = default)
+        => client.SendBatchAsync(
+            new BatchSendRequest(channelName, batch) { ConnectionSettings = settings },
+            cancellationToken);
+
+    /// <inheritdoc cref="IMessagingClient.SendBatchAsync(BatchSendRequest, CancellationToken)"/>
+    public static Task<OperationResult<BatchSendResult>> SendBatchAsync<TConnector>(
+        this IMessagingClient client,
+        IMessageBatch batch,
+        CancellationToken cancellationToken = default)
+        where TConnector : class, IChannelConnector
+        => client.SendBatchAsync(
+            new BatchSendRequest(typeof(TConnector).Name, batch)
+            {
+                ConnectorType = typeof(TConnector)
+            },
+            cancellationToken);
+
+    /// <inheritdoc cref="IMessagingClient.SendBatchAsync(BatchSendRequest, CancellationToken)"/>
+    public static Task<OperationResult<BatchSendResult>> SendBatchAsync<TConnector>(
+        this IMessagingClient client,
+        ConnectionSettings settings, IMessageBatch batch,
+        CancellationToken cancellationToken = default)
+        where TConnector : class, IChannelConnector
+        => client.SendBatchAsync(
+            new BatchSendRequest(typeof(TConnector).Name, batch)
+            {
+                ConnectionSettings = settings,
+                ConnectorType = typeof(TConnector)
+            },
+            cancellationToken);
+
+    // ── ReceiveAsync ─────────────────────────────────────────────────────
+
+    /// <inheritdoc cref="IMessagingClient.ReceiveAsync(ReceiveRequest, CancellationToken)"/>
+    public static Task<OperationResult<ReceiveResult>> ReceiveAsync(
+        this IMessagingClient client,
+        string channelName, MessageSource source,
+        CancellationToken cancellationToken = default)
+        => client.ReceiveAsync(new ReceiveRequest(channelName, source), cancellationToken);
+
+    /// <inheritdoc cref="IMessagingClient.ReceiveAsync(ReceiveRequest, CancellationToken)"/>
+    public static Task<OperationResult<ReceiveResult>> ReceiveAsync(
+        this IMessagingClient client,
+        string channelName, ConnectionSettings settings, MessageSource source,
+        CancellationToken cancellationToken = default)
+        => client.ReceiveAsync(
+            new ReceiveRequest(channelName, source) { ConnectionSettings = settings },
+            cancellationToken);
+
+    /// <inheritdoc cref="IMessagingClient.ReceiveAsync(ReceiveRequest, CancellationToken)"/>
+    public static Task<OperationResult<ReceiveResult>> ReceiveAsync<TConnector>(
+        this IMessagingClient client,
+        MessageSource source,
+        CancellationToken cancellationToken = default)
+        where TConnector : class, IChannelConnector
+        => client.ReceiveAsync(
+            new ReceiveRequest(typeof(TConnector).Name, source)
+            {
+                ConnectorType = typeof(TConnector)
+            },
+            cancellationToken);
+
+    /// <inheritdoc cref="IMessagingClient.ReceiveAsync(ReceiveRequest, CancellationToken)"/>
+    public static Task<OperationResult<ReceiveResult>> ReceiveAsync<TConnector>(
+        this IMessagingClient client,
+        ConnectionSettings settings, MessageSource source,
+        CancellationToken cancellationToken = default)
+        where TConnector : class, IChannelConnector
+        => client.ReceiveAsync(
+            new ReceiveRequest(typeof(TConnector).Name, source)
+            {
+                ConnectionSettings = settings,
+                ConnectorType = typeof(TConnector)
+            },
+            cancellationToken);
+
+    // ── GetStatusAsync ───────────────────────────────────────────────────
+
+    /// <inheritdoc cref="IMessagingClient.GetStatusAsync(StatusRequest, CancellationToken)"/>
+    public static Task<OperationResult<StatusInfo>> GetStatusAsync(
+        this IMessagingClient client,
+        string channelName,
+        CancellationToken cancellationToken = default)
+        => client.GetStatusAsync(new StatusRequest(channelName), cancellationToken);
+
+    /// <inheritdoc cref="IMessagingClient.GetStatusAsync(StatusRequest, CancellationToken)"/>
+    public static Task<OperationResult<StatusInfo>> GetStatusAsync(
+        this IMessagingClient client,
+        string channelName, ConnectionSettings settings,
+        CancellationToken cancellationToken = default)
+        => client.GetStatusAsync(
+            new StatusRequest(channelName) { ConnectionSettings = settings },
+            cancellationToken);
+
+    /// <inheritdoc cref="IMessagingClient.GetStatusAsync(StatusRequest, CancellationToken)"/>
+    public static Task<OperationResult<StatusInfo>> GetStatusAsync<TConnector>(
+        this IMessagingClient client,
+        CancellationToken cancellationToken = default)
+        where TConnector : class, IChannelConnector
+        => client.GetStatusAsync(
+            new StatusRequest(typeof(TConnector).Name)
+            {
+                ConnectorType = typeof(TConnector)
+            },
+            cancellationToken);
+
+    /// <inheritdoc cref="IMessagingClient.GetStatusAsync(StatusRequest, CancellationToken)"/>
+    public static Task<OperationResult<StatusInfo>> GetStatusAsync<TConnector>(
+        this IMessagingClient client,
+        ConnectionSettings settings,
+        CancellationToken cancellationToken = default)
+        where TConnector : class, IChannelConnector
+        => client.GetStatusAsync(
+            new StatusRequest(typeof(TConnector).Name)
+            {
+                ConnectionSettings = settings,
+                ConnectorType = typeof(TConnector)
+            },
+            cancellationToken);
+
+    // ── ReceiveMessageStatusAsync ────────────────────────────────────────
+
+    /// <inheritdoc cref="IMessagingClient.ReceiveMessageStatusAsync(ReceiveStatusRequest, CancellationToken)"/>
+    public static Task<OperationResult<StatusUpdateResult>> ReceiveMessageStatusAsync(
+        this IMessagingClient client,
+        string channelName, MessageSource source,
+        CancellationToken cancellationToken = default)
+        => client.ReceiveMessageStatusAsync(new ReceiveStatusRequest(channelName, source), cancellationToken);
+
+    /// <inheritdoc cref="IMessagingClient.ReceiveMessageStatusAsync(ReceiveStatusRequest, CancellationToken)"/>
+    public static Task<OperationResult<StatusUpdateResult>> ReceiveMessageStatusAsync(
+        this IMessagingClient client,
+        string channelName, ConnectionSettings settings, MessageSource source,
+        CancellationToken cancellationToken = default)
+        => client.ReceiveMessageStatusAsync(
+            new ReceiveStatusRequest(channelName, source) { ConnectionSettings = settings },
+            cancellationToken);
+
+    /// <inheritdoc cref="IMessagingClient.ReceiveMessageStatusAsync(ReceiveStatusRequest, CancellationToken)"/>
+    public static Task<OperationResult<StatusUpdateResult>> ReceiveMessageStatusAsync<TConnector>(
+        this IMessagingClient client,
+        MessageSource source,
+        CancellationToken cancellationToken = default)
+        where TConnector : class, IChannelConnector
+        => client.ReceiveMessageStatusAsync(
+            new ReceiveStatusRequest(typeof(TConnector).Name, source)
+            {
+                ConnectorType = typeof(TConnector)
+            },
+            cancellationToken);
+
+    /// <inheritdoc cref="IMessagingClient.ReceiveMessageStatusAsync(ReceiveStatusRequest, CancellationToken)"/>
+    public static Task<OperationResult<StatusUpdateResult>> ReceiveMessageStatusAsync<TConnector>(
+        this IMessagingClient client,
+        ConnectionSettings settings, MessageSource source,
+        CancellationToken cancellationToken = default)
+        where TConnector : class, IChannelConnector
+        => client.ReceiveMessageStatusAsync(
+            new ReceiveStatusRequest(typeof(TConnector).Name, source)
+            {
+                ConnectionSettings = settings,
+                ConnectorType = typeof(TConnector)
+            },
+            cancellationToken);
+}

--- a/src/Ratatosk/MessagingClientOptions.cs
+++ b/src/Ratatosk/MessagingClientOptions.cs
@@ -39,5 +39,10 @@ namespace Ratatosk
         /// do not provide their own. A value of <c>0</c> means no timeout.
         /// </remarks>
         public int DefaultTimeoutSeconds { get; set; } = 30;
+
+        /// <summary>
+        /// Gets or sets the telemetry configuration for the messaging client.
+        /// </summary>
+        public TelemetryOptions Telemetry { get; set; } = new();
     }
 }

--- a/src/Ratatosk/Ratatosk.csproj
+++ b/src/Ratatosk/Ratatosk.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net9.0'">
@@ -23,6 +24,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.16" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.16" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.6" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'net10.0'">
@@ -31,6 +33,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.8" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.0" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="10.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Using Include="Deveel" />

--- a/src/Ratatosk/ReceiveRequest.cs
+++ b/src/Ratatosk/ReceiveRequest.cs
@@ -1,0 +1,17 @@
+namespace Ratatosk;
+
+public class ReceiveRequest
+{
+    public string ChannelName { get; }
+    public MessageSource Source { get; }
+    public ConnectionSettings? ConnectionSettings { get; init; }
+    public Type? ConnectorType { get; init; }
+    public MessageContext? Context { get; init; }
+
+    public ReceiveRequest(string channelName, MessageSource source)
+    {
+        ArgumentNullException.ThrowIfNull(channelName);
+        ChannelName = channelName;
+        Source = source;
+    }
+}

--- a/src/Ratatosk/ReceiveStatusRequest.cs
+++ b/src/Ratatosk/ReceiveStatusRequest.cs
@@ -1,0 +1,17 @@
+namespace Ratatosk;
+
+public class ReceiveStatusRequest
+{
+    public string ChannelName { get; }
+    public MessageSource Source { get; }
+    public ConnectionSettings? ConnectionSettings { get; init; }
+    public Type? ConnectorType { get; init; }
+    public MessageContext? Context { get; init; }
+
+    public ReceiveStatusRequest(string channelName, MessageSource source)
+    {
+        ArgumentNullException.ThrowIfNull(channelName);
+        ChannelName = channelName;
+        Source = source;
+    }
+}

--- a/src/Ratatosk/SendRequest.cs
+++ b/src/Ratatosk/SendRequest.cs
@@ -1,0 +1,18 @@
+namespace Ratatosk;
+
+public class SendRequest
+{
+    public string ChannelName { get; }
+    public IMessage Message { get; }
+    public ConnectionSettings? ConnectionSettings { get; init; }
+    public Type? ConnectorType { get; init; }
+    public MessageContext? Context { get; init; }
+
+    public SendRequest(string channelName, IMessage message)
+    {
+        ArgumentNullException.ThrowIfNull(channelName);
+        ArgumentNullException.ThrowIfNull(message);
+        ChannelName = channelName;
+        Message = message;
+    }
+}

--- a/src/Ratatosk/StatusRequest.cs
+++ b/src/Ratatosk/StatusRequest.cs
@@ -1,0 +1,15 @@
+namespace Ratatosk;
+
+public class StatusRequest
+{
+    public string ChannelName { get; }
+    public ConnectionSettings? ConnectionSettings { get; init; }
+    public Type? ConnectorType { get; init; }
+    public MessageContext? Context { get; init; }
+
+    public StatusRequest(string channelName)
+    {
+        ArgumentNullException.ThrowIfNull(channelName);
+        ChannelName = channelName;
+    }
+}

--- a/test/Ratatosk.Connectors.XUnit/Unit/ConnectorTelemetryTests.cs
+++ b/test/Ratatosk.Connectors.XUnit/Unit/ConnectorTelemetryTests.cs
@@ -1,0 +1,393 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace Ratatosk;
+
+[Trait("Category", "Unit")]
+[Trait("Feature", "Telemetry")]
+public class ConnectorTelemetryTests
+{
+    private sealed class TelemetryTestConnector : ChannelConnectorBase
+    {
+        public TelemetryTestConnector(IChannelSchema schema, ConnectionSettings? settings = null)
+            : base(schema, settings ?? new ConnectionSettings())
+        {
+        }
+
+        public bool FailSend { get; set; }
+        public bool FailReceive { get; set; }
+
+        protected override ValueTask InitializeConnectorAsync(CancellationToken cancellationToken)
+        {
+            SetState(ConnectorState.Ready);
+            return ValueTask.CompletedTask;
+        }
+
+        protected override ValueTask TestConnectorConnectionAsync(CancellationToken cancellationToken)
+            => ValueTask.CompletedTask;
+
+        protected override Task<SendResult> SendMessageCoreAsync(IMessage message, CancellationToken cancellationToken)
+        {
+            if (FailSend)
+                throw new ConnectorException("SEND_ERROR", "Test", "Send failed");
+
+            return Task.FromResult(new SendResult(message.Id!, "remote-id")
+            {
+                Status = MessageStatus.Delivered
+            });
+        }
+
+        protected override Task<StatusInfo> GetConnectorStatusAsync(CancellationToken cancellationToken)
+            => Task.FromResult(new StatusInfo("OK"));
+
+        protected override Task<ReceiveResult> ReceiveMessagesCoreAsync(MessageSource source, CancellationToken cancellationToken)
+        {
+            if (FailReceive)
+                throw new ConnectorException("RECV_ERROR", "Test", "Receive failed");
+
+            var messages = new List<IMessage>
+            {
+                new Message { Id = "recv-1" },
+                new Message { Id = "recv-2" }
+            };
+
+            return Task.FromResult(new ReceiveResult("batch-1", messages));
+        }
+    }
+
+    private static IChannelSchema CreateSchema()
+        => new ChannelSchemaBuilder("TestProvider", "test", "1.0")
+            .WithCapabilities(ChannelCapability.SendMessages | ChannelCapability.ReceiveMessages | ChannelCapability.HealthCheck)
+            .HandlesMessageEndpoint(EndpointType.PhoneNumber, e => { e.CanSend = true; e.CanReceive = true; })
+            .Build();
+
+    private static Message CreateTestMessage()
+        => new Message
+        {
+            Id = "msg-1",
+            Sender = new Endpoint(EndpointType.PhoneNumber, "+1234"),
+            Receiver = new Endpoint(EndpointType.PhoneNumber, "+5678")
+        };
+
+    [Fact]
+    public async Task SendOperation_CreatesActivity()
+    {
+        var events = new List<Activity>();
+
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name.StartsWith("Ratatosk.Connector."),
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStarted = activity => events.Add(activity)
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        var schema = CreateSchema();
+        var connector = new TelemetryTestConnector(schema);
+        await connector.InitializeAsync(TestContext.Current.CancellationToken);
+
+        var message = CreateTestMessage();
+        var result = await connector.SendMessageAsync(message, TestContext.Current.CancellationToken);
+
+        Assert.True(result.IsSuccess());
+        Assert.Contains(events, a =>
+            a.OperationName.Contains("send") &&
+            a.Tags.Any(t => t.Key == "messaging.operation" && (string?)t.Value == "send"));
+    }
+
+    [Fact]
+    public async Task SendOperation_RecordsSentCounter()
+    {
+        var counterValues = new List<int>();
+
+        using var meterListener = new MeterListener
+        {
+            InstrumentPublished = (instrument, listener) =>
+            {
+                if (instrument.Name == "ratatosk.messages.sent")
+                    listener.EnableMeasurementEvents(instrument);
+            }
+        };
+        meterListener.SetMeasurementEventCallback<int>((instrument, value, _, _) =>
+        {
+            if (instrument.Name == "ratatosk.messages.sent")
+                counterValues.Add(value);
+        });
+        meterListener.Start();
+
+        var schema = CreateSchema();
+        var connector = new TelemetryTestConnector(schema);
+        await connector.InitializeAsync(TestContext.Current.CancellationToken);
+
+        var message = CreateTestMessage();
+        await connector.SendMessageAsync(message, TestContext.Current.CancellationToken);
+
+        meterListener.RecordObservableInstruments();
+
+        Assert.Contains(counterValues, v => v > 0);
+    }
+
+    [Fact]
+    public async Task SendOperation_Failure_RecordsFailedCounter()
+    {
+        var failedValues = new List<int>();
+
+        using var meterListener = new MeterListener
+        {
+            InstrumentPublished = (instrument, listener) =>
+            {
+                if (instrument.Name is "ratatosk.messages.send_failed")
+                    listener.EnableMeasurementEvents(instrument);
+            }
+        };
+        meterListener.SetMeasurementEventCallback<int>((instrument, value, _, _) =>
+        {
+            if (instrument.Name == "ratatosk.messages.send_failed")
+                failedValues.Add(value);
+        });
+        meterListener.Start();
+
+        var schema = CreateSchema();
+        var connector = new TelemetryTestConnector(schema) { FailSend = true };
+        await connector.InitializeAsync(TestContext.Current.CancellationToken);
+
+        var message = CreateTestMessage();
+        await connector.SendMessageAsync(message, TestContext.Current.CancellationToken);
+
+        meterListener.RecordObservableInstruments();
+
+        Assert.Contains(failedValues, v => v > 0);
+    }
+
+    [Fact]
+    public async Task SendOperation_TagsMessageId()
+    {
+        Activity? captured = null;
+
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name.StartsWith("Ratatosk.Connector."),
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStarted = activity =>
+            {
+                if (activity.OperationName.Contains("send"))
+                    captured = activity;
+            }
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        var schema = CreateSchema();
+        var connector = new TelemetryTestConnector(schema);
+        await connector.InitializeAsync(TestContext.Current.CancellationToken);
+
+        var message = CreateTestMessage();
+        await connector.SendMessageAsync(message, TestContext.Current.CancellationToken);
+
+        Assert.NotNull(captured);
+        Assert.Contains(captured.Tags, t => t.Key == "messaging.message.id" && (string?)t.Value == "msg-1");
+    }
+
+    [Fact]
+    public async Task ReceiveOperation_CreatesActivity()
+    {
+        var events = new List<Activity>();
+
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name.StartsWith("Ratatosk.Connector."),
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStarted = activity => events.Add(activity)
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        var schema = CreateSchema();
+        var connector = new TelemetryTestConnector(schema);
+        await connector.InitializeAsync(TestContext.Current.CancellationToken);
+
+        var source = MessageSource.Text("{}");
+        var result = await connector.ReceiveMessagesAsync(source, TestContext.Current.CancellationToken);
+
+        Assert.True(result.IsSuccess());
+        Assert.Contains(events, a =>
+            a.OperationName.Contains("receive") &&
+            a.Tags.Any(t => t.Key == "messaging.operation" && (string?)t.Value == "receive"));
+    }
+
+    [Fact]
+    public async Task ReceiveOperation_RecordsMetrics()
+    {
+        var recvValues = new List<int>();
+
+        using var meterListener = new MeterListener
+        {
+            InstrumentPublished = (instrument, listener) =>
+            {
+                if (instrument.Name == "ratatosk.messages.received")
+                    listener.EnableMeasurementEvents(instrument);
+            }
+        };
+        meterListener.SetMeasurementEventCallback<int>((instrument, value, _, _) =>
+        {
+            if (instrument.Name == "ratatosk.messages.received")
+                recvValues.Add(value);
+        });
+        meterListener.Start();
+
+        var schema = CreateSchema();
+        var connector = new TelemetryTestConnector(schema);
+        await connector.InitializeAsync(TestContext.Current.CancellationToken);
+
+        var source = MessageSource.Text("{}");
+        await connector.ReceiveMessagesAsync(source, TestContext.Current.CancellationToken);
+
+        meterListener.RecordObservableInstruments();
+
+        Assert.Contains(recvValues, v => v > 0);
+    }
+
+    [Fact]
+    public async Task ReceiveOperation_Failure_RecordsFailedCounter()
+    {
+        var failedValues = new List<int>();
+
+        using var meterListener = new MeterListener
+        {
+            InstrumentPublished = (instrument, listener) =>
+            {
+                if (instrument.Name == "ratatosk.messages.receive_failed")
+                    listener.EnableMeasurementEvents(instrument);
+            }
+        };
+        meterListener.SetMeasurementEventCallback<int>((instrument, value, _, _) =>
+        {
+            if (instrument.Name == "ratatosk.messages.receive_failed")
+                failedValues.Add(value);
+        });
+        meterListener.Start();
+
+        var schema = CreateSchema();
+        var connector = new TelemetryTestConnector(schema) { FailReceive = true };
+        await connector.InitializeAsync(TestContext.Current.CancellationToken);
+
+        var source = MessageSource.Text("{}");
+        await connector.ReceiveMessagesAsync(source, TestContext.Current.CancellationToken);
+
+        meterListener.RecordObservableInstruments();
+
+        Assert.Contains(failedValues, v => v > 0);
+    }
+
+    [Fact]
+    public async Task InitializeOperation_CreatesActivity()
+    {
+        Activity? captured = null;
+
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name.StartsWith("Ratatosk.Connector."),
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStarted = activity =>
+            {
+                if (activity.OperationName.Contains("initialize"))
+                    captured = activity;
+            }
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        var schema = CreateSchema();
+        var connector = new TelemetryTestConnector(schema);
+        var result = await connector.InitializeAsync(TestContext.Current.CancellationToken);
+
+        Assert.True(result.IsSuccess());
+        Assert.NotNull(captured);
+        Assert.Contains(captured.Tags, t => t.Key == "messaging.operation" && (string?)t.Value == "initialize");
+    }
+
+    [Fact]
+    public async Task MultipleConnectors_HaveSeparateSources()
+    {
+        var sources = new HashSet<string>();
+
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source =>
+            {
+                sources.Add(source.Name);
+                return source.Name.StartsWith("Ratatosk.Connector.");
+            },
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        var schema1 = new ChannelSchemaBuilder("ProviderA", "type-a", "1.0")
+            .WithCapabilities(ChannelCapability.SendMessages)
+            .HandlesMessageEndpoint(EndpointType.PhoneNumber, e => { e.CanSend = true; })
+            .Build();
+
+        var schema2 = new ChannelSchemaBuilder("ProviderB", "type-b", "1.0")
+            .WithCapabilities(ChannelCapability.SendMessages)
+            .HandlesMessageEndpoint(EndpointType.PhoneNumber, e => { e.CanSend = true; })
+            .Build();
+
+        var connector1 = new TelemetryTestConnector(schema1);
+        var connector2 = new TelemetryTestConnector(schema2);
+
+        await connector1.InitializeAsync(TestContext.Current.CancellationToken);
+        await connector2.InitializeAsync(TestContext.Current.CancellationToken);
+
+        Assert.Contains(sources, s => s.Contains("type-a"));
+        Assert.Contains(sources, s => s.Contains("type-b"));
+    }
+
+    [Fact]
+    public async Task StatusQuery_CreatesActivity()
+    {
+        Activity? captured = null;
+
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name.StartsWith("Ratatosk.Connector."),
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStarted = activity =>
+            {
+                if (activity.OperationName.Contains("status_query"))
+                    captured = activity;
+            }
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        var schema = CreateSchema();
+        var connector = new TelemetryTestConnector(schema);
+        await connector.InitializeAsync(TestContext.Current.CancellationToken);
+
+        await connector.GetStatusAsync(TestContext.Current.CancellationToken);
+
+        Assert.NotNull(captured);
+    }
+
+    [Fact]
+    public async Task HealthCheck_CreatesActivity()
+    {
+        Activity? captured = null;
+
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name.StartsWith("Ratatosk.Connector."),
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStarted = activity =>
+            {
+                if (activity.OperationName.Contains("health_check"))
+                    captured = activity;
+            }
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        var schema = CreateSchema();
+        var connector = new TelemetryTestConnector(schema);
+        await connector.InitializeAsync(TestContext.Current.CancellationToken);
+
+        await connector.GetHealthAsync(TestContext.Current.CancellationToken);
+
+        Assert.NotNull(captured);
+    }
+}

--- a/test/Ratatosk.Extensions.OpenTelemetry.XUnit/Ratatosk.Extensions.OpenTelemetry.XUnit.csproj
+++ b/test/Ratatosk.Extensions.OpenTelemetry.XUnit/Ratatosk.Extensions.OpenTelemetry.XUnit.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Title>Ratatosk OpenTelemetry Tests</Title>
+    <Description>Unit tests for the Ratatosk OpenTelemetry instrumentation package.</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Ratatosk.Extensions.OpenTelemetry\Ratatosk.Extensions.OpenTelemetry.csproj" />
+    <ProjectReference Include="..\..\src\Ratatosk\Ratatosk.csproj" />
+  </ItemGroup>
+</Project>

--- a/test/Ratatosk.Extensions.OpenTelemetry.XUnit/Ratatosk.Extensions.OpenTelemetry.XUnit.csproj
+++ b/test/Ratatosk.Extensions.OpenTelemetry.XUnit/Ratatosk.Extensions.OpenTelemetry.XUnit.csproj
@@ -8,4 +8,16 @@
     <ProjectReference Include="..\..\src\Ratatosk.Extensions.OpenTelemetry\Ratatosk.Extensions.OpenTelemetry.csproj" />
     <ProjectReference Include="..\..\src\Ratatosk\Ratatosk.csproj" />
   </ItemGroup>
+
+  <ItemGroup Condition="$(TargetFramework) == 'net8.0'">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(TargetFramework) == 'net9.0'">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.16" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(TargetFramework) == 'net10.0'">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+  </ItemGroup>
 </Project>

--- a/test/Ratatosk.Extensions.OpenTelemetry.XUnit/Unit/OpenTelemetryBuilderExtensionsTests.cs
+++ b/test/Ratatosk.Extensions.OpenTelemetry.XUnit/Unit/OpenTelemetryBuilderExtensionsTests.cs
@@ -14,102 +14,75 @@ namespace Ratatosk;
 public class OpenTelemetryBuilderExtensionsTests
 {
     [Fact]
-    public void AddRatatoskInstrumentation_OnTracerProviderBuilder_RegistersClientSource()
+    public void AddRatatoskInstrumentation_OnTracerProviderBuilder_ExportsClientActivities()
     {
-        var sourceNames = new List<string>();
+        var processor = new TestActivityProcessor();
 
         using var tracerProvider = Sdk.CreateTracerProviderBuilder()
             .AddRatatoskInstrumentation()
+            .AddProcessor(processor)
             .Build();
 
-        // Verify by checking that sources are added (via listener detection)
-        using var listener = new ActivityListener
-        {
-            ShouldListenTo = source =>
-            {
-                sourceNames.Add(source.Name);
-                return false;
-            },
-            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.None
-        };
-        ActivitySource.AddActivityListener(listener);
+        var source = new ActivitySource("Ratatosk.Client");
+        using var activity = source.StartActivity("test-activity");
+        activity?.Stop();
 
-        _ = new ActivitySource("Ratatosk.Client");
-        _ = new ActivitySource("Ratatosk.Connector.TwilioSms");
-
-        Assert.Contains(sourceNames, s => s == "Ratatosk.Client");
+        Assert.Contains(processor.Exported, a => a.Source.Name == "Ratatosk.Client");
     }
 
     [Fact]
-    public void AddRatatoskInstrumentation_OnTracerProviderBuilder_RegistersConnectorWildcard()
+    public void AddRatatoskInstrumentation_OnTracerProviderBuilder_ExportsConnectorActivities()
     {
-        var sourceNames = new List<string>();
+        var processor = new TestActivityProcessor();
 
         using var tracerProvider = Sdk.CreateTracerProviderBuilder()
             .AddRatatoskInstrumentation()
+            .AddProcessor(processor)
             .Build();
 
-        using var listener = new ActivityListener
-        {
-            ShouldListenTo = source =>
-            {
-                sourceNames.Add(source.Name);
-                return false;
-            },
-            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.None
-        };
-        ActivitySource.AddActivityListener(listener);
+        var source = new ActivitySource("Ratatosk.Connector.TwilioSms");
+        using var activity = source.StartActivity("test-activity");
+        activity?.Stop();
 
-        _ = new ActivitySource("Ratatosk.Connector.TwilioSms");
-        _ = new ActivitySource("Ratatosk.Connector.SendGridEmail");
-
-        Assert.Contains(sourceNames, s => s == "Ratatosk.Connector.TwilioSms");
-        Assert.Contains(sourceNames, s => s == "Ratatosk.Connector.SendGridEmail");
+        Assert.Contains(processor.Exported, a => a.Source.Name == "Ratatosk.Connector.TwilioSms");
     }
 
     [Fact]
-    public void AddRatatoskInstrumentation_OnMeterProviderBuilder_RegistersClientMeter()
+    public void AddRatatoskInstrumentation_OnMeterProviderBuilder_ExportsClientMetrics()
     {
-        var meterNames = new List<string>();
+        var exporter = new TestMetricExporter();
 
         using var meterProvider = Sdk.CreateMeterProviderBuilder()
             .AddRatatoskInstrumentation()
+            .AddReader(new PeriodicExportingMetricReader(exporter, 10) { TemporalityPreference = MetricReaderTemporalityPreference.Cumulative })
             .Build();
 
-        using var meterListener = new MeterListener
-        {
-            InstrumentPublished = (instrument, listener) => { }
-        };
+        var meter = new Meter("Ratatosk.Client");
+        var counter = meter.CreateCounter<int>("test_counter");
+        counter.Add(1);
 
-        // Create meters to verify they are registered
-        var meter1 = new Meter("Ratatosk.Client");
-        var meter2 = new Meter("Ratatosk.Connector.TwilioSms");
+        meterProvider.ForceFlush();
 
-        // No exception thrown = registration succeeded
-        Assert.NotNull(meter1);
-        Assert.NotNull(meter2);
+        Assert.Contains(exporter.Exported, m => m.MeterName == "Ratatosk.Client");
     }
 
     [Fact]
-    public void AddRatatoskInstrumentation_OnMeterProviderBuilder_RegistersConnectorWildcard()
+    public void AddRatatoskInstrumentation_OnMeterProviderBuilder_ExportsConnectorMetrics()
     {
+        var exporter = new TestMetricExporter();
+
         using var meterProvider = Sdk.CreateMeterProviderBuilder()
             .AddRatatoskInstrumentation()
+            .AddReader(new PeriodicExportingMetricReader(exporter, 10) { TemporalityPreference = MetricReaderTemporalityPreference.Cumulative })
             .Build();
-
-        using var meterListener = new MeterListener
-        {
-            InstrumentPublished = (instrument, listener) => { }
-        };
-        meterListener.Start();
 
         var meter = new Meter("Ratatosk.Connector.SendGridEmail");
-        var counter = meter.CreateCounter<int>("test");
+        var counter = meter.CreateCounter<int>("test_counter");
+        counter.Add(1);
 
-        meterListener.RecordObservableInstruments();
+        meterProvider.ForceFlush();
 
-        // No exception = registration succeeded
-        Assert.NotNull(counter);
+        Assert.Contains(exporter.Exported, m => m.MeterName == "Ratatosk.Connector.SendGridEmail");
     }
 
     [Fact]
@@ -150,7 +123,6 @@ public class OpenTelemetryBuilderExtensionsTests
 
         var provider = services.BuildServiceProvider();
 
-        // OpenTelemetry hosting integration registers these services
         var tracerProvider = provider.GetService<TracerProvider>();
         var meterProvider = provider.GetService<MeterProvider>();
 
@@ -168,5 +140,28 @@ public class OpenTelemetryBuilderExtensionsTests
 
         Assert.NotNull(builder);
         Assert.Same(services, builder.Services);
+    }
+
+    private sealed class TestActivityProcessor : BaseProcessor<Activity>
+    {
+        public List<Activity> Exported { get; } = new();
+
+        public override void OnEnd(Activity data)
+        {
+            Exported.Add(data);
+            base.OnEnd(data);
+        }
+    }
+
+    private sealed class TestMetricExporter : BaseExporter<Metric>
+    {
+        public List<Metric> Exported { get; } = new();
+
+        public override ExportResult Export(in Batch<Metric> batch)
+        {
+            foreach (var metric in batch)
+                Exported.Add(metric);
+            return ExportResult.Success;
+        }
     }
 }

--- a/test/Ratatosk.Extensions.OpenTelemetry.XUnit/Unit/OpenTelemetryBuilderExtensionsTests.cs
+++ b/test/Ratatosk.Extensions.OpenTelemetry.XUnit/Unit/OpenTelemetryBuilderExtensionsTests.cs
@@ -1,0 +1,172 @@
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
+namespace Ratatosk;
+
+[Trait("Category", "Unit")]
+[Trait("Feature", "OpenTelemetry")]
+public class OpenTelemetryBuilderExtensionsTests
+{
+    [Fact]
+    public void AddRatatoskInstrumentation_OnTracerProviderBuilder_RegistersClientSource()
+    {
+        var sourceNames = new List<string>();
+
+        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddRatatoskInstrumentation()
+            .Build();
+
+        // Verify by checking that sources are added (via listener detection)
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source =>
+            {
+                sourceNames.Add(source.Name);
+                return false;
+            },
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.None
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        _ = new ActivitySource("Ratatosk.Client");
+        _ = new ActivitySource("Ratatosk.Connector.TwilioSms");
+
+        Assert.Contains(sourceNames, s => s == "Ratatosk.Client");
+    }
+
+    [Fact]
+    public void AddRatatoskInstrumentation_OnTracerProviderBuilder_RegistersConnectorWildcard()
+    {
+        var sourceNames = new List<string>();
+
+        using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+            .AddRatatoskInstrumentation()
+            .Build();
+
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source =>
+            {
+                sourceNames.Add(source.Name);
+                return false;
+            },
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.None
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        _ = new ActivitySource("Ratatosk.Connector.TwilioSms");
+        _ = new ActivitySource("Ratatosk.Connector.SendGridEmail");
+
+        Assert.Contains(sourceNames, s => s == "Ratatosk.Connector.TwilioSms");
+        Assert.Contains(sourceNames, s => s == "Ratatosk.Connector.SendGridEmail");
+    }
+
+    [Fact]
+    public void AddRatatoskInstrumentation_OnMeterProviderBuilder_RegistersClientMeter()
+    {
+        var meterNames = new List<string>();
+
+        using var meterProvider = Sdk.CreateMeterProviderBuilder()
+            .AddRatatoskInstrumentation()
+            .Build();
+
+        using var meterListener = new MeterListener
+        {
+            InstrumentPublished = (instrument, listener) => { }
+        };
+
+        // Create meters to verify they are registered
+        var meter1 = new Meter("Ratatosk.Client");
+        var meter2 = new Meter("Ratatosk.Connector.TwilioSms");
+
+        // No exception thrown = registration succeeded
+        Assert.NotNull(meter1);
+        Assert.NotNull(meter2);
+    }
+
+    [Fact]
+    public void AddRatatoskInstrumentation_OnMeterProviderBuilder_RegistersConnectorWildcard()
+    {
+        using var meterProvider = Sdk.CreateMeterProviderBuilder()
+            .AddRatatoskInstrumentation()
+            .Build();
+
+        using var meterListener = new MeterListener
+        {
+            InstrumentPublished = (instrument, listener) => { }
+        };
+        meterListener.Start();
+
+        var meter = new Meter("Ratatosk.Connector.SendGridEmail");
+        var counter = meter.CreateCounter<int>("test");
+
+        meterListener.RecordObservableInstruments();
+
+        // No exception = registration succeeded
+        Assert.NotNull(counter);
+    }
+
+    [Fact]
+    public void AddRatatoskInstrumentation_OnTracerProviderBuilder_CanBeCalledMultipleTimes()
+    {
+        var exception = Record.Exception(() =>
+        {
+            using var tracerProvider = Sdk.CreateTracerProviderBuilder()
+                .AddRatatoskInstrumentation()
+                .AddRatatoskInstrumentation()
+                .Build();
+        });
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void AddRatatoskInstrumentation_OnMeterProviderBuilder_CanBeCalledMultipleTimes()
+    {
+        var exception = Record.Exception(() =>
+        {
+            using var meterProvider = Sdk.CreateMeterProviderBuilder()
+                .AddRatatoskInstrumentation()
+                .AddRatatoskInstrumentation()
+                .Build();
+        });
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void WithOpenTelemetry_OnMessagingBuilder_RegistersOpenTelemetryServices()
+    {
+        var services = new ServiceCollection();
+
+        services.AddMessaging()
+            .WithOpenTelemetry();
+
+        var provider = services.BuildServiceProvider();
+
+        // OpenTelemetry hosting integration registers these services
+        var tracerProvider = provider.GetService<TracerProvider>();
+        var meterProvider = provider.GetService<MeterProvider>();
+
+        Assert.NotNull(tracerProvider);
+        Assert.NotNull(meterProvider);
+    }
+
+    [Fact]
+    public void WithOpenTelemetry_OnMessagingBuilder_ReturnsBuilder()
+    {
+        var services = new ServiceCollection();
+
+        var builder = services.AddMessaging()
+            .WithOpenTelemetry();
+
+        Assert.NotNull(builder);
+        Assert.Same(services, builder.Services);
+    }
+}

--- a/test/Ratatosk.XUnit/Unit/MessageContextTests.cs
+++ b/test/Ratatosk.XUnit/Unit/MessageContextTests.cs
@@ -1,0 +1,161 @@
+namespace Ratatosk.XUnit.Unit;
+
+[Trait("Category", "Unit")]
+[Trait("Feature", "MessageContext")]
+public class MessageContextTests
+{
+    [Fact]
+    public void Should_StoreAndRetrieveValues()
+    {
+        var ctx = new MessageContext();
+        ctx["tenant_id"] = "tenant-123";
+        ctx["user_id"] = "user-456";
+
+        Assert.Equal("tenant-123", ctx["tenant_id"]);
+        Assert.Equal("user-456", ctx["user_id"]);
+    }
+
+    [Fact]
+    public void Should_ReturnNull_ForMissingKey()
+    {
+        var ctx = new MessageContext();
+        Assert.Null(ctx["nonexistent"]);
+    }
+
+    [Fact]
+    public void Should_BuildWithInitialTuples()
+    {
+        var ctx = new MessageContext(
+            ("tenant_id", "tenant-123"),
+            ("user_id", "user-456"),
+            ("env", "production")
+        );
+
+        Assert.Equal("tenant-123", ctx["tenant_id"]);
+        Assert.Equal("user-456", ctx["user_id"]);
+        Assert.Equal("production", ctx["env"]);
+    }
+
+    [Fact]
+    public void Should_SupportFluentWithPattern()
+    {
+        var ctx = new MessageContext()
+            .With("tenant_id", "tenant-123")
+            .With("user_id", "user-456");
+
+        Assert.Equal("tenant-123", ctx["tenant_id"]);
+        Assert.Equal("user-456", ctx["user_id"]);
+    }
+
+    [Fact]
+    public void Should_EnumerateAllEntries()
+    {
+        var ctx = new MessageContext(
+            ("key1", "value1"),
+            ("key2", "value2")
+        );
+
+        Assert.Equal(2, ctx.Data.Count);
+        Assert.Contains(ctx.Data, kvp => kvp.Key == "key1" && (string)kvp.Value! == "value1");
+        Assert.Contains(ctx.Data, kvp => kvp.Key == "key2" && (string)kvp.Value! == "value2");
+    }
+
+    [Fact]
+    public void Should_Throw_WhenKeyIsNull()
+    {
+        var ctx = new MessageContext();
+        Assert.Throws<ArgumentNullException>(() => ctx[null!] = "value");
+    }
+
+    [Fact]
+    public void Should_Throw_WhenKeyIsWhitespace()
+    {
+        var ctx = new MessageContext();
+        Assert.Throws<ArgumentException>(() => ctx["  "] = "value");
+    }
+
+    [Fact]
+    public void Should_Throw_WhenKeyContainsSpaces()
+    {
+        var ctx = new MessageContext();
+        var ex = Assert.Throws<ArgumentException>(() => ctx["my key"] = "value");
+        Assert.Contains("must not contain spaces", ex.Message);
+    }
+
+    [Fact]
+    public void Should_Throw_WhenFluentWithReceivesSpaces()
+    {
+        var ctx = new MessageContext();
+        var ex = Assert.Throws<ArgumentException>(() => ctx.With("bad key", "value"));
+        Assert.Contains("must not contain spaces", ex.Message);
+    }
+
+    [Fact]
+    public void Should_Throw_WhenInitialTupleKeyContainsSpaces()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            new MessageContext(("bad key", "value")));
+    }
+
+    [Fact]
+    public void Should_UseOrdinalIgnoreCase_ForKeyComparisons()
+    {
+        var ctx = new MessageContext();
+        ctx["Tenant_ID"] = "tenant-123";
+
+        Assert.Equal("tenant-123", ctx["tenant_id"]);
+        Assert.Equal("tenant-123", ctx["TENANT_ID"]);
+        Assert.Equal("tenant-123", ctx["Tenant_Id"]);
+    }
+
+    [Fact]
+    public void Should_AllowNullValues()
+    {
+        var ctx = new MessageContext();
+        ctx["nullable"] = null;
+
+        Assert.Null(ctx["nullable"]);
+        Assert.True(ctx.Data.ContainsKey("nullable"));
+    }
+
+    [Fact]
+    public void Should_OverwriteExistingKey()
+    {
+        var ctx = new MessageContext(("key", "original"));
+        ctx["key"] = "overwritten";
+
+        Assert.Equal("overwritten", ctx["key"]);
+        Assert.Single(ctx.Data);
+    }
+
+    [Fact]
+    public void StaticValidateKey_ShouldNotThrow_ForValidKey()
+    {
+        MessageContext.ValidateKey("valid_key");
+        MessageContext.ValidateKey("another-valid.key");
+    }
+
+    [Fact]
+    public void StaticValidateKey_ShouldThrow_ForNullKey()
+    {
+        Assert.Throws<ArgumentNullException>(() => MessageContext.ValidateKey(null!));
+    }
+
+    [Fact]
+    public void StaticValidateKey_ShouldThrow_ForSpaces()
+    {
+        Assert.Throws<ArgumentException>(() => MessageContext.ValidateKey("has space"));
+    }
+
+    [Fact]
+    public void Data_ShouldBePubliclyAccessible_AndMutableViaIndexer()
+    {
+        var ctx = new MessageContext();
+        ctx["a"] = 1;
+        ctx["b"] = "two";
+
+        Assert.Equal(2, ctx.Data.Count);
+        Assert.Equal(1, ctx.Data["a"]);
+        Assert.Equal("two", ctx.Data["b"]);
+    }
+}

--- a/test/Ratatosk.XUnit/Unit/MessagingClientContextEnrichmentTests.cs
+++ b/test/Ratatosk.XUnit/Unit/MessagingClientContextEnrichmentTests.cs
@@ -1,0 +1,522 @@
+using Microsoft.Extensions.DependencyInjection;
+using Ratatosk.XUnit.Fixtures;
+using System.Diagnostics;
+
+namespace Ratatosk.XUnit.Unit;
+
+[Trait("Category", "Integration")]
+[Trait("Feature", "MessagingClient")]
+public class MessagingClientContextEnrichmentTests
+{
+    private static IServiceProvider CreateClient(Action<MessagingBuilder>? configure = null)
+    {
+        var services = new ServiceCollection();
+        var builder = services.AddMessaging();
+        builder.AddConnector<MockConnector>("mock", _ => { });
+        configure?.Invoke(builder);
+        builder.AddClient();
+        return services.BuildServiceProvider();
+    }
+
+    private static Message CreateTestMessage(string id = "test-msg")
+        => new MessageBuilder()
+            .WithId(id)
+            .FromPhone("+15551234567")
+            .ToPhone("+15557654321")
+            .WithText("Hello world")
+            .Build();
+
+    // ── Message property stamping on send ───────────────────────────────
+
+    [Fact]
+    public async Task Should_StampContext_OnMessageProperties_WhenSending()
+    {
+        var provider = CreateClient();
+        var client = provider.GetRequiredService<IMessagingClient>();
+
+        var message = CreateTestMessage("ctx-stamp-1");
+        var context = new MessageContext(
+            ("tenant_id", "tenant-123"),
+            ("user_id", "user-456")
+        );
+
+        var request = new SendRequest("mock", message) { Context = context };
+        var result = await client.SendAsync(request);
+
+        Assert.True(result.IsSuccess());
+
+        var msgProps = message.Properties;
+        Assert.NotNull(msgProps);
+        Assert.Contains(msgProps, p => p.Key == "tenant_id");
+        Assert.Contains(msgProps, p => p.Key == "user_id");
+        Assert.Equal("tenant-123", msgProps!["tenant_id"].Value);
+        Assert.Equal("user-456", msgProps["user_id"].Value);
+    }
+
+    [Fact]
+    public async Task Should_NotStampContext_WhenContextIsNull()
+    {
+        var provider = CreateClient();
+        var client = provider.GetRequiredService<IMessagingClient>();
+
+        var message = CreateTestMessage("ctx-null");
+        var request = new SendRequest("mock", message);
+
+        var result = await client.SendAsync(request);
+
+        Assert.True(result.IsSuccess());
+        Assert.Null(message.Properties);
+    }
+
+    [Fact]
+    public async Task Should_NotStampContext_WhenContextDataIsEmpty()
+    {
+        var provider = CreateClient();
+        var client = provider.GetRequiredService<IMessagingClient>();
+
+        var message = CreateTestMessage("ctx-empty");
+        var request = new SendRequest("mock", message)
+        {
+            Context = new MessageContext()
+        };
+
+        var result = await client.SendAsync(request);
+
+        Assert.True(result.IsSuccess());
+        Assert.Null(message.Properties);
+    }
+
+    [Fact]
+    public async Task Should_StampMultipleContextEntries()
+    {
+        var provider = CreateClient();
+        var client = provider.GetRequiredService<IMessagingClient>();
+
+        var message = CreateTestMessage("ctx-multi");
+        var context = new MessageContext()
+            .With("tenant_id", "t-1")
+            .With("env", "prod")
+            .With("version", "2.0");
+
+        var request = new SendRequest("mock", message) { Context = context };
+        var result = await client.SendAsync(request);
+
+        Assert.True(result.IsSuccess());
+        Assert.Equal("t-1", message.Properties!["tenant_id"].Value);
+        Assert.Equal("prod", message.Properties["env"].Value);
+        Assert.Equal("2.0", message.Properties["version"].Value);
+    }
+
+    [Fact]
+    public async Task Should_PreserveExistingProperties_WhenStampingContext()
+    {
+        var provider = CreateClient();
+        var client = provider.GetRequiredService<IMessagingClient>();
+
+        var message = CreateTestMessage("ctx-merge");
+        message.Properties = new Dictionary<string, MessageProperty>
+        {
+            ["existing"] = new MessageProperty("existing", "keep-me")
+        };
+
+        var context = new MessageContext(("tenant_id", "t-1"));
+        var request = new SendRequest("mock", message) { Context = context };
+
+        var result = await client.SendAsync(request);
+
+        Assert.True(result.IsSuccess());
+        Assert.Equal("keep-me", message.Properties["existing"].Value);
+        Assert.Equal("t-1", message.Properties["tenant_id"].Value);
+    }
+
+    // ── Activity tag enrichment (via ActivityListener) ──────────────────
+
+    [Fact]
+    public async Task Should_AddContextTags_ToSendActivity()
+    {
+        var recorded = new List<Activity>();
+
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == "Ratatosk.Client",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStarted = activity => recorded.Add(activity)
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        var provider = CreateClient();
+        var client = provider.GetRequiredService<IMessagingClient>();
+
+        var message = CreateTestMessage("act-tag-send");
+        var context = new MessageContext(("tenant_id", "t-1"), ("user_id", "u-1"));
+        var request = new SendRequest("mock", message) { Context = context };
+
+        await client.SendAsync(request);
+
+        var activity = recorded.FirstOrDefault(a => a.OperationName == "mock send");
+        Assert.NotNull(activity);
+        Assert.Equal("ratatosk", activity.GetTagItem("messaging.system"));
+        Assert.Equal("send", activity.GetTagItem("messaging.operation"));
+        Assert.Equal("t-1", activity.GetTagItem("tenant_id"));
+        Assert.Equal("u-1", activity.GetTagItem("user_id"));
+    }
+
+    [Fact]
+    public async Task Should_AddContextTags_ToReceiveActivity()
+    {
+        var recorded = new List<Activity>();
+
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == "Ratatosk.Client",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStarted = activity => recorded.Add(activity)
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        var provider = CreateClient();
+        var client = provider.GetRequiredService<IMessagingClient>();
+
+        var context = new MessageContext(("tenant_id", "t-2"));
+        var source = MessageSource.Json("{}");
+        var request = new ReceiveRequest("mock", source) { Context = context };
+
+        await client.ReceiveAsync(request);
+
+        var activity = recorded.FirstOrDefault(a => a.OperationName == "mock receive");
+        Assert.NotNull(activity);
+        Assert.Equal("t-2", activity.GetTagItem("tenant_id"));
+    }
+
+    [Fact]
+    public async Task Should_AddContextTags_ToStatusActivity()
+    {
+        var recorded = new List<Activity>();
+
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == "Ratatosk.Client",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStarted = activity => recorded.Add(activity)
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        var provider = CreateClient();
+        var client = provider.GetRequiredService<IMessagingClient>();
+
+        var context = new MessageContext(("tenant_id", "t-3"));
+        var request = new StatusRequest("mock") { Context = context };
+
+        await client.GetStatusAsync(request);
+
+        var activity = recorded.FirstOrDefault(a => a.OperationName == "mock status_query");
+        Assert.NotNull(activity);
+        Assert.Equal("t-3", activity.GetTagItem("tenant_id"));
+    }
+
+    [Fact]
+    public async Task Should_AddContextTags_ToReceiveStatusActivity()
+    {
+        var recorded = new List<Activity>();
+
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == "Ratatosk.Client",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStarted = activity => recorded.Add(activity)
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        var provider = CreateClient();
+        var client = provider.GetRequiredService<IMessagingClient>();
+
+        var context = new MessageContext(("tenant_id", "t-4"));
+        var source = MessageSource.Json("{}");
+        var request = new ReceiveStatusRequest("mock", source) { Context = context };
+
+        await client.ReceiveMessageStatusAsync(request);
+
+        var activity = recorded.FirstOrDefault(a => a.OperationName == "mock receive_status");
+        Assert.NotNull(activity);
+        Assert.Equal("t-4", activity.GetTagItem("tenant_id"));
+    }
+
+    [Fact]
+    public async Task Should_NotCreateActivity_WhenNoContextListener()
+    {
+        // By default, telemetry is enabled but without a listener there's no allocation.
+        // This verifies HasListeners() guard works.
+        var provider = CreateClient();
+        var client = provider.GetRequiredService<IMessagingClient>();
+
+        var message = CreateTestMessage("no-listener");
+        var request = new SendRequest("mock", message)
+        {
+            Context = new MessageContext(("k", "v"))
+        };
+
+        var result = await client.SendAsync(request);
+
+        Assert.True(result.IsSuccess());
+    }
+
+    // ── Activity parent-child linking ───────────────────────────────────
+
+    [Fact]
+    public async Task SendActivity_ShouldBeChildOfCurrentActivity()
+    {
+        var recorded = new List<Activity>();
+
+        using var clientListener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name is "Ratatosk.Client" or "TestApp",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStarted = activity => recorded.Add(activity)
+        };
+        ActivitySource.AddActivityListener(clientListener);
+
+        var provider = CreateClient();
+        var client = provider.GetRequiredService<IMessagingClient>();
+
+        var parentSource = new ActivitySource("TestApp");
+        using var parent = parentSource.StartActivity("ParentOperation", ActivityKind.Server);
+
+        Assert.NotNull(parent);
+
+        var message = CreateTestMessage("child-span");
+        var request = new SendRequest("mock", message);
+        await client.SendAsync(request);
+
+        var childActivity = recorded.FirstOrDefault(a => a.OperationName == "mock send");
+        Assert.NotNull(childActivity);
+
+        // The send span should be a child of the parent activity
+        Assert.Equal(parent.TraceId, childActivity.TraceId);
+        Assert.Equal(parent.SpanId, childActivity.ParentSpanId);
+    }
+
+    [Fact]
+    public async Task SendActivity_ShouldBeRoot_WhenNoCurrentActivity()
+    {
+        var recorded = new List<Activity>();
+
+        using var listener = new ActivityListener
+        {
+            ShouldListenTo = source => source.Name == "Ratatosk.Client",
+            Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            ActivityStarted = activity => recorded.Add(activity)
+        };
+        ActivitySource.AddActivityListener(listener);
+
+        var provider = CreateClient();
+        var client = provider.GetRequiredService<IMessagingClient>();
+
+        // Ensure no current activity
+        Activity.Current = null;
+
+        var message = CreateTestMessage("root-span");
+        var request = new SendRequest("mock", message);
+        await client.SendAsync(request);
+
+        var activity = recorded.FirstOrDefault(a => a.OperationName == "mock send");
+        Assert.NotNull(activity);
+        // When there's no parent Activity instance, Parent is null
+        Assert.Null(activity.Parent);
+        // ParentSpanId is default(SpanId) when no parent context
+        Assert.Equal(default(ActivitySpanId), activity.ParentSpanId);
+    }
+
+    // ── Extension methods backward compat ───────────────────────────────
+
+    [Fact]
+    public async Task Should_CallSendViaExtension_ByName()
+    {
+        var provider = CreateClient();
+        var client = provider.GetRequiredService<IMessagingClient>();
+
+        var message = CreateTestMessage("ext-name");
+        var result = await client.SendAsync("mock", message);
+
+        Assert.True(result.IsSuccess());
+    }
+
+    [Fact]
+    public async Task Should_CallSendViaExtension_ByNameWithSettings()
+    {
+        var services = new ServiceCollection();
+        services.AddMessaging()
+            .AddConnectorType<MockConnector>("mock")
+            .AddClient();
+        var provider = services.BuildServiceProvider();
+        var client = provider.GetRequiredService<IMessagingClient>();
+        var settings = new ConnectionSettings();
+
+        var message = CreateTestMessage("ext-name-settings");
+        var result = await client.SendAsync("mock", settings, message);
+
+        Assert.True(result.IsSuccess());
+    }
+
+    [Fact]
+    public async Task Should_CallSendViaExtension_ByType()
+    {
+        var services = new ServiceCollection();
+        services.AddMessaging()
+            .AddConnector<MockConnector>(_ => { })
+            .AddClient();
+        var provider = services.BuildServiceProvider();
+        var client = provider.GetRequiredService<IMessagingClient>();
+
+        var message = CreateTestMessage("ext-type");
+        var result = await client.SendAsync<MockConnector>(message);
+
+        Assert.True(result.IsSuccess());
+    }
+
+    [Fact]
+    public async Task Should_CallSendViaExtension_ByTypeWithSettings()
+    {
+        var services = new ServiceCollection();
+        services.AddMessaging()
+            .AddConnector<MockConnector>(_ => { })
+            .AddClient();
+        var provider = services.BuildServiceProvider();
+        var client = provider.GetRequiredService<IMessagingClient>();
+        var settings = new ConnectionSettings();
+
+        var message = CreateTestMessage("ext-type-settings");
+        var result = await client.SendAsync<MockConnector>(settings, message);
+
+        Assert.True(result.IsSuccess());
+    }
+
+    [Fact]
+    public async Task Should_CallReceiveViaExtension_ByName()
+    {
+        var provider = CreateClient();
+        var client = provider.GetRequiredService<IMessagingClient>();
+
+        var source = MessageSource.Json("{}");
+        var result = await client.ReceiveAsync("mock", source);
+
+        Assert.True(result.IsSuccess());
+    }
+
+    [Fact]
+    public async Task Should_CallReceiveViaExtension_ByType()
+    {
+        var services = new ServiceCollection();
+        services.AddMessaging()
+            .AddConnector<MockConnector>(_ => { })
+            .AddClient();
+        var provider = services.BuildServiceProvider();
+        var client = provider.GetRequiredService<IMessagingClient>();
+
+        var result = await client.ReceiveAsync<MockConnector>(MessageSource.Json("{}"));
+
+        Assert.True(result.IsSuccess());
+    }
+
+    [Fact]
+    public async Task Should_CallGetStatusViaExtension_ByName()
+    {
+        var provider = CreateClient();
+        var client = provider.GetRequiredService<IMessagingClient>();
+
+        var result = await client.GetStatusAsync("mock");
+
+        Assert.True(result.IsSuccess());
+    }
+
+    [Fact]
+    public async Task Should_CallGetStatusViaExtension_ByType()
+    {
+        var services = new ServiceCollection();
+        services.AddMessaging()
+            .AddConnector<MockConnector>(_ => { })
+            .AddClient();
+        var provider = services.BuildServiceProvider();
+        var client = provider.GetRequiredService<IMessagingClient>();
+
+        var result = await client.GetStatusAsync<MockConnector>();
+
+        Assert.True(result.IsSuccess());
+    }
+
+    [Fact]
+    public async Task Should_CallReceiveStatusViaExtension_ByName()
+    {
+        var provider = CreateClient();
+        var client = provider.GetRequiredService<IMessagingClient>();
+
+        var source = MessageSource.Json("{}");
+        var result = await client.ReceiveMessageStatusAsync("mock", source);
+
+        Assert.True(result.IsSuccess());
+    }
+
+    [Fact]
+    public async Task Should_CallReceiveStatusViaExtension_ByType()
+    {
+        var services = new ServiceCollection();
+        services.AddMessaging()
+            .AddConnector<MockConnector>(_ => { })
+            .AddClient();
+        var provider = services.BuildServiceProvider();
+        var client = provider.GetRequiredService<IMessagingClient>();
+
+        var result = await client.ReceiveMessageStatusAsync<MockConnector>(MessageSource.Json("{}"));
+
+        Assert.True(result.IsSuccess());
+    }
+
+    // ── Request object construction ────────────────────────────────────
+
+    [Fact]
+    public void SendRequest_ShouldThrow_WhenChannelNameIsNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => new SendRequest(null!, new Message()));
+    }
+
+    [Fact]
+    public void SendRequest_ShouldThrow_WhenMessageIsNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => new SendRequest("ch", null!));
+    }
+
+    [Fact]
+    public void ReceiveRequest_ShouldThrow_WhenChannelNameIsNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => new ReceiveRequest(null!, default));
+    }
+
+    [Fact]
+    public void StatusRequest_ShouldThrow_WhenChannelNameIsNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => new StatusRequest(null!));
+    }
+
+    [Fact]
+    public void ReceiveStatusRequest_ShouldThrow_WhenChannelNameIsNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => new ReceiveStatusRequest(null!, default));
+    }
+
+    [Fact]
+    public void SendRequest_ShouldInitializeProperties()
+    {
+        var msg = new Message { Id = "req-test" };
+        var request = new SendRequest("my-channel", msg)
+        {
+            ConnectionSettings = new ConnectionSettings(),
+            ConnectorType = typeof(MockConnector),
+            Context = new MessageContext(("k", "v"))
+        };
+
+        Assert.Equal("my-channel", request.ChannelName);
+        Assert.Same(msg, request.Message);
+        Assert.NotNull(request.ConnectionSettings);
+        Assert.Equal(typeof(MockConnector), request.ConnectorType);
+        Assert.Equal("v", request.Context!["k"]);
+    }
+}


### PR DESCRIPTION
This pull request introduces first-class OpenTelemetry support to the Ratatosk Framework, marking tracing and metrics as complete for the v1.1.0 "Resilience & Observability" milestone. It adds a new `Ratatosk.Extensions.OpenTelemetry` package for seamless integration, updates documentation to reflect the new capabilities, and marks related roadmap items as complete. The solution and installation instructions are updated accordingly.

**Key changes:**

**OpenTelemetry Support and Instrumentation**
- Added the new `Ratatosk.Extensions.OpenTelemetry` package, providing convenience extensions for wiring Ratatosk telemetry sources into the OpenTelemetry SDK (e.g., `WithOpenTelemetry()` on `MessagingBuilder`, `AddRatatoskInstrumentation()` on `TracerProviderBuilder`/`MeterProviderBuilder`). This enables distributed tracing and metrics with minimal configuration. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R60) [[2]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938R73) [[3]](diffhunk://#diff-d6a200ee12a6723e2ff3d1a59ee2845d327baaa2e0ea325b31daf8bab06b8d74R66-R69) [[4]](diffhunk://#diff-d6a200ee12a6723e2ff3d1a59ee2845d327baaa2e0ea325b31daf8bab06b8d74R380-R403) [[5]](diffhunk://#diff-d6a200ee12a6723e2ff3d1a59ee2845d327baaa2e0ea325b31daf8bab06b8d74R434-R435) [[6]](diffhunk://#diff-8b042e3f94ca5c59a7cd990b950aec0073ea84fe811e7b22be51158d7b180d56R32-R34)

**Documentation Updates**
- Updated the main `README.md`, `docs/README.md`, and `docs/installation.md` to include the new package, describe OpenTelemetry integration, and provide installation instructions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R60) [[2]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938R73) [[3]](diffhunk://#diff-8b042e3f94ca5c59a7cd990b950aec0073ea84fe811e7b22be51158d7b180d56R32-R34)
- Replaced the old metrics decorator example in `docs/advanced.md` with an overview of built-in telemetry and a reference to the new [Telemetry](telemetry.md) documentation.
- Added a new entry for telemetry in the documentation reading path.

**Roadmap and Feature Status**
- Updated `ROADMAP.md` to reflect the current stable release (`v1.0.1`), mark retry policies and OpenTelemetry tracing & metrics as complete, and clarify which features remain in progress. [[1]](diffhunk://#diff-683343bdf93f55ed3cada86151abb8051282e1936e58d4e0a04beca95dff6e51L5-R7) [[2]](diffhunk://#diff-683343bdf93f55ed3cada86151abb8051282e1936e58d4e0a04beca95dff6e51L18-R18) [[3]](diffhunk://#diff-683343bdf93f55ed3cada86151abb8051282e1936e58d4e0a04beca95dff6e51R275-R276) [[4]](diffhunk://#diff-683343bdf93f55ed3cada86151abb8051282e1936e58d4e0a04beca95dff6e51L297-R316)
- Updated the checklist in `README.md` to indicate OpenTelemetry tracing & metrics are now implemented.

**Feature Details**
- Expanded the roadmap's OpenTelemetry section to describe what was built, including configurable options for telemetry, opt-in payload size metrics, and the benefits of the new observability features.

These changes collectively bring robust, production-grade observability to all Ratatosk connectors and update the documentation to help users leverage these new capabilities.…ramework