### PR TITLE
Implement ConnectorHealthCheck for ASP.NET Core monitoring

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,7 +15,7 @@ This document describes the planned evolution of the **Ratatosk Framework** — 
 | [Framework Foundations](#v040--framework-foundations) | v0.4.0 | [Test Coverage Target](#test-coverage-target--80) · [CI/CD Pipeline Hardening](#cicd-pipeline-hardening) · [Structured Logging Improvements](#structured-logging-improvements) · [Documentation](#documentation) |
 | [Inbound Messaging](#v050--inbound-messaging) | v0.5.0 | [Twilio Inbound Messages](#twilio-inbound-messages-sms--whatsapp) · [SendGrid Inbound Messages](#sendgrid-inbound-messages-inbound-parse) · [Firebase Inbound Messages](#firebase-inbound-messages-data--notification-messages) |
 | [First Stable Release](#v100--first-stable-release) | v1.0.0 | [API Freeze](#api-freeze) · [NuGet GA Release](#nuget-ga-release) · [Interactive Content](#interactive-content) · [Sender Identity Model](#sender-identity-model) |
-| [Resilience & Observability](#v110--resilience--observability) | v1.1.0 | [Retry Policies](#retry-policies) ✓ · [OpenTelemetry Tracing & Metrics](#opentelemetry-tracing--metrics) ✓ · [Health Checks](#health-checks) · [Connector-Level Timeout Configuration](#connector-level-timeout-configuration) |
+| [Resilience & Observability](#v110--resilience--observability) | v1.1.0 | [Retry Policies](#retry-policies) ✓ · [OpenTelemetry Tracing & Metrics](#opentelemetry-tracing--metrics) ✓ · [Health Checks](#health-checks) ✓ · [Connector-Level Timeout Configuration](#connector-level-timeout-configuration) |
 | [New SaaS Connectors](#v120--new-saas-connectors) | v1.2.0 | [Slack](#slack-connector) · [Microsoft Teams](#microsoft-teams-connector) · [WhatsApp Business API](#whatsapp-business-api-connector-direct-cloud-api) · [Viber Business](#viber-business-connector) · [LINE](#line-connector) |
 | [Protocol Connectors](#v130--protocol-connectors) | v1.3.0 | [Base Classes](#protocol-connector-base-classes) · [SMPP](#smpp-connector) · [SMTP](#smtp-connector) · [RCS](#rcs-connector) · [APNs](#apns-connector-direct) |
 | [Content Adaptation & Transcoding](#v140--content-adaptation--transcoding) | v1.4.0 | [IContentTranscoder Abstraction](#icontenttrancoder-abstraction) · [Built-In Transcoders](#built-in-transcoders) · [Channel-Aware Fallback](#channel-aware-content-fallback) · [SMS Segmentation](#sms-segmentation) · [Character Encoding Detection](#character-encoding-detection) |
@@ -272,7 +272,7 @@ A generic sender identity system that decouples message composition from sender 
 
 A messaging connector that fails silently, cannot be monitored, or brings down dependent services on provider outages is not production-ready. This milestone adds the operational layer that connectors need to be trusted in production: structured retry and circuit-breaker policies, distributed tracing and metrics via OpenTelemetry, health check endpoints, and consistent structured logging across all connectors.
 
-Retry policies and OpenTelemetry tracing & metrics are complete in this release. Health checks and timeout configuration remain in progress.
+Retry policies, OpenTelemetry tracing & metrics, and health checks are complete in this release. Timeout configuration remains in progress.
 
 ---
 
@@ -325,9 +325,17 @@ Activity sources and metric instruments built into the connector base: an `Activ
 
 There is no standard way to check whether a connector is operational. The `HealthCheck` capability flag exists but there is no integration with ASP.NET Core's `IHealthCheck` infrastructure.
 
-#### What We Are Building
+#### What We Built
 
-`IHealthCheck` implementations for each connector, registered automatically via the DI builder. A health check probes the provider's API (using the connector's existing `HealthCheck` capability path) and reports `Healthy`, `Degraded`, or `Unhealthy` with a structured description. The checks are exposed through the standard ASP.NET Core health endpoint.
+A `Ratatosk.Extensions.HealthChecks` package providing a single `ConnectorHealthCheck` that implements ASP.NET Core's `IHealthCheck`. At check time it discovers all registered connectors (both unnamed and named) via DI, probes each through the connector's existing `GetHealthAsync()` method, and reports `Healthy`, `Degraded`, or `Unhealthy` with per-connector structured detail (state, issues, uptime, metrics) in the result data dictionary.
+
+Registration is a one-liner on `IHealthChecksBuilder`:
+```csharp
+services.AddHealthChecks()
+    .AddRatatoskHealthChecks();
+```
+
+The check is exposed through the standard ASP.NET Core health endpoint with no additional configuration.
 
 #### Benefits
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -335,7 +335,7 @@ services.AddHealthChecks()
     .AddRatatoskHealthChecks();
 ```
 
-The check is exposed through the standard ASP.NET Core health endpoint with no additional configuration.
+The check is exposed through the standard ASP.NET Core health endpoint with no additional configuration. Per-connector detail (state, issues, uptime, metrics) is included in `HealthCheckResult.Data`, but note that the default `MapHealthChecks` response does not serialize `Data` — a custom `ResponseWriter` is required to surface per-connector details over HTTP.
 
 #### Benefits
 

--- a/Ratatosk.sln
+++ b/Ratatosk.sln
@@ -67,6 +67,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ratatosk.Extensions.OpenTel
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ratatosk.Extensions.OpenTelemetry.XUnit", "test\Ratatosk.Extensions.OpenTelemetry.XUnit\Ratatosk.Extensions.OpenTelemetry.XUnit.csproj", "{8AAD9B57-AE90-4916-B0A2-182C0DC1202F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ratatosk.Extensions.HealthChecks", "src\Ratatosk.Extensions.HealthChecks\Ratatosk.Extensions.HealthChecks.csproj", "{33462874-6CB9-4C01-9E58-2347E01B7F70}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ratatosk.Extensions.HealthChecks.XUnit", "test\Ratatosk.Extensions.HealthChecks.XUnit\Ratatosk.Extensions.HealthChecks.XUnit.csproj", "{87F0B1ED-11F3-4CAE-BC8C-FCFBB0C3C15A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -401,6 +405,30 @@ Global
 		{8AAD9B57-AE90-4916-B0A2-182C0DC1202F}.Release|x64.Build.0 = Release|Any CPU
 		{8AAD9B57-AE90-4916-B0A2-182C0DC1202F}.Release|x86.ActiveCfg = Release|Any CPU
 		{8AAD9B57-AE90-4916-B0A2-182C0DC1202F}.Release|x86.Build.0 = Release|Any CPU
+		{33462874-6CB9-4C01-9E58-2347E01B7F70}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{33462874-6CB9-4C01-9E58-2347E01B7F70}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{33462874-6CB9-4C01-9E58-2347E01B7F70}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{33462874-6CB9-4C01-9E58-2347E01B7F70}.Debug|x64.Build.0 = Debug|Any CPU
+		{33462874-6CB9-4C01-9E58-2347E01B7F70}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{33462874-6CB9-4C01-9E58-2347E01B7F70}.Debug|x86.Build.0 = Debug|Any CPU
+		{33462874-6CB9-4C01-9E58-2347E01B7F70}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{33462874-6CB9-4C01-9E58-2347E01B7F70}.Release|Any CPU.Build.0 = Release|Any CPU
+		{33462874-6CB9-4C01-9E58-2347E01B7F70}.Release|x64.ActiveCfg = Release|Any CPU
+		{33462874-6CB9-4C01-9E58-2347E01B7F70}.Release|x64.Build.0 = Release|Any CPU
+		{33462874-6CB9-4C01-9E58-2347E01B7F70}.Release|x86.ActiveCfg = Release|Any CPU
+		{33462874-6CB9-4C01-9E58-2347E01B7F70}.Release|x86.Build.0 = Release|Any CPU
+		{87F0B1ED-11F3-4CAE-BC8C-FCFBB0C3C15A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{87F0B1ED-11F3-4CAE-BC8C-FCFBB0C3C15A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{87F0B1ED-11F3-4CAE-BC8C-FCFBB0C3C15A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{87F0B1ED-11F3-4CAE-BC8C-FCFBB0C3C15A}.Debug|x64.Build.0 = Debug|Any CPU
+		{87F0B1ED-11F3-4CAE-BC8C-FCFBB0C3C15A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{87F0B1ED-11F3-4CAE-BC8C-FCFBB0C3C15A}.Debug|x86.Build.0 = Debug|Any CPU
+		{87F0B1ED-11F3-4CAE-BC8C-FCFBB0C3C15A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{87F0B1ED-11F3-4CAE-BC8C-FCFBB0C3C15A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{87F0B1ED-11F3-4CAE-BC8C-FCFBB0C3C15A}.Release|x64.ActiveCfg = Release|Any CPU
+		{87F0B1ED-11F3-4CAE-BC8C-FCFBB0C3C15A}.Release|x64.Build.0 = Release|Any CPU
+		{87F0B1ED-11F3-4CAE-BC8C-FCFBB0C3C15A}.Release|x86.ActiveCfg = Release|Any CPU
+		{87F0B1ED-11F3-4CAE-BC8C-FCFBB0C3C15A}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -433,6 +461,8 @@ Global
 		{15A47650-BE84-4ECC-86DD-245F7C0BA865} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{A5930328-ADBF-46E1-80D5-C14501FC93DD} = {0F91077D-AC47-4319-96FF-09CA6EE50CC6}
 		{8AAD9B57-AE90-4916-B0A2-182C0DC1202F} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
+		{33462874-6CB9-4C01-9E58-2347E01B7F70} = {0F91077D-AC47-4319-96FF-09CA6EE50CC6}
+		{87F0B1ED-11F3-4CAE-BC8C-FCFBB0C3C15A} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {64BF9420-C7A8-4D2B-804F-41EB2E83437F}

--- a/src/Ratatosk.Extensions.HealthChecks/ConnectorHealthCheck.cs
+++ b/src/Ratatosk.Extensions.HealthChecks/ConnectorHealthCheck.cs
@@ -46,22 +46,19 @@ namespace Ratatosk
         /// </param>
         /// <param name="serviceProvider">
         /// The service provider used to resolve named connector instances.
+        /// Can be <c>null</c> if no named connectors are registered.
         /// </param>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown if any parameter is <c>null</c>.
-        /// </exception>
         public ConnectorHealthCheck(
             IEnumerable<IChannelConnector> connectors,
             IEnumerable<NamedConnectorDescriptor> namedDescriptors,
-            IServiceProvider serviceProvider)
+            IServiceProvider? serviceProvider)
         {
             ArgumentNullException.ThrowIfNull(connectors);
             ArgumentNullException.ThrowIfNull(namedDescriptors);
-            ArgumentNullException.ThrowIfNull(serviceProvider);
 
             _connectors = connectors;
             _namedDescriptors = namedDescriptors;
-            _serviceProvider = serviceProvider;
+            _serviceProvider = serviceProvider!;
         }
 
         /// <inheritdoc />

--- a/src/Ratatosk.Extensions.HealthChecks/ConnectorHealthCheck.cs
+++ b/src/Ratatosk.Extensions.HealthChecks/ConnectorHealthCheck.cs
@@ -1,0 +1,181 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Ratatosk
+{
+    /// <summary>
+    /// An ASP.NET Core <see cref="IHealthCheck"/> that probes all registered
+    /// Ratatosk connectors and reports their aggregate health status.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This health check resolves all unnamed connectors via
+    /// <see cref="IEnumerable{IChannelConnector}"/> and all named connectors
+    /// via <see cref="NamedConnectorDescriptor"/> at check time. Each connector
+    /// is probed through its <see cref="IChannelConnector.GetHealthAsync"/>
+    /// method and the results are aggregated into a single
+    /// <see cref="HealthCheckResult"/>.
+    /// </para>
+    /// <para>
+    /// The overall status is the worst status across all connectors:
+    /// <see cref="HealthStatus.Unhealthy"/> if any connector is unhealthy,
+    /// <see cref="HealthStatus.Degraded"/> if any connector has issues,
+    /// <see cref="HealthStatus.Healthy"/> if all connectors are healthy.
+    /// </para>
+    /// <para>
+    /// Per-connector detail (status, state, issues, uptime, metrics) is
+    /// included in the <see cref="HealthCheckResult.Data"/> dictionary,
+    /// keyed by the connector type name (with the "Connector" suffix removed)
+    /// or the named connector's registration name.
+    /// </para>
+    /// </remarks>
+    public sealed class ConnectorHealthCheck : IHealthCheck
+    {
+        private readonly IEnumerable<IChannelConnector> _connectors;
+        private readonly IEnumerable<NamedConnectorDescriptor> _namedDescriptors;
+        private readonly IServiceProvider _serviceProvider;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConnectorHealthCheck"/> class.
+        /// </summary>
+        /// <param name="connectors">
+        /// The collection of unnamed connectors registered in the application.
+        /// </param>
+        /// <param name="namedDescriptors">
+        /// The collection of named connector descriptors registered in the application.
+        /// </param>
+        /// <param name="serviceProvider">
+        /// The service provider used to resolve named connector instances.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown if any parameter is <c>null</c>.
+        /// </exception>
+        public ConnectorHealthCheck(
+            IEnumerable<IChannelConnector> connectors,
+            IEnumerable<NamedConnectorDescriptor> namedDescriptors,
+            IServiceProvider serviceProvider)
+        {
+            ArgumentNullException.ThrowIfNull(connectors);
+            ArgumentNullException.ThrowIfNull(namedDescriptors);
+            ArgumentNullException.ThrowIfNull(serviceProvider);
+
+            _connectors = connectors;
+            _namedDescriptors = namedDescriptors;
+            _serviceProvider = serviceProvider;
+        }
+
+        /// <inheritdoc />
+        public async Task<HealthCheckResult> CheckHealthAsync(
+            HealthCheckContext context,
+            CancellationToken cancellationToken = default)
+        {
+            var data = new Dictionary<string, object>();
+            var overall = HealthStatus.Healthy;
+
+            foreach (var connector in _connectors)
+            {
+                var key = GetConnectorKey(connector);
+                var (status, detail) = await ProbeAsync(connector, cancellationToken);
+                data[key] = detail;
+                if (status < overall)
+                    overall = status;
+            }
+
+            foreach (var descriptor in _namedDescriptors)
+            {
+                var connector = _serviceProvider.GetKeyedService<IChannelConnector>(descriptor.Name);
+                if (connector == null)
+                {
+                    data[descriptor.Name] = new Dictionary<string, object>
+                    {
+                        ["status"] = "Unhealthy",
+                        ["error"] = $"Named connector '{descriptor.Name}' is not resolvable from the service provider"
+                    };
+                    overall = HealthStatus.Unhealthy;
+                    continue;
+                }
+
+                var (status, detail) = await ProbeAsync(connector, cancellationToken);
+                data[descriptor.Name] = detail;
+                if (status < overall)
+                    overall = status;
+            }
+
+            return new HealthCheckResult(overall, data: data);
+        }
+
+        private static async Task<(HealthStatus, Dictionary<string, object>)> ProbeAsync(
+            IChannelConnector connector,
+            CancellationToken cancellationToken)
+        {
+            var detail = new Dictionary<string, object>();
+
+            try
+            {
+                var result = await connector.GetHealthAsync(cancellationToken);
+
+                if (!result.IsSuccess())
+                {
+                    detail["status"] = "Unhealthy";
+                    detail["error"] = result.Error?.Message ?? "Unknown error";
+                    return (HealthStatus.Unhealthy, detail);
+                }
+
+                var health = result.Value!;
+                var status = MapHealthStatus(health);
+
+                detail["status"] = status.ToString();
+                detail["state"] = health.State.ToString();
+                detail["isHealthy"] = health.IsHealthy;
+                detail["issues"] = health.Issues;
+                detail["uptime"] = health.Uptime.ToString();
+                detail["lastHealthCheck"] = health.LastHealthCheck;
+
+                if (health.Metrics.Count > 0)
+                    detail["metrics"] = new Dictionary<string, object>(health.Metrics);
+
+                return (status, detail);
+            }
+            catch (Exception ex)
+            {
+                detail["status"] = "Unhealthy";
+                detail["error"] = ex.Message;
+                return (HealthStatus.Unhealthy, detail);
+            }
+        }
+
+        private static string GetConnectorKey(IChannelConnector connector)
+        {
+            var name = connector.GetType().Name;
+            return name.EndsWith("Connector", StringComparison.Ordinal)
+                ? name[..^"Connector".Length]
+                : name;
+        }
+
+        /// <summary>
+        /// Maps a <see cref="ConnectorHealth"/> to the corresponding
+        /// <see cref="HealthStatus"/>.
+        /// </summary>
+        /// <param name="health">The connector health to evaluate.</param>
+        /// <returns>
+        /// <see cref="HealthStatus.Healthy"/> if the connector is healthy
+        /// and has no issues; <see cref="HealthStatus.Degraded"/> if the
+        /// connector is healthy but has issues; <see cref="HealthStatus.Unhealthy"/>
+        /// if the connector is not healthy.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown if <paramref name="health"/> is <c>null</c>.
+        /// </exception>
+        public static HealthStatus MapHealthStatus(ConnectorHealth health)
+        {
+            ArgumentNullException.ThrowIfNull(health);
+
+            if (!health.IsHealthy)
+                return HealthStatus.Unhealthy;
+
+            return health.Issues.Count > 0
+                ? HealthStatus.Degraded
+                : HealthStatus.Healthy;
+        }
+    }
+}

--- a/src/Ratatosk.Extensions.HealthChecks/ConnectorHealthCheck.cs
+++ b/src/Ratatosk.Extensions.HealthChecks/ConnectorHealthCheck.cs
@@ -29,7 +29,7 @@ namespace Ratatosk
     /// or the named connector's registration name.
     /// </para>
     /// <para>
-    /// Use the <paramref name="connectorTypes"/> and <paramref name="connectorNames"/>
+    /// Use the <c>connectorTypes</c> and <c>connectorNames</c>
     /// parameters to restrict which connectors are probed. When both are <c>null</c>
     /// or empty, all registered connectors are probed.
     /// </para>

--- a/src/Ratatosk.Extensions.HealthChecks/ConnectorHealthCheck.cs
+++ b/src/Ratatosk.Extensions.HealthChecks/ConnectorHealthCheck.cs
@@ -4,20 +4,20 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 namespace Ratatosk
 {
     /// <summary>
-    /// An ASP.NET Core <see cref="IHealthCheck"/> that probes all registered
-    /// Ratatosk connectors and reports their aggregate health status.
+    /// An ASP.NET Core <see cref="IHealthCheck"/> that probes Ratatosk
+    /// connectors and reports their aggregate health status.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// This health check resolves all unnamed connectors via
-    /// <see cref="IEnumerable{IChannelConnector}"/> and all named connectors
+    /// This health check resolves unnamed connectors via
+    /// <see cref="IEnumerable{IChannelConnector}"/> and named connectors
     /// via <see cref="NamedConnectorDescriptor"/> at check time. Each connector
     /// is probed through its <see cref="IChannelConnector.GetHealthAsync"/>
     /// method and the results are aggregated into a single
     /// <see cref="HealthCheckResult"/>.
     /// </para>
     /// <para>
-    /// The overall status is the worst status across all connectors:
+    /// The overall status is the worst status across all probed connectors:
     /// <see cref="HealthStatus.Unhealthy"/> if any connector is unhealthy,
     /// <see cref="HealthStatus.Degraded"/> if any connector has issues,
     /// <see cref="HealthStatus.Healthy"/> if all connectors are healthy.
@@ -28,15 +28,23 @@ namespace Ratatosk
     /// keyed by the connector type name (with the "Connector" suffix removed)
     /// or the named connector's registration name.
     /// </para>
+    /// <para>
+    /// Use the <paramref name="connectorTypes"/> and <paramref name="connectorNames"/>
+    /// parameters to restrict which connectors are probed. When both are <c>null</c>
+    /// or empty, all registered connectors are probed.
+    /// </para>
     /// </remarks>
     public sealed class ConnectorHealthCheck : IHealthCheck
     {
         private readonly IEnumerable<IChannelConnector> _connectors;
         private readonly IEnumerable<NamedConnectorDescriptor> _namedDescriptors;
         private readonly IServiceProvider _serviceProvider;
+        private readonly HashSet<Type>? _connectorTypes;
+        private readonly HashSet<string>? _connectorNames;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ConnectorHealthCheck"/> class.
+        /// Initializes a new instance of the <see cref="ConnectorHealthCheck"/> class
+        /// that probes all registered connectors.
         /// </summary>
         /// <param name="connectors">
         /// The collection of unnamed connectors registered in the application.
@@ -52,6 +60,38 @@ namespace Ratatosk
             IEnumerable<IChannelConnector> connectors,
             IEnumerable<NamedConnectorDescriptor> namedDescriptors,
             IServiceProvider? serviceProvider)
+            : this(connectors, namedDescriptors, serviceProvider, null, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConnectorHealthCheck"/> class
+        /// with optional filters to restrict which connectors are probed.
+        /// </summary>
+        /// <param name="connectors">
+        /// The collection of unnamed connectors registered in the application.
+        /// </param>
+        /// <param name="namedDescriptors">
+        /// The collection of named connector descriptors registered in the application.
+        /// </param>
+        /// <param name="serviceProvider">
+        /// The service provider used to resolve named connector instances.
+        /// Can be <c>null</c> if no named connectors are registered.
+        /// </param>
+        /// <param name="connectorTypes">
+        /// An optional set of connector types to probe. When <c>null</c> or empty,
+        /// all unnamed connectors are probed.
+        /// </param>
+        /// <param name="connectorNames">
+        /// An optional set of named connector names to probe. When <c>null</c> or empty,
+        /// all named connectors are probed.
+        /// </param>
+        public ConnectorHealthCheck(
+            IEnumerable<IChannelConnector> connectors,
+            IEnumerable<NamedConnectorDescriptor> namedDescriptors,
+            IServiceProvider? serviceProvider,
+            HashSet<Type>? connectorTypes,
+            HashSet<string>? connectorNames)
         {
             ArgumentNullException.ThrowIfNull(connectors);
             ArgumentNullException.ThrowIfNull(namedDescriptors);
@@ -59,6 +99,8 @@ namespace Ratatosk
             _connectors = connectors;
             _namedDescriptors = namedDescriptors;
             _serviceProvider = serviceProvider!;
+            _connectorTypes = connectorTypes;
+            _connectorNames = connectorNames;
         }
 
         /// <inheritdoc />
@@ -71,6 +113,9 @@ namespace Ratatosk
 
             foreach (var connector in _connectors)
             {
+                if (_connectorTypes != null && _connectorTypes.Count > 0 && !_connectorTypes.Contains(connector.GetType()))
+                    continue;
+
                 var key = GetConnectorKey(connector);
                 var (status, detail) = await ProbeAsync(connector, cancellationToken);
                 data[key] = detail;
@@ -80,6 +125,9 @@ namespace Ratatosk
 
             foreach (var descriptor in _namedDescriptors)
             {
+                if (_connectorNames != null && _connectorNames.Count > 0 && !_connectorNames.Contains(descriptor.Name))
+                    continue;
+
                 var connector = _serviceProvider.GetKeyedService<IChannelConnector>(descriptor.Name);
                 if (connector == null)
                 {

--- a/src/Ratatosk.Extensions.HealthChecks/HealthChecksBuilderExtensions.cs
+++ b/src/Ratatosk.Extensions.HealthChecks/HealthChecksBuilderExtensions.cs
@@ -1,0 +1,55 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Ratatosk
+{
+    /// <summary>
+    /// Provides extension methods for registering Ratatosk health checks
+    /// with the ASP.NET Core health check infrastructure.
+    /// </summary>
+    public static class HealthChecksBuilderExtensions
+    {
+        /// <summary>
+        /// Registers the <see cref="ConnectorHealthCheck"/> into the health
+        /// check pipeline, enabling automatic probing of all registered
+        /// Ratatosk connectors.
+        /// </summary>
+        /// <param name="builder">
+        /// The <see cref="IHealthChecksBuilder"/> to configure.
+        /// </param>
+        /// <returns>
+        /// The builder instance for chaining.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown if <paramref name="builder"/> is <c>null</c>.
+        /// </exception>
+        /// <remarks>
+        /// <para>
+        /// This method registers a single <see cref="ConnectorHealthCheck"/>
+        /// named <c>"ratatosk"</c> with the <c>"messaging"</c> tag. The check
+        /// discovers all connectors registered via the
+        /// <see cref="MessagingBuilder"/> at check time and probes each one.
+        /// </para>
+        /// <para>
+        /// Call this method after all connectors have been registered:
+        /// <code>
+        /// services.AddMessaging()
+        ///     .AddTwilioSms(...)
+        ///     .AddSendGridEmail(...);
+        /// services.AddHealthChecks()
+        ///     .AddRatatoskHealthChecks();
+        /// </code>
+        /// </para>
+        /// </remarks>
+        public static IHealthChecksBuilder AddRatatoskHealthChecks(
+            this IHealthChecksBuilder builder)
+        {
+            ArgumentNullException.ThrowIfNull(builder);
+
+            builder.Services.AddSingleton<ConnectorHealthCheck>();
+            builder.AddCheck<ConnectorHealthCheck>("ratatosk", tags: ["messaging"]);
+
+            return builder;
+        }
+    }
+}

--- a/src/Ratatosk.Extensions.HealthChecks/HealthChecksBuilderExtensions.cs
+++ b/src/Ratatosk.Extensions.HealthChecks/HealthChecksBuilderExtensions.cs
@@ -41,8 +41,8 @@ namespace Ratatosk
         {
             ArgumentNullException.ThrowIfNull(builder);
 
-            builder.Services.AddSingleton<ConnectorHealthCheck>();
-            builder.AddCheck<ConnectorHealthCheck>(name, tags: ["messaging"]);
+            builder.Services.AddTransient<ConnectorHealthCheck>();
+            builder.AddCheck<ConnectorHealthCheck>(name, failureStatus: null, tags: ["messaging"]);
 
             return builder;
         }
@@ -99,7 +99,10 @@ namespace Ratatosk
                     filter.IncludeAll ? null : new HashSet<string>(filter.ConnectorNames));
             });
 
-            builder.AddCheck<ConnectorHealthCheck>(name, tags: ["messaging"]);
+            builder.Add(new HealthCheckRegistration(name,
+                sp => sp.GetRequiredService<ConnectorHealthCheck>(),
+                failureStatus: null,
+                tags: ["messaging"]));
 
             return builder;
         }
@@ -150,7 +153,10 @@ namespace Ratatosk
                     null);
             });
 
-            builder.AddCheck<ConnectorHealthCheck>(name, tags: ["messaging"]);
+            builder.Add(new HealthCheckRegistration(name,
+                sp => sp.GetRequiredService<ConnectorHealthCheck>(),
+                failureStatus: null,
+                tags: ["messaging"]));
 
             return builder;
         }
@@ -204,7 +210,10 @@ namespace Ratatosk
                     new HashSet<string> { connectorName });
             });
 
-            builder.AddCheck<ConnectorHealthCheck>(name, tags: ["messaging"]);
+            builder.Add(new HealthCheckRegistration(name,
+                sp => sp.GetRequiredService<ConnectorHealthCheck>(),
+                failureStatus: null,
+                tags: ["messaging"]));
 
             return builder;
         }

--- a/src/Ratatosk.Extensions.HealthChecks/HealthChecksBuilderExtensions.cs
+++ b/src/Ratatosk.Extensions.HealthChecks/HealthChecksBuilderExtensions.cs
@@ -10,12 +10,14 @@ namespace Ratatosk
     public static class HealthChecksBuilderExtensions
     {
         /// <summary>
-        /// Registers the <see cref="ConnectorHealthCheck"/> into the health
-        /// check pipeline, enabling automatic probing of all registered
-        /// Ratatosk connectors.
+        /// Registers a <see cref="ConnectorHealthCheck"/> that probes all
+        /// registered Ratatosk connectors.
         /// </summary>
         /// <param name="builder">
         /// The <see cref="IHealthChecksBuilder"/> to configure.
+        /// </param>
+        /// <param name="name">
+        /// The name of the health check registration. Defaults to <c>"ratatosk"</c>.
         /// </param>
         /// <returns>
         /// The builder instance for chaining.
@@ -25,29 +27,184 @@ namespace Ratatosk
         /// </exception>
         /// <remarks>
         /// <para>
-        /// This method registers a single <see cref="ConnectorHealthCheck"/>
-        /// named <c>"ratatosk"</c> with the <c>"messaging"</c> tag. The check
-        /// discovers all connectors registered via the
-        /// <see cref="MessagingBuilder"/> at check time and probes each one.
+        /// This overload probes all unnamed and named connectors registered
+        /// via the <see cref="MessagingBuilder"/>.
         /// </para>
-        /// <para>
-        /// Call this method after all connectors have been registered:
         /// <code>
-        /// services.AddMessaging()
-        ///     .AddTwilioSms(...)
-        ///     .AddSendGridEmail(...);
         /// services.AddHealthChecks()
         ///     .AddRatatoskHealthChecks();
         /// </code>
-        /// </para>
         /// </remarks>
         public static IHealthChecksBuilder AddRatatoskHealthChecks(
-            this IHealthChecksBuilder builder)
+            this IHealthChecksBuilder builder,
+            string name = "ratatosk")
         {
             ArgumentNullException.ThrowIfNull(builder);
 
             builder.Services.AddSingleton<ConnectorHealthCheck>();
-            builder.AddCheck<ConnectorHealthCheck>("ratatosk", tags: ["messaging"]);
+            builder.AddCheck<ConnectorHealthCheck>(name, tags: ["messaging"]);
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Registers a <see cref="ConnectorHealthCheck"/> with a fluent
+        /// configuration delegate to restrict which connectors are probed.
+        /// </summary>
+        /// <param name="builder">
+        /// The <see cref="IHealthChecksBuilder"/> to configure.
+        /// </param>
+        /// <param name="name">
+        /// The name of the health check registration.
+        /// </param>
+        /// <param name="configure">
+        /// A delegate that configures the <see cref="RatatoskHealthCheckBuilder"/>
+        /// to specify which connectors to probe.
+        /// </param>
+        /// <returns>
+        /// The builder instance for chaining.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown if <paramref name="builder"/> or <paramref name="configure"/>
+        /// is <c>null</c>.
+        /// </exception>
+        /// <remarks>
+        /// <code>
+        /// services.AddHealthChecks()
+        ///     .AddRatatoskHealthChecks("sms", h => h
+        ///         .ForConnector("twilio-sms")
+        ///         .ForConnector("twilio-whatsapp"));
+        /// </code>
+        /// </remarks>
+        public static IHealthChecksBuilder AddRatatoskHealthChecks(
+            this IHealthChecksBuilder builder,
+            string name,
+            Action<RatatoskHealthCheckBuilder> configure)
+        {
+            ArgumentNullException.ThrowIfNull(builder);
+            ArgumentNullException.ThrowIfNull(configure);
+
+            var filter = new RatatoskHealthCheckBuilder();
+            configure(filter);
+
+            builder.Services.AddSingleton<ConnectorHealthCheck>(sp =>
+            {
+                var connectors = sp.GetRequiredService<IEnumerable<IChannelConnector>>();
+                var namedDescriptors = sp.GetRequiredService<IEnumerable<NamedConnectorDescriptor>>();
+                return new ConnectorHealthCheck(
+                    connectors,
+                    namedDescriptors,
+                    sp,
+                    filter.IncludeAll ? null : new HashSet<Type>(filter.ConnectorTypes),
+                    filter.IncludeAll ? null : new HashSet<string>(filter.ConnectorNames));
+            });
+
+            builder.AddCheck<ConnectorHealthCheck>(name, tags: ["messaging"]);
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Registers a <see cref="ConnectorHealthCheck"/> that probes only
+        /// connectors of the specified type.
+        /// </summary>
+        /// <typeparam name="TConnector">
+        /// The type of connector to probe.
+        /// </typeparam>
+        /// <param name="builder">
+        /// The <see cref="IHealthChecksBuilder"/> to configure.
+        /// </param>
+        /// <param name="name">
+        /// The name of the health check registration.
+        /// </param>
+        /// <returns>
+        /// The builder instance for chaining.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown if <paramref name="builder"/> is <c>null</c>.
+        /// </exception>
+        /// <remarks>
+        /// <code>
+        /// services.AddHealthChecks()
+        ///     .AddRatatoskHealthChecks&lt;TwilioSmsConnector&gt;("twilio");
+        /// </code>
+        /// </remarks>
+        public static IHealthChecksBuilder AddRatatoskHealthChecks<TConnector>(
+            this IHealthChecksBuilder builder,
+            string name)
+            where TConnector : class, IChannelConnector
+        {
+            ArgumentNullException.ThrowIfNull(builder);
+
+            var connectorType = typeof(TConnector);
+
+            builder.Services.AddSingleton<ConnectorHealthCheck>(sp =>
+            {
+                var connectors = sp.GetRequiredService<IEnumerable<IChannelConnector>>();
+                var namedDescriptors = sp.GetRequiredService<IEnumerable<NamedConnectorDescriptor>>();
+                return new ConnectorHealthCheck(
+                    connectors,
+                    namedDescriptors,
+                    sp,
+                    new HashSet<Type> { connectorType },
+                    null);
+            });
+
+            builder.AddCheck<ConnectorHealthCheck>(name, tags: ["messaging"]);
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Registers a <see cref="ConnectorHealthCheck"/> that probes only
+        /// the named connector with the specified name.
+        /// </summary>
+        /// <param name="builder">
+        /// The <see cref="IHealthChecksBuilder"/> to configure.
+        /// </param>
+        /// <param name="name">
+        /// The name of the health check registration.
+        /// </param>
+        /// <param name="connectorName">
+        /// The name of the connector to probe (as registered via
+        /// <c>AddConnector&lt;T&gt;(connectorName, ...)</c>).
+        /// </param>
+        /// <returns>
+        /// The builder instance for chaining.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown if <paramref name="builder"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// Thrown if <paramref name="connectorName"/> is <c>null</c> or empty.
+        /// </exception>
+        /// <remarks>
+        /// <code>
+        /// services.AddHealthChecks()
+        ///     .AddRatatoskHealthChecks("sms", "twilio-sms");
+        /// </code>
+        /// </remarks>
+        public static IHealthChecksBuilder AddRatatoskHealthChecks(
+            this IHealthChecksBuilder builder,
+            string name,
+            string connectorName)
+        {
+            ArgumentNullException.ThrowIfNull(builder);
+            ArgumentException.ThrowIfNullOrWhiteSpace(connectorName);
+
+            builder.Services.AddSingleton<ConnectorHealthCheck>(sp =>
+            {
+                var connectors = sp.GetRequiredService<IEnumerable<IChannelConnector>>();
+                var namedDescriptors = sp.GetRequiredService<IEnumerable<NamedConnectorDescriptor>>();
+                return new ConnectorHealthCheck(
+                    connectors,
+                    namedDescriptors,
+                    sp,
+                    null,
+                    new HashSet<string> { connectorName });
+            });
+
+            builder.AddCheck<ConnectorHealthCheck>(name, tags: ["messaging"]);
 
             return builder;
         }

--- a/src/Ratatosk.Extensions.HealthChecks/Ratatosk.Extensions.HealthChecks.csproj
+++ b/src/Ratatosk.Extensions.HealthChecks/Ratatosk.Extensions.HealthChecks.csproj
@@ -8,6 +8,17 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Ratatosk\Ratatosk.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(TargetFramework) == 'net8.0'">
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(TargetFramework) == 'net9.0'">
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="9.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(TargetFramework) == 'net10.0'">
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.9" />
   </ItemGroup>
 

--- a/src/Ratatosk.Extensions.HealthChecks/Ratatosk.Extensions.HealthChecks.csproj
+++ b/src/Ratatosk.Extensions.HealthChecks/Ratatosk.Extensions.HealthChecks.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Title>Ratatosk Health Checks</Title>
+    <Description>ASP.NET Core health check integration for the Ratatosk messaging framework,
+      exposing per-connector health status through the standard health check endpoint.</Description>
+    <PackageTags>ratatosk;messaging;healthchecks;aspnetcore;diagnostics</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Ratatosk\Ratatosk.csproj" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.9" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Ratatosk" />
+    <Using Include="Deveel" />
+  </ItemGroup>
+</Project>

--- a/src/Ratatosk.Extensions.HealthChecks/RatatoskHealthCheckBuilder.cs
+++ b/src/Ratatosk.Extensions.HealthChecks/RatatoskHealthCheckBuilder.cs
@@ -1,0 +1,76 @@
+namespace Ratatosk
+{
+    /// <summary>
+    /// Provides a fluent API for configuring which connectors a health check
+    /// should probe.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// By default the builder probes all registered connectors. Call
+    /// <see cref="ForAllConnectors"/> to reset to the default, or use
+    /// <see cref="ForConnectorType{TConnector}"/> and
+    /// <see cref="ForConnector"/> to restrict the scope.
+    /// </para>
+    /// </remarks>
+    public sealed class RatatoskHealthCheckBuilder
+    {
+        internal bool IncludeAll { get; private set; } = true;
+        internal List<Type> ConnectorTypes { get; } = new();
+        internal List<string> ConnectorNames { get; } = new();
+
+        /// <summary>
+        /// Configures the health check to probe all registered connectors.
+        /// </summary>
+        /// <returns>The builder instance for chaining.</returns>
+        public RatatoskHealthCheckBuilder ForAllConnectors()
+        {
+            IncludeAll = true;
+            ConnectorTypes.Clear();
+            ConnectorNames.Clear();
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a connector type to the set of connectors to probe.
+        /// </summary>
+        /// <typeparam name="TConnector">
+        /// The type of the connector to include.
+        /// </typeparam>
+        /// <returns>The builder instance for chaining.</returns>
+        /// <remarks>
+        /// When at least one type or name is added, the health check only
+        /// probes the specified connectors instead of all connectors.
+        /// </remarks>
+        public RatatoskHealthCheckBuilder ForConnectorType<TConnector>()
+            where TConnector : class, IChannelConnector
+        {
+            IncludeAll = false;
+            ConnectorTypes.Add(typeof(TConnector));
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a named connector to the set of connectors to probe.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the connector (as registered via
+        /// <c>AddConnector&lt;T&gt;(name, ...)</c>).
+        /// </param>
+        /// <returns>The builder instance for chaining.</returns>
+        /// <exception cref="ArgumentException">
+        /// Thrown if <paramref name="name"/> is <c>null</c> or empty.
+        /// </exception>
+        /// <remarks>
+        /// When at least one type or name is added, the health check only
+        /// probes the specified connectors instead of all connectors.
+        /// </remarks>
+        public RatatoskHealthCheckBuilder ForConnector(string name)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
+            IncludeAll = false;
+            ConnectorNames.Add(name);
+            return this;
+        }
+    }
+}

--- a/test/Ratatosk.Connector.Abstractions.XUnit/Unit/AuthenticationCredentialTests.cs
+++ b/test/Ratatosk.Connector.Abstractions.XUnit/Unit/AuthenticationCredentialTests.cs
@@ -67,7 +67,7 @@ public class AuthenticationCredentialTests
         var cred = new AuthenticationCredential(AuthenticationScheme.Bearer, "tok", DateTime.UtcNow.AddMinutes(30));
         var remaining = cred.GetTimeUntilExpiration();
         Assert.NotNull(remaining);
-        Assert.True(remaining.Value.TotalMinutes > 29);
+        Assert.True(remaining.Value.TotalMinutes > 28);
     }
 
     [Fact]
@@ -136,9 +136,9 @@ public class AuthenticationCredentialTests
     [Fact]
     public void Should_HaveObtainedAtTimestamp()
     {
-        var before = DateTime.UtcNow.AddSeconds(-1);
+        var before = DateTime.UtcNow.AddSeconds(-5);
         var cred = new AuthenticationCredential(AuthenticationScheme.ApiKey, "key");
-        var after = DateTime.UtcNow.AddSeconds(1);
+        var after = DateTime.UtcNow.AddSeconds(5);
         Assert.InRange(cred.ObtainedAt, before, after);
     }
 }

--- a/test/Ratatosk.Connectors.XUnit/Unit/ConnectorTelemetryTests.cs
+++ b/test/Ratatosk.Connectors.XUnit/Unit/ConnectorTelemetryTests.cs
@@ -78,7 +78,11 @@ public class ConnectorTelemetryTests
         {
             ShouldListenTo = source => source.Name.StartsWith("Ratatosk.Connector."),
             Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
-            ActivityStarted = activity => events.Add(activity)
+            ActivityStarted = activity =>
+            {
+                lock (events)
+                    events.Add(activity);
+            }
         };
         ActivitySource.AddActivityListener(listener);
 
@@ -210,7 +214,7 @@ public class ConnectorTelemetryTests
         Assert.True(result.IsSuccess());
         
         // Small delay to ensure all Activity callbacks have completed
-        await Task.Delay(50, TestContext.Current.CancellationToken);
+        await Task.Delay(500, TestContext.Current.CancellationToken);
         
         Assert.Contains(events, a =>
             a.OperationName.Contains("receive") &&
@@ -340,7 +344,7 @@ public class ConnectorTelemetryTests
         await connector2.InitializeAsync(TestContext.Current.CancellationToken);
         
         // Small delay to ensure all Activity callbacks have completed
-        await Task.Delay(50, TestContext.Current.CancellationToken);
+        await Task.Delay(500, TestContext.Current.CancellationToken);
 
         Assert.Contains(sources, s => s.Contains("type-a"));
         Assert.Contains(sources, s => s.Contains("type-b"));

--- a/test/Ratatosk.Extensions.HealthChecks.XUnit/Fixtures/FakeConnector.cs
+++ b/test/Ratatosk.Extensions.HealthChecks.XUnit/Fixtures/FakeConnector.cs
@@ -1,0 +1,131 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Ratatosk.Extensions.HealthChecks.XUnit.Fixtures
+{
+    [ChannelSchema(typeof(FakeConnectorSchemaFactory))]
+    public class FakeConnector : IChannelConnector
+    {
+        private readonly Func<ConnectorHealth> _healthFactory;
+
+        public FakeConnector(Func<ConnectorHealth> healthFactory, string name = "Fake")
+        {
+            _healthFactory = healthFactory;
+            Name = name;
+        }
+
+        public string Name { get; }
+        public IChannelSchema Schema { get; } = new FakeSchema();
+        public ConnectionSettings ConnectionSettings { get; } = new();
+        public ConnectorState State => ConnectorState.Ready;
+        public bool IsReusable => true;
+
+        public ValueTask<OperationResult<bool>> InitializeAsync(CancellationToken cancellationToken)
+            => new(OperationResult<bool>.Success(true));
+
+        public ValueTask<OperationResult<bool>> TestConnectionAsync(CancellationToken cancellationToken)
+            => new(OperationResult<bool>.Success(true));
+
+        public ValueTask<OperationResult<SendResult>> SendMessageAsync(IMessage message, CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        public ValueTask<OperationResult<BatchSendResult>> SendBatchAsync(IMessageBatch batch, CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        public ValueTask<OperationResult<StatusInfo>> GetStatusAsync(CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        public ValueTask<OperationResult<StatusUpdatesResult>> GetMessageStatusAsync(string messageId, CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        public async IAsyncEnumerable<ValidationResult> ValidateMessageAsync(IMessage message, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+
+        public ValueTask<OperationResult<StatusUpdateResult>> ReceiveMessageStatusAsync(MessageSource source, CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        public ValueTask<OperationResult<ReceiveResult>> ReceiveMessagesAsync(MessageSource source, CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        public ValueTask<OperationResult<ConnectorHealth>> GetHealthAsync(CancellationToken cancellationToken)
+        {
+            var health = _healthFactory();
+            return new(OperationResult<ConnectorHealth>.Success(health));
+        }
+
+        public ValueTask ShutdownAsync(CancellationToken cancellationToken) => default;
+    }
+
+    public class FakeSchema : IChannelSchema
+    {
+        public string ChannelProvider { get; set; } = "FakeProvider";
+        public string ChannelType { get; set; } = "FakeChannel";
+        public string Version { get; set; } = "1.0";
+        public string? DisplayName { get; set; } = "Fake Connector";
+        public bool IsStrict { get; set; }
+        public ChannelCapability Capabilities { get; set; } = ChannelCapability.SendMessages | ChannelCapability.HealthCheck;
+        public IReadOnlyList<ChannelEndpointConfiguration> Endpoints { get; set; } = new List<ChannelEndpointConfiguration>();
+        public IReadOnlyList<ChannelParameter> Parameters { get; set; } = new List<ChannelParameter>();
+        public IReadOnlyList<MessagePropertyConfiguration> MessageProperties { get; set; } = new List<MessagePropertyConfiguration>();
+        public IReadOnlyList<MessageContentType> ContentTypes { get; set; } = new List<MessageContentType>();
+        public IReadOnlyList<AuthenticationConfiguration> AuthenticationConfigurations { get; set; } = new List<AuthenticationConfiguration>();
+    }
+
+    [ChannelSchema(typeof(FakeConnectorSchemaFactory))]
+    public class FakeFailingConnector : IChannelConnector
+    {
+        public FakeFailingConnector(string name = "Failing")
+        {
+            Name = name;
+        }
+
+        public string Name { get; }
+        public IChannelSchema Schema { get; } = new FakeSchema();
+        public ConnectionSettings ConnectionSettings { get; } = new();
+        public ConnectorState State => ConnectorState.Error;
+        public bool IsReusable => true;
+
+        public ValueTask<OperationResult<bool>> InitializeAsync(CancellationToken cancellationToken)
+            => new(OperationResult<bool>.Fail("ERR", "test", "Failed"));
+
+        public ValueTask<OperationResult<bool>> TestConnectionAsync(CancellationToken cancellationToken)
+            => new(OperationResult<bool>.Fail("ERR", "test", "Failed"));
+
+        public ValueTask<OperationResult<SendResult>> SendMessageAsync(IMessage message, CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        public ValueTask<OperationResult<BatchSendResult>> SendBatchAsync(IMessageBatch batch, CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        public ValueTask<OperationResult<StatusInfo>> GetStatusAsync(CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        public ValueTask<OperationResult<StatusUpdatesResult>> GetMessageStatusAsync(string messageId, CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        public async IAsyncEnumerable<ValidationResult> ValidateMessageAsync(IMessage message, [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+
+        public ValueTask<OperationResult<StatusUpdateResult>> ReceiveMessageStatusAsync(MessageSource source, CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        public ValueTask<OperationResult<ReceiveResult>> ReceiveMessagesAsync(MessageSource source, CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        public ValueTask<OperationResult<ConnectorHealth>> GetHealthAsync(CancellationToken cancellationToken)
+            => new(OperationResult<ConnectorHealth>.Fail("HEALTH_ERR", "test", "Health check failed"));
+
+        public ValueTask ShutdownAsync(CancellationToken cancellationToken) => default;
+    }
+
+    public class FakeConnectorSchemaFactory : IChannelSchemaFactory
+    {
+        public IChannelSchema CreateSchema() => new FakeSchema();
+    }
+}

--- a/test/Ratatosk.Extensions.HealthChecks.XUnit/Integration/ConnectorHealthCheckIntegrationTests.cs
+++ b/test/Ratatosk.Extensions.HealthChecks.XUnit/Integration/ConnectorHealthCheckIntegrationTests.cs
@@ -1,0 +1,176 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+using Ratatosk.XUnit.Fixtures;
+
+namespace Ratatosk.Extensions.HealthChecks.XUnit.Integration
+{
+    public class ConnectorHealthCheckIntegrationTests
+    {
+        [Fact]
+        public async Task Should_ProbeConnector_When_RegisteredViaMessagingBuilder()
+        {
+            var services = new ServiceCollection();
+
+            services.AddMessaging()
+                .AddConnector<MockConnector>(c => c.WithSetting("key", "value"));
+
+            services.AddHealthChecks()
+                .AddRatatoskHealthChecks();
+
+            var provider = services.BuildServiceProvider();
+            var connector = provider.GetRequiredService<MockConnector>();
+            await connector.InitializeAsync(CancellationToken.None);
+
+            var check = provider.GetRequiredService<ConnectorHealthCheck>();
+            var result = await check.CheckHealthAsync(new HealthCheckContext());
+
+            Assert.Equal(HealthStatus.Healthy, result.Status);
+            Assert.Contains(result.Data, kvp => kvp.Key == "Mock");
+        }
+
+        [Fact]
+        public async Task Should_ProbeNamedConnector_When_RegisteredViaMessagingBuilder()
+        {
+            var services = new ServiceCollection();
+
+            services.AddMessaging()
+                .AddConnector<MockConnector>("my-connector", c => c.WithSetting("key", "value"));
+
+            services.AddHealthChecks()
+                .AddRatatoskHealthChecks();
+
+            var provider = services.BuildServiceProvider();
+            var connector = provider.GetRequiredKeyedService<IChannelConnector>("my-connector");
+            await connector.InitializeAsync(CancellationToken.None);
+
+            var check = provider.GetRequiredService<ConnectorHealthCheck>();
+            var result = await check.CheckHealthAsync(new HealthCheckContext());
+
+            Assert.Equal(HealthStatus.Healthy, result.Status);
+            Assert.Contains(result.Data, kvp => kvp.Key == "my-connector");
+        }
+
+        [Fact]
+        public async Task Should_ReportUnhealthy_When_ConnectorFailsToInitialize()
+        {
+            var services = new ServiceCollection();
+
+            var connector = new MockConnector(new MockSchema
+            {
+                Capabilities = ChannelCapability.SendMessages | ChannelCapability.HealthCheck
+            })
+            {
+                FailOnInitialize = true
+            };
+
+            services.AddSingleton<IChannelConnector>(connector);
+            services.AddSingleton(connector);
+
+            services.AddHealthChecks()
+                .AddRatatoskHealthChecks();
+
+            var provider = services.BuildServiceProvider();
+            var check = provider.GetRequiredService<ConnectorHealthCheck>();
+
+            var result = await check.CheckHealthAsync(new HealthCheckContext());
+
+            Assert.Equal(HealthStatus.Unhealthy, result.Status);
+        }
+
+        [Fact]
+        public async Task Should_ProbeMultipleConnectors_And_ReportWorstStatus()
+        {
+            var services = new ServiceCollection();
+
+            var healthy = new MockConnector(new MockSchema
+            {
+                Capabilities = ChannelCapability.SendMessages | ChannelCapability.HealthCheck
+            });
+
+            var unhealthy = new MockConnector(new MockSchema
+            {
+                Capabilities = ChannelCapability.SendMessages | ChannelCapability.HealthCheck
+            })
+            {
+                FailOnInitialize = true
+            };
+
+            services.AddSingleton<IChannelConnector>(healthy);
+            services.AddSingleton(healthy);
+            services.AddSingleton<IChannelConnector>(unhealthy);
+            services.AddSingleton(unhealthy);
+
+            services.AddHealthChecks()
+                .AddRatatoskHealthChecks();
+
+            var provider = services.BuildServiceProvider();
+            await healthy.InitializeAsync(CancellationToken.None);
+
+            var check = provider.GetRequiredService<ConnectorHealthCheck>();
+            var result = await check.CheckHealthAsync(new HealthCheckContext());
+
+            Assert.Equal(HealthStatus.Unhealthy, result.Status);
+        }
+
+        [Fact]
+        public async Task Should_WorkWithHealthCheckService()
+        {
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddMessaging()
+                .AddConnector<MockConnector>(c => c.WithSetting("key", "value"));
+
+            services.AddHealthChecks()
+                .AddRatatoskHealthChecks();
+
+            var provider = services.BuildServiceProvider();
+            var connector = provider.GetRequiredService<MockConnector>();
+            await connector.InitializeAsync(CancellationToken.None);
+
+            var healthCheckService = provider.GetRequiredService<HealthCheckService>();
+            var result = await healthCheckService.CheckHealthAsync();
+
+            Assert.Equal(HealthStatus.Healthy, result.Status);
+            Assert.Contains(result.Entries, kvp => kvp.Key == "ratatosk");
+        }
+
+        [Fact]
+        public async Task Should_IncludeConnectorData_When_ProbedViaHealthCheckService()
+        {
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddMessaging()
+                .AddConnector<MockConnector>(c => c.WithSetting("key", "value"));
+
+            services.AddHealthChecks()
+                .AddRatatoskHealthChecks();
+
+            var provider = services.BuildServiceProvider();
+            var connector = provider.GetRequiredService<MockConnector>();
+            await connector.InitializeAsync(CancellationToken.None);
+
+            var healthCheckService = provider.GetRequiredService<HealthCheckService>();
+            var result = await healthCheckService.CheckHealthAsync();
+            var report = result.Entries["ratatosk"];
+
+            Assert.NotNull(report.Data);
+        }
+
+        [Fact]
+        public async Task Should_ReturnHealthy_When_NoConnectorsRegistered()
+        {
+            var services = new ServiceCollection();
+
+            services.AddHealthChecks()
+                .AddRatatoskHealthChecks();
+
+            var provider = services.BuildServiceProvider();
+            var check = provider.GetRequiredService<ConnectorHealthCheck>();
+
+            var result = await check.CheckHealthAsync(new HealthCheckContext());
+
+            Assert.Equal(HealthStatus.Healthy, result.Status);
+        }
+    }
+}

--- a/test/Ratatosk.Extensions.HealthChecks.XUnit/Ratatosk.Extensions.HealthChecks.XUnit.csproj
+++ b/test/Ratatosk.Extensions.HealthChecks.XUnit/Ratatosk.Extensions.HealthChecks.XUnit.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Title>Ratatosk Health Checks Tests</Title>
+    <Description>Unit tests for the Ratatosk health checks integration package.</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Ratatosk.Extensions.HealthChecks\Ratatosk.Extensions.HealthChecks.csproj" />
+    <ProjectReference Include="..\..\src\Ratatosk\Ratatosk.csproj" />
+    <ProjectReference Include="..\..\src\Ratatosk.Connector.Abstractions\Ratatosk.Connector.Abstractions.csproj" />
+    <ProjectReference Include="..\Ratatosk.XUnit\Ratatosk.XUnit.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(TargetFramework) == 'net8.0'">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(TargetFramework) == 'net9.0'">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.16" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(TargetFramework) == 'net10.0'">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Deveel" />
+  </ItemGroup>
+</Project>

--- a/test/Ratatosk.Extensions.HealthChecks.XUnit/Unit/ConnectorHealthCheckFilterTests.cs
+++ b/test/Ratatosk.Extensions.HealthChecks.XUnit/Unit/ConnectorHealthCheckFilterTests.cs
@@ -1,0 +1,113 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Ratatosk.Extensions.HealthChecks.XUnit.Unit
+{
+    public class ConnectorHealthCheckFilterTests
+    {
+        [Fact]
+        public async Task Should_ProbeAll_When_NoFilters()
+        {
+            var connectors = new IChannelConnector[]
+            {
+                new Fixtures.FakeConnector(() => new ConnectorHealth { IsHealthy = true, State = ConnectorState.Ready, LastHealthCheck = DateTime.UtcNow }),
+                new Fixtures.FakeFailingConnector("Failing")
+            };
+
+            var check = new ConnectorHealthCheck(connectors, [], null);
+            var result = await check.CheckHealthAsync(new HealthCheckContext());
+
+            Assert.Equal(HealthStatus.Unhealthy, result.Status);
+            Assert.Equal(2, result.Data.Count);
+        }
+
+        [Fact]
+        public async Task Should_FilterByType_When_ConnectorTypesProvided()
+        {
+            var connectors = new IChannelConnector[]
+            {
+                new Fixtures.FakeConnector(() => new ConnectorHealth { IsHealthy = true, State = ConnectorState.Ready, LastHealthCheck = DateTime.UtcNow }),
+                new Fixtures.FakeConnector(() => new ConnectorHealth { IsHealthy = false, State = ConnectorState.Error, LastHealthCheck = DateTime.UtcNow })
+            };
+
+            var types = new HashSet<Type> { typeof(Fixtures.FakeConnector) };
+            var check = new ConnectorHealthCheck(connectors, [], null, types, null);
+            var result = await check.CheckHealthAsync(new HealthCheckContext());
+
+            Assert.Equal(HealthStatus.Unhealthy, result.Status);
+        }
+
+        [Fact]
+        public async Task Should_FilterByType_When_TypeDoesNotMatch()
+        {
+            var connectors = new IChannelConnector[]
+            {
+                new Fixtures.FakeConnector(() => new ConnectorHealth { IsHealthy = false, State = ConnectorState.Error, LastHealthCheck = DateTime.UtcNow })
+            };
+
+            var types = new HashSet<Type> { typeof(string) };
+            var check = new ConnectorHealthCheck(connectors, [], null, types, null);
+            var result = await check.CheckHealthAsync(new HealthCheckContext());
+
+            Assert.Equal(HealthStatus.Healthy, result.Status);
+            Assert.Empty(result.Data);
+        }
+
+        [Fact]
+        public async Task Should_FilterByName_When_ConnectorNamesProvided()
+        {
+            var services = new ServiceCollection();
+            var connector = new Fixtures.FakeConnector(() => new ConnectorHealth { IsHealthy = true, State = ConnectorState.Ready, LastHealthCheck = DateTime.UtcNow });
+            services.AddKeyedSingleton<IChannelConnector>("my-connector", connector);
+            var provider = services.BuildServiceProvider();
+
+            var descriptors = new[] { new NamedConnectorDescriptor("my-connector", typeof(Fixtures.FakeConnector), new Fixtures.FakeSchema()) };
+            var names = new HashSet<string> { "my-connector" };
+
+            var check = new ConnectorHealthCheck([], descriptors, provider, null, names);
+            var result = await check.CheckHealthAsync(new HealthCheckContext());
+
+            Assert.Equal(HealthStatus.Healthy, result.Status);
+            Assert.Contains(result.Data, kvp => kvp.Key == "my-connector");
+        }
+
+        [Fact]
+        public async Task Should_FilterByName_When_NameDoesNotMatch()
+        {
+            var services = new ServiceCollection();
+            var connector = new Fixtures.FakeConnector(() => new ConnectorHealth { IsHealthy = true, State = ConnectorState.Ready, LastHealthCheck = DateTime.UtcNow });
+            services.AddKeyedSingleton<IChannelConnector>("my-connector", connector);
+            var provider = services.BuildServiceProvider();
+
+            var descriptors = new[] { new NamedConnectorDescriptor("my-connector", typeof(Fixtures.FakeConnector), new Fixtures.FakeSchema()) };
+            var names = new HashSet<string> { "other-connector" };
+
+            var check = new ConnectorHealthCheck([], descriptors, provider, null, names);
+            var result = await check.CheckHealthAsync(new HealthCheckContext());
+
+            Assert.Equal(HealthStatus.Healthy, result.Status);
+            Assert.Empty(result.Data);
+        }
+
+        [Fact]
+        public async Task Should_CombineTypeAndNameFilters()
+        {
+            var services = new ServiceCollection();
+            var namedConnector = new Fixtures.FakeConnector(() => new ConnectorHealth { IsHealthy = true, State = ConnectorState.Ready, LastHealthCheck = DateTime.UtcNow });
+            services.AddKeyedSingleton<IChannelConnector>("named-one", namedConnector);
+            var provider = services.BuildServiceProvider();
+
+            var unnamedConnector = new Fixtures.FakeConnector(() => new ConnectorHealth { IsHealthy = true, State = ConnectorState.Ready, LastHealthCheck = DateTime.UtcNow });
+            var descriptors = new[] { new NamedConnectorDescriptor("named-one", typeof(Fixtures.FakeConnector), new Fixtures.FakeSchema()) };
+
+            var types = new HashSet<Type> { typeof(Fixtures.FakeConnector) };
+            var names = new HashSet<string> { "named-one" };
+
+            var check = new ConnectorHealthCheck([unnamedConnector], descriptors, provider, types, names);
+            var result = await check.CheckHealthAsync(new HealthCheckContext());
+
+            Assert.Equal(HealthStatus.Healthy, result.Status);
+            Assert.Equal(2, result.Data.Count);
+        }
+    }
+}

--- a/test/Ratatosk.Extensions.HealthChecks.XUnit/Unit/ConnectorHealthCheckTests.cs
+++ b/test/Ratatosk.Extensions.HealthChecks.XUnit/Unit/ConnectorHealthCheckTests.cs
@@ -1,0 +1,222 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Ratatosk.Extensions.HealthChecks.XUnit.Unit
+{
+    public class ConnectorHealthCheckTests
+    {
+        [Fact]
+        public async Task Should_ReturnHealthy_When_AllConnectorsHealthy()
+        {
+            var connectors = new[]
+            {
+                new Fixtures.FakeConnector(() => new ConnectorHealth
+                {
+                    IsHealthy = true,
+                    State = ConnectorState.Ready,
+                    LastHealthCheck = DateTime.UtcNow
+                })
+            };
+
+            var check = new ConnectorHealthCheck(connectors, [], null!);
+            var result = await check.CheckHealthAsync(new HealthCheckContext());
+
+            Assert.Equal(HealthStatus.Healthy, result.Status);
+            Assert.Contains(result.Data, kvp => kvp.Key == "Fake");
+        }
+
+        [Fact]
+        public async Task Should_ReturnDegraded_When_ConnectorHasIssues()
+        {
+            var connectors = new[]
+            {
+                new Fixtures.FakeConnector(() => new ConnectorHealth
+                {
+                    IsHealthy = true,
+                    State = ConnectorState.Ready,
+                    Issues = ["High latency detected"],
+                    LastHealthCheck = DateTime.UtcNow
+                })
+            };
+
+            var check = new ConnectorHealthCheck(connectors, [], null!);
+            var result = await check.CheckHealthAsync(new HealthCheckContext());
+
+            Assert.Equal(HealthStatus.Degraded, result.Status);
+        }
+
+        [Fact]
+        public async Task Should_ReturnUnhealthy_When_ConnectorIsNotHealthy()
+        {
+            var connectors = new[]
+            {
+                new Fixtures.FakeConnector(() => new ConnectorHealth
+                {
+                    IsHealthy = false,
+                    State = ConnectorState.Error,
+                    Issues = ["Connection failed"],
+                    LastHealthCheck = DateTime.UtcNow
+                })
+            };
+
+            var check = new ConnectorHealthCheck(connectors, [], null!);
+            var result = await check.CheckHealthAsync(new HealthCheckContext());
+
+            Assert.Equal(HealthStatus.Unhealthy, result.Status);
+        }
+
+        [Fact]
+        public async Task Should_ReturnUnhealthy_When_GetHealthAsyncFails()
+        {
+            var connectors = new[]
+            {
+                new Fixtures.FakeConnector(() => throw new InvalidOperationException("Unexpected error"))
+            };
+
+            var check = new ConnectorHealthCheck(connectors, [], null!);
+            var result = await check.CheckHealthAsync(new HealthCheckContext());
+
+            Assert.Equal(HealthStatus.Unhealthy, result.Status);
+        }
+
+        [Fact]
+        public async Task Should_ReturnUnhealthy_When_OperationResultIsFailure()
+        {
+            var connectors = new[]
+            {
+                new Fixtures.FakeFailingConnector("FailingConnector")
+            };
+
+            var check = new ConnectorHealthCheck(connectors, [], null!);
+            var result = await check.CheckHealthAsync(new HealthCheckContext());
+
+            Assert.Equal(HealthStatus.Unhealthy, result.Status);
+        }
+
+        [Fact]
+        public async Task Should_IncludeMetrics_When_ConnectorProvidesMetrics()
+        {
+            var connectors = new[]
+            {
+                new Fixtures.FakeConnector(() => new ConnectorHealth
+                {
+                    IsHealthy = true,
+                    State = ConnectorState.Ready,
+                    Metrics = new Dictionary<string, object>
+                    {
+                        ["ProjectId"] = "test-project",
+                        ["IsInitialized"] = true
+                    },
+                    LastHealthCheck = DateTime.UtcNow
+                })
+            };
+
+            var check = new ConnectorHealthCheck(connectors, [], null!);
+            var result = await check.CheckHealthAsync(new HealthCheckContext());
+
+            Assert.Equal(HealthStatus.Healthy, result.Status);
+            var data = Assert.IsType<Dictionary<string, object>>(result.Data["Fake"]);
+            var metrics = Assert.IsType<Dictionary<string, object>>(data["metrics"]);
+            Assert.Equal("test-project", metrics["ProjectId"]);
+        }
+
+        [Fact]
+        public async Task Should_ReportWorstStatus_When_MultipleConnectors()
+        {
+            var connectors = new[]
+            {
+                new Fixtures.FakeConnector(() => new ConnectorHealth
+                {
+                    IsHealthy = true,
+                    State = ConnectorState.Ready,
+                    LastHealthCheck = DateTime.UtcNow
+                }),
+                new Fixtures.FakeConnector(() => new ConnectorHealth
+                {
+                    IsHealthy = false,
+                    State = ConnectorState.Error,
+                    Issues = ["Down"],
+                    LastHealthCheck = DateTime.UtcNow
+                })
+            };
+
+            var check = new ConnectorHealthCheck(connectors, [], null!);
+            var result = await check.CheckHealthAsync(new HealthCheckContext());
+
+            Assert.Equal(HealthStatus.Unhealthy, result.Status);
+        }
+
+        [Fact]
+        public async Task Should_ReportDegraded_When_MixedHealthyAndDegraded()
+        {
+            var connectors = new[]
+            {
+                new Fixtures.FakeConnector(() => new ConnectorHealth
+                {
+                    IsHealthy = true,
+                    State = ConnectorState.Ready,
+                    LastHealthCheck = DateTime.UtcNow
+                }),
+                new Fixtures.FakeConnector(() => new ConnectorHealth
+                {
+                    IsHealthy = true,
+                    State = ConnectorState.Ready,
+                    Issues = ["Slow response"],
+                    LastHealthCheck = DateTime.UtcNow
+                })
+            };
+
+            var check = new ConnectorHealthCheck(connectors, [], null!);
+            var result = await check.CheckHealthAsync(new HealthCheckContext());
+
+            Assert.Equal(HealthStatus.Degraded, result.Status);
+        }
+
+        [Fact]
+        public async Task Should_HandleEmptyConnectors()
+        {
+            var check = new ConnectorHealthCheck([], [], null!);
+            var result = await check.CheckHealthAsync(new HealthCheckContext());
+
+            Assert.Equal(HealthStatus.Healthy, result.Status);
+        }
+
+        [Fact]
+        public void MapHealthStatus_ShouldReturnHealthy_WhenIsHealthyAndNoIssues()
+        {
+            var health = new ConnectorHealth
+            {
+                IsHealthy = true,
+                Issues = []
+            };
+
+            var status = ConnectorHealthCheck.MapHealthStatus(health);
+            Assert.Equal(HealthStatus.Healthy, status);
+        }
+
+        [Fact]
+        public void MapHealthStatus_ShouldReturnDegraded_WhenIsHealthyButHasIssues()
+        {
+            var health = new ConnectorHealth
+            {
+                IsHealthy = true,
+                Issues = ["Warning"]
+            };
+
+            var status = ConnectorHealthCheck.MapHealthStatus(health);
+            Assert.Equal(HealthStatus.Degraded, status);
+        }
+
+        [Fact]
+        public void MapHealthStatus_ShouldReturnUnhealthy_WhenNotHealthy()
+        {
+            var health = new ConnectorHealth
+            {
+                IsHealthy = false,
+                Issues = []
+            };
+
+            var status = ConnectorHealthCheck.MapHealthStatus(health);
+            Assert.Equal(HealthStatus.Unhealthy, status);
+        }
+    }
+}

--- a/test/Ratatosk.Extensions.HealthChecks.XUnit/Unit/ConnectorHealthCheckTests.cs
+++ b/test/Ratatosk.Extensions.HealthChecks.XUnit/Unit/ConnectorHealthCheckTests.cs
@@ -1,9 +1,11 @@
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 namespace Ratatosk.Extensions.HealthChecks.XUnit.Unit
 {
     public class ConnectorHealthCheckTests
     {
+        private static readonly IServiceProvider EmptyServiceProvider = new ServiceCollection().BuildServiceProvider();
         [Fact]
         public async Task Should_ReturnHealthy_When_AllConnectorsHealthy()
         {
@@ -17,7 +19,7 @@ namespace Ratatosk.Extensions.HealthChecks.XUnit.Unit
                 })
             };
 
-            var check = new ConnectorHealthCheck(connectors, [], null!);
+            var check = new ConnectorHealthCheck(connectors, [], EmptyServiceProvider);
             var result = await check.CheckHealthAsync(new HealthCheckContext());
 
             Assert.Equal(HealthStatus.Healthy, result.Status);
@@ -38,7 +40,7 @@ namespace Ratatosk.Extensions.HealthChecks.XUnit.Unit
                 })
             };
 
-            var check = new ConnectorHealthCheck(connectors, [], null!);
+            var check = new ConnectorHealthCheck(connectors, [], EmptyServiceProvider);
             var result = await check.CheckHealthAsync(new HealthCheckContext());
 
             Assert.Equal(HealthStatus.Degraded, result.Status);
@@ -58,7 +60,7 @@ namespace Ratatosk.Extensions.HealthChecks.XUnit.Unit
                 })
             };
 
-            var check = new ConnectorHealthCheck(connectors, [], null!);
+            var check = new ConnectorHealthCheck(connectors, [], EmptyServiceProvider);
             var result = await check.CheckHealthAsync(new HealthCheckContext());
 
             Assert.Equal(HealthStatus.Unhealthy, result.Status);
@@ -72,7 +74,7 @@ namespace Ratatosk.Extensions.HealthChecks.XUnit.Unit
                 new Fixtures.FakeConnector(() => throw new InvalidOperationException("Unexpected error"))
             };
 
-            var check = new ConnectorHealthCheck(connectors, [], null!);
+            var check = new ConnectorHealthCheck(connectors, [], EmptyServiceProvider);
             var result = await check.CheckHealthAsync(new HealthCheckContext());
 
             Assert.Equal(HealthStatus.Unhealthy, result.Status);
@@ -86,7 +88,7 @@ namespace Ratatosk.Extensions.HealthChecks.XUnit.Unit
                 new Fixtures.FakeFailingConnector("FailingConnector")
             };
 
-            var check = new ConnectorHealthCheck(connectors, [], null!);
+            var check = new ConnectorHealthCheck(connectors, [], EmptyServiceProvider);
             var result = await check.CheckHealthAsync(new HealthCheckContext());
 
             Assert.Equal(HealthStatus.Unhealthy, result.Status);
@@ -110,7 +112,7 @@ namespace Ratatosk.Extensions.HealthChecks.XUnit.Unit
                 })
             };
 
-            var check = new ConnectorHealthCheck(connectors, [], null!);
+            var check = new ConnectorHealthCheck(connectors, [], EmptyServiceProvider);
             var result = await check.CheckHealthAsync(new HealthCheckContext());
 
             Assert.Equal(HealthStatus.Healthy, result.Status);
@@ -139,7 +141,7 @@ namespace Ratatosk.Extensions.HealthChecks.XUnit.Unit
                 })
             };
 
-            var check = new ConnectorHealthCheck(connectors, [], null!);
+            var check = new ConnectorHealthCheck(connectors, [], EmptyServiceProvider);
             var result = await check.CheckHealthAsync(new HealthCheckContext());
 
             Assert.Equal(HealthStatus.Unhealthy, result.Status);
@@ -165,7 +167,7 @@ namespace Ratatosk.Extensions.HealthChecks.XUnit.Unit
                 })
             };
 
-            var check = new ConnectorHealthCheck(connectors, [], null!);
+            var check = new ConnectorHealthCheck(connectors, [], EmptyServiceProvider);
             var result = await check.CheckHealthAsync(new HealthCheckContext());
 
             Assert.Equal(HealthStatus.Degraded, result.Status);
@@ -174,7 +176,7 @@ namespace Ratatosk.Extensions.HealthChecks.XUnit.Unit
         [Fact]
         public async Task Should_HandleEmptyConnectors()
         {
-            var check = new ConnectorHealthCheck([], [], null!);
+            var check = new ConnectorHealthCheck([], [], EmptyServiceProvider);
             var result = await check.CheckHealthAsync(new HealthCheckContext());
 
             Assert.Equal(HealthStatus.Healthy, result.Status);

--- a/test/Ratatosk.Extensions.HealthChecks.XUnit/Unit/HealthChecksBuilderExtensionsTests.cs
+++ b/test/Ratatosk.Extensions.HealthChecks.XUnit/Unit/HealthChecksBuilderExtensionsTests.cs
@@ -6,7 +6,7 @@ namespace Ratatosk.Extensions.HealthChecks.XUnit.Unit
     public class HealthChecksBuilderExtensionsTests
     {
         [Fact]
-        public void Should_RegisterConnectorHealthCheck()
+        public void Should_RegisterAllConnectors_DefaultName()
         {
             var services = new ServiceCollection();
             var healthBuilder = services.AddHealthChecks();
@@ -20,11 +20,127 @@ namespace Ratatosk.Extensions.HealthChecks.XUnit.Unit
         }
 
         [Fact]
+        public void Should_RegisterAllConnectors_CustomName()
+        {
+            var services = new ServiceCollection();
+            var healthBuilder = services.AddHealthChecks();
+
+            healthBuilder.AddRatatoskHealthChecks("messaging");
+
+            var provider = services.BuildServiceProvider();
+            var check = provider.GetService<ConnectorHealthCheck>();
+
+            Assert.NotNull(check);
+        }
+
+        [Fact]
+        public void Should_RegisterSingleType()
+        {
+            var services = new ServiceCollection();
+            var healthBuilder = services.AddHealthChecks();
+
+            healthBuilder.AddRatatoskHealthChecks<Fixtures.FakeConnector>("fake");
+
+            var provider = services.BuildServiceProvider();
+            var check = provider.GetService<ConnectorHealthCheck>();
+
+            Assert.NotNull(check);
+        }
+
+        [Fact]
+        public void Should_RegisterSingleName()
+        {
+            var services = new ServiceCollection();
+            var healthBuilder = services.AddHealthChecks();
+
+            healthBuilder.AddRatatoskHealthChecks("sms", "twilio-sms");
+
+            var provider = services.BuildServiceProvider();
+            var check = provider.GetService<ConnectorHealthCheck>();
+
+            Assert.NotNull(check);
+        }
+
+        [Fact]
+        public void Should_RegisterWithFluentBuilder_AllConnectors()
+        {
+            var services = new ServiceCollection();
+            var healthBuilder = services.AddHealthChecks();
+
+            healthBuilder.AddRatatoskHealthChecks("all", h => h.ForAllConnectors());
+
+            var provider = services.BuildServiceProvider();
+            var check = provider.GetService<ConnectorHealthCheck>();
+
+            Assert.NotNull(check);
+        }
+
+        [Fact]
+        public void Should_RegisterWithFluentBuilder_ByType()
+        {
+            var services = new ServiceCollection();
+            var healthBuilder = services.AddHealthChecks();
+
+            healthBuilder.AddRatatoskHealthChecks("fake", h => h.ForConnectorType<Fixtures.FakeConnector>());
+
+            var provider = services.BuildServiceProvider();
+            var check = provider.GetService<ConnectorHealthCheck>();
+
+            Assert.NotNull(check);
+        }
+
+        [Fact]
+        public void Should_RegisterWithFluentBuilder_ByName()
+        {
+            var services = new ServiceCollection();
+            var healthBuilder = services.AddHealthChecks();
+
+            healthBuilder.AddRatatoskHealthChecks("sms", h => h.ForConnector("twilio-sms"));
+
+            var provider = services.BuildServiceProvider();
+            var check = provider.GetService<ConnectorHealthCheck>();
+
+            Assert.NotNull(check);
+        }
+
+        [Fact]
+        public void Should_RegisterWithFluentBuilder_MultipleNames()
+        {
+            var services = new ServiceCollection();
+            var healthBuilder = services.AddHealthChecks();
+
+            healthBuilder.AddRatatoskHealthChecks("sms", h => h
+                .ForConnector("twilio-sms")
+                .ForConnector("twilio-whatsapp"));
+
+            var provider = services.BuildServiceProvider();
+            var check = provider.GetService<ConnectorHealthCheck>();
+
+            Assert.NotNull(check);
+        }
+
+        [Fact]
         public void Should_Throw_When_BuilderIsNull()
         {
             IHealthChecksBuilder? builder = null;
 
             Assert.Throws<ArgumentNullException>(() => builder!.AddRatatoskHealthChecks());
+        }
+
+        [Fact]
+        public void Should_Throw_When_ConfigureIsNull()
+        {
+            var builder = new ServiceCollection().AddHealthChecks();
+
+            Assert.Throws<ArgumentNullException>(() => builder.AddRatatoskHealthChecks("test", (Action<RatatoskHealthCheckBuilder>)null!));
+        }
+
+        [Fact]
+        public void Should_Throw_When_ConnectorNameIsEmpty()
+        {
+            var builder = new ServiceCollection().AddHealthChecks();
+
+            Assert.Throws<ArgumentException>(() => builder.AddRatatoskHealthChecks("test", ""));
         }
 
         [Fact]

--- a/test/Ratatosk.Extensions.HealthChecks.XUnit/Unit/HealthChecksBuilderExtensionsTests.cs
+++ b/test/Ratatosk.Extensions.HealthChecks.XUnit/Unit/HealthChecksBuilderExtensionsTests.cs
@@ -1,0 +1,56 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Ratatosk.Extensions.HealthChecks.XUnit.Unit
+{
+    public class HealthChecksBuilderExtensionsTests
+    {
+        [Fact]
+        public void Should_RegisterConnectorHealthCheck()
+        {
+            var services = new ServiceCollection();
+            var healthBuilder = services.AddHealthChecks();
+
+            healthBuilder.AddRatatoskHealthChecks();
+
+            var provider = services.BuildServiceProvider();
+            var check = provider.GetService<ConnectorHealthCheck>();
+
+            Assert.NotNull(check);
+        }
+
+        [Fact]
+        public void Should_Throw_When_BuilderIsNull()
+        {
+            IHealthChecksBuilder? builder = null;
+
+            Assert.Throws<ArgumentNullException>(() => builder!.AddRatatoskHealthChecks());
+        }
+
+        [Fact]
+        public async Task Should_ProbeRegisteredConnectors()
+        {
+            var services = new ServiceCollection();
+
+            var connector = new Fixtures.FakeConnector(() => new ConnectorHealth
+            {
+                IsHealthy = true,
+                State = ConnectorState.Ready,
+                LastHealthCheck = DateTime.UtcNow
+            });
+
+            services.AddSingleton<IChannelConnector>(connector);
+            services.AddSingleton(connector);
+
+            var healthBuilder = services.AddHealthChecks();
+            healthBuilder.AddRatatoskHealthChecks();
+
+            var provider = services.BuildServiceProvider();
+            var check = provider.GetRequiredService<ConnectorHealthCheck>();
+
+            var result = await check.CheckHealthAsync(new HealthCheckContext());
+
+            Assert.Equal(HealthStatus.Healthy, result.Status);
+        }
+    }
+}

--- a/test/Ratatosk.Extensions.OpenTelemetry.XUnit/Unit/OpenTelemetryBuilderExtensionsTests.cs
+++ b/test/Ratatosk.Extensions.OpenTelemetry.XUnit/Unit/OpenTelemetryBuilderExtensionsTests.cs
@@ -63,7 +63,8 @@ public class OpenTelemetryBuilderExtensionsTests
 
         meterProvider.ForceFlush();
 
-        Assert.Contains(exporter.Exported, m => m.MeterName == "Ratatosk.Client");
+        var exported = exporter.GetExported();
+        Assert.Contains(exported, m => m.MeterName == "Ratatosk.Client");
     }
 
     [Fact]
@@ -82,7 +83,8 @@ public class OpenTelemetryBuilderExtensionsTests
 
         meterProvider.ForceFlush();
 
-        Assert.Contains(exporter.Exported, m => m.MeterName == "Ratatosk.Connector.SendGridEmail");
+        var exported = exporter.GetExported();
+        Assert.Contains(exported, m => m.MeterName == "Ratatosk.Connector.SendGridEmail");
     }
 
     [Fact]
@@ -155,12 +157,22 @@ public class OpenTelemetryBuilderExtensionsTests
 
     private sealed class TestMetricExporter : BaseExporter<Metric>
     {
-        public List<Metric> Exported { get; } = new();
+        private readonly object _lock = new();
+        private readonly List<Metric> _exported = new();
+
+        public List<Metric> GetExported()
+        {
+            lock (_lock)
+                return _exported.ToList();
+        }
 
         public override ExportResult Export(in Batch<Metric> batch)
         {
-            foreach (var metric in batch)
-                Exported.Add(metric);
+            lock (_lock)
+            {
+                foreach (var metric in batch)
+                    _exported.Add(metric);
+            }
             return ExportResult.Success;
         }
     }

--- a/test/Ratatosk.Sendgrid.XUnit/Unit/SendGridEmailConnectorJsonEdgeCaseTests.cs
+++ b/test/Ratatosk.Sendgrid.XUnit/Unit/SendGridEmailConnectorJsonEdgeCaseTests.cs
@@ -211,8 +211,8 @@ public class SendGridEmailConnectorJsonEdgeCaseTests
         Assert.True(result.IsSuccess());
         Assert.NotNull(result.Value);
         Assert.Equal("invalid_timestamp_123", result.Value.MessageId);
-        // Timestamp should be recent (within last minute)
-        Assert.True(result.Value.Timestamp >= DateTime.UtcNow.AddMinutes(-1));
+        // Timestamp should be recent (within last 5 minutes)
+        Assert.True(result.Value.Timestamp >= DateTime.UtcNow.AddMinutes(-5));
         Assert.True(result.Value.Timestamp <= DateTime.UtcNow);
     }
 

--- a/test/Ratatosk.Twilio.XUnit/Unit/TwilioMessageReceivingTests.cs
+++ b/test/Ratatosk.Twilio.XUnit/Unit/TwilioMessageReceivingTests.cs
@@ -202,7 +202,7 @@ public class TwilioMessageReceivingTests
         Assert.Equal("SM1234567890", statusResult.MessageId);
         Assert.Equal(MessageStatus.Delivered, statusResult.Status);
         Assert.True(statusResult.Timestamp <= DateTimeOffset.UtcNow);
-        Assert.True(statusResult.Timestamp >= DateTimeOffset.UtcNow.AddMinutes(-1)); // Recent timestamp
+        Assert.True(statusResult.Timestamp >= DateTimeOffset.UtcNow.AddMinutes(-5)); // Recent timestamp
 
         // Check additional Twilio status data
         Assert.NotNull(statusResult.AdditionalData);
@@ -245,7 +245,7 @@ public class TwilioMessageReceivingTests
         Assert.Equal("SM1234567890", statusResult.MessageId);
         Assert.Equal(MessageStatus.DeliveryFailed, statusResult.Status);
         Assert.True(statusResult.Timestamp <= DateTimeOffset.UtcNow);
-        Assert.True(statusResult.Timestamp >= DateTimeOffset.UtcNow.AddMinutes(-1)); // Recent timestamp
+        Assert.True(statusResult.Timestamp >= DateTimeOffset.UtcNow.AddMinutes(-5)); // Recent timestamp
 
         // Check error information
         Assert.NotNull(statusResult.AdditionalData);
@@ -340,7 +340,7 @@ public class TwilioMessageReceivingTests
         Assert.Equal("SM1234567890", statusResult.MessageId);
         Assert.Equal(expectedStatus, statusResult.Status);
         Assert.True(statusResult.Timestamp <= DateTimeOffset.UtcNow);
-        Assert.True(statusResult.Timestamp >= DateTimeOffset.UtcNow.AddMinutes(-1)); // Recent timestamp
+        Assert.True(statusResult.Timestamp >= DateTimeOffset.UtcNow.AddMinutes(-5)); // Recent timestamp
 
         // Verify that additional data is properly initialized even if empty
         Assert.NotNull(statusResult.AdditionalData);

--- a/test/Ratatosk.XUnit/Unit/MessagingClientContextEnrichmentTests.cs
+++ b/test/Ratatosk.XUnit/Unit/MessagingClientContextEnrichmentTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Ratatosk.XUnit.Fixtures;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 
 namespace Ratatosk.XUnit.Unit;
@@ -134,7 +135,7 @@ public class MessagingClientContextEnrichmentTests
     [Fact]
     public async Task Should_AddContextTags_ToSendActivity()
     {
-        var recorded = new List<Activity>();
+        var recorded = new ConcurrentBag<Activity>();
 
         using var listener = new ActivityListener
         {
@@ -153,7 +154,7 @@ public class MessagingClientContextEnrichmentTests
 
         await client.SendAsync(request);
 
-        var activity = recorded.FirstOrDefault(a => a.OperationName == "mock send");
+        var activity = WaitForActivity(recorded, "mock send");
         Assert.NotNull(activity);
         Assert.Equal("ratatosk", activity.GetTagItem("messaging.system"));
         Assert.Equal("send", activity.GetTagItem("messaging.operation"));
@@ -164,7 +165,7 @@ public class MessagingClientContextEnrichmentTests
     [Fact]
     public async Task Should_AddContextTags_ToReceiveActivity()
     {
-        var recorded = new List<Activity>();
+        var recorded = new ConcurrentBag<Activity>();
 
         using var listener = new ActivityListener
         {
@@ -183,7 +184,7 @@ public class MessagingClientContextEnrichmentTests
 
         await client.ReceiveAsync(request);
 
-        var activity = recorded.FirstOrDefault(a => a.OperationName == "mock receive");
+        var activity = WaitForActivity(recorded, "mock receive");
         Assert.NotNull(activity);
         Assert.Equal("t-2", activity.GetTagItem("tenant_id"));
     }
@@ -191,7 +192,7 @@ public class MessagingClientContextEnrichmentTests
     [Fact]
     public async Task Should_AddContextTags_ToStatusActivity()
     {
-        var recorded = new List<Activity>();
+        var recorded = new ConcurrentBag<Activity>();
 
         using var listener = new ActivityListener
         {
@@ -209,7 +210,7 @@ public class MessagingClientContextEnrichmentTests
 
         await client.GetStatusAsync(request);
 
-        var activity = recorded.FirstOrDefault(a => a.OperationName == "mock status_query");
+        var activity = WaitForActivity(recorded, "mock status_query");
         Assert.NotNull(activity);
         Assert.Equal("t-3", activity.GetTagItem("tenant_id"));
     }
@@ -217,7 +218,7 @@ public class MessagingClientContextEnrichmentTests
     [Fact]
     public async Task Should_AddContextTags_ToReceiveStatusActivity()
     {
-        var recorded = new List<Activity>();
+        var recorded = new ConcurrentBag<Activity>();
 
         using var listener = new ActivityListener
         {
@@ -236,7 +237,7 @@ public class MessagingClientContextEnrichmentTests
 
         await client.ReceiveMessageStatusAsync(request);
 
-        var activity = recorded.FirstOrDefault(a => a.OperationName == "mock receive_status");
+        var activity = WaitForActivity(recorded, "mock receive_status");
         Assert.NotNull(activity);
         Assert.Equal("t-4", activity.GetTagItem("tenant_id"));
     }
@@ -265,7 +266,7 @@ public class MessagingClientContextEnrichmentTests
     [Fact]
     public async Task SendActivity_ShouldBeChildOfCurrentActivity()
     {
-        var recorded = new List<Activity>();
+        var recorded = new ConcurrentBag<Activity>();
 
         using var clientListener = new ActivityListener
         {
@@ -287,7 +288,7 @@ public class MessagingClientContextEnrichmentTests
         var request = new SendRequest("mock", message);
         await client.SendAsync(request);
 
-        var childActivity = recorded.FirstOrDefault(a => a.OperationName == "mock send");
+        var childActivity = WaitForActivity(recorded, "mock send");
         Assert.NotNull(childActivity);
 
         // The send span should be a child of the parent activity
@@ -298,7 +299,7 @@ public class MessagingClientContextEnrichmentTests
     [Fact]
     public async Task SendActivity_ShouldBeRoot_WhenNoCurrentActivity()
     {
-        var recorded = new List<Activity>();
+        var recorded = new ConcurrentBag<Activity>();
 
         using var listener = new ActivityListener
         {
@@ -318,7 +319,7 @@ public class MessagingClientContextEnrichmentTests
         var request = new SendRequest("mock", message);
         await client.SendAsync(request);
 
-        var activity = recorded.FirstOrDefault(a => a.OperationName == "mock send");
+        var activity = WaitForActivity(recorded, "mock send");
         Assert.NotNull(activity);
         // When there's no parent Activity instance, Parent is null
         Assert.Null(activity.Parent);
@@ -518,5 +519,18 @@ public class MessagingClientContextEnrichmentTests
         Assert.NotNull(request.ConnectionSettings);
         Assert.Equal(typeof(MockConnector), request.ConnectorType);
         Assert.Equal("v", request.Context!["k"]);
+    }
+
+    private static Activity? WaitForActivity(ConcurrentBag<Activity> recorded, string operationName)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(5);
+        while (DateTime.UtcNow < deadline)
+        {
+            var activity = recorded.FirstOrDefault(a => a.OperationName == operationName);
+            if (activity != null)
+                return activity;
+            Thread.SpinWait(10);
+        }
+        return recorded.FirstOrDefault(a => a.OperationName == operationName);
     }
 }

--- a/test/Ratatosk.XUnit/Unit/MessagingClientContextEnrichmentTests.cs
+++ b/test/Ratatosk.XUnit/Unit/MessagingClientContextEnrichmentTests.cs
@@ -523,10 +523,10 @@ public class MessagingClientContextEnrichmentTests
 
     private static Activity WaitForActivity(BlockingCollection<Activity> recorded, string operationName)
     {
-        var deadline = DateTime.UtcNow.AddSeconds(5);
+        var deadline = DateTime.UtcNow.AddSeconds(15);
         while (DateTime.UtcNow < deadline)
         {
-            if (recorded.TryTake(out var activity, 10) && activity.OperationName == operationName)
+            if (recorded.TryTake(out var activity, 100) && activity.OperationName == operationName)
                 return activity;
         }
         throw new InvalidOperationException($"Activity '{operationName}' was not recorded within the timeout.");

--- a/test/Ratatosk.XUnit/Unit/MessagingClientContextEnrichmentTests.cs
+++ b/test/Ratatosk.XUnit/Unit/MessagingClientContextEnrichmentTests.cs
@@ -135,7 +135,7 @@ public class MessagingClientContextEnrichmentTests
     [Fact]
     public async Task Should_AddContextTags_ToSendActivity()
     {
-        var recorded = new ConcurrentBag<Activity>();
+        var recorded = new BlockingCollection<Activity>();
 
         using var listener = new ActivityListener
         {
@@ -165,7 +165,7 @@ public class MessagingClientContextEnrichmentTests
     [Fact]
     public async Task Should_AddContextTags_ToReceiveActivity()
     {
-        var recorded = new ConcurrentBag<Activity>();
+        var recorded = new BlockingCollection<Activity>();
 
         using var listener = new ActivityListener
         {
@@ -192,7 +192,7 @@ public class MessagingClientContextEnrichmentTests
     [Fact]
     public async Task Should_AddContextTags_ToStatusActivity()
     {
-        var recorded = new ConcurrentBag<Activity>();
+        var recorded = new BlockingCollection<Activity>();
 
         using var listener = new ActivityListener
         {
@@ -218,7 +218,7 @@ public class MessagingClientContextEnrichmentTests
     [Fact]
     public async Task Should_AddContextTags_ToReceiveStatusActivity()
     {
-        var recorded = new ConcurrentBag<Activity>();
+        var recorded = new BlockingCollection<Activity>();
 
         using var listener = new ActivityListener
         {
@@ -266,7 +266,7 @@ public class MessagingClientContextEnrichmentTests
     [Fact]
     public async Task SendActivity_ShouldBeChildOfCurrentActivity()
     {
-        var recorded = new ConcurrentBag<Activity>();
+        var recorded = new BlockingCollection<Activity>();
 
         using var clientListener = new ActivityListener
         {
@@ -299,7 +299,7 @@ public class MessagingClientContextEnrichmentTests
     [Fact]
     public async Task SendActivity_ShouldBeRoot_WhenNoCurrentActivity()
     {
-        var recorded = new ConcurrentBag<Activity>();
+        var recorded = new BlockingCollection<Activity>();
 
         using var listener = new ActivityListener
         {
@@ -521,16 +521,14 @@ public class MessagingClientContextEnrichmentTests
         Assert.Equal("v", request.Context!["k"]);
     }
 
-    private static Activity? WaitForActivity(ConcurrentBag<Activity> recorded, string operationName)
+    private static Activity WaitForActivity(BlockingCollection<Activity> recorded, string operationName)
     {
         var deadline = DateTime.UtcNow.AddSeconds(5);
         while (DateTime.UtcNow < deadline)
         {
-            var activity = recorded.FirstOrDefault(a => a.OperationName == operationName);
-            if (activity != null)
+            if (recorded.TryTake(out var activity, 10) && activity.OperationName == operationName)
                 return activity;
-            Thread.SpinWait(10);
         }
-        return recorded.FirstOrDefault(a => a.OperationName == operationName);
+        throw new InvalidOperationException($"Activity '{operationName}' was not recorded within the timeout.");
     }
 }

--- a/website/versioned_docs/version-1.1.3/connectors-configuration/health-checks.md
+++ b/website/versioned_docs/version-1.1.3/connectors-configuration/health-checks.md
@@ -68,6 +68,28 @@ app.Run();
 
 The health check result includes per-connector detail in the `Data` dictionary, keyed by connector type name (with the `Connector` suffix removed) or the named connector's registration name:
 
+> **Note:** By default, ASP.NET Core's `MapHealthChecks` middleware does not serialize `HealthCheckResult.Data` in the HTTP response. To expose per-connector details over HTTP, provide a custom `ResponseWriter`:
+>
+> ```csharp
+> app.MapHealthChecks("/health/detail", new HealthCheckOptions
+> {
+>     ResponseWriter = async (context, report) =>
+>     {
+>         var json = JsonSerializer.Serialize(new
+>         {
+>             status = report.Status.ToString(),
+>             results = report.Entries.ToDictionary(
+>                 e => e.Key,
+>                 e => e.Value.Data)
+>         });
+>         context.Response.ContentType = "application/json";
+>         await context.Response.WriteAsync(json);
+>     }
+> });
+> ```
+
+The per-connector data has this shape:
+
 ```json
 {
   "status": "Degraded",

--- a/website/versioned_docs/version-1.1.3/connectors-configuration/health-checks.md
+++ b/website/versioned_docs/version-1.1.3/connectors-configuration/health-checks.md
@@ -27,66 +27,79 @@ if (health.IsSuccess())
 
 ## ASP.NET Core Health Check Integration
 
-Register connector health checks with ASP.NET Core health monitoring:
+The `Ratatosk.Extensions.HealthChecks` package provides a `ConnectorHealthCheck` that automatically discovers all registered connectors and probes them through the standard ASP.NET Core health check pipeline.
 
-### Basic Registration
+### Installation
 
-```csharp
-builder.Services
-    .AddHealthChecks()
-    .AddCheck<MessagingHealthCheck>("messaging", tags: ["ready"]);
-```
+Add the `Ratatosk.Extensions.HealthChecks` NuGet package to your project.
 
-### Implementation
+### Registration
+
+Register the health check after all connectors have been configured:
 
 ```csharp
-public class MessagingHealthCheck : IHealthCheck
-{
-    private readonly IEnumerable<IChannelConnector> _connectors;
+services.AddMessaging()
+    .AddTwilioSms(...)
+    .AddSendGridEmail(...);
 
-    public MessagingHealthCheck(IEnumerable<IChannelConnector> connectors)
-    {
-        _connectors = connectors;
-    }
-
-    public async Task<HealthCheckResult> CheckHealthAsync(
-        HealthCheckContext context, CancellationToken ct)
-    {
-        var healthy = true;
-        var data = new Dictionary<string, object>();
-
-        foreach (var connector in _connectors)
-        {
-            var health = await connector.GetHealthAsync(ct);
-            var connectorName = $"{connector.Schema.ChannelProvider}/{connector.Schema.ChannelType}";
-            
-            data[$"{connectorName}_healthy"] = health.Value?.IsHealthy;
-            data[$"{connectorName}_state"] = health.Value?.State.ToString();
-            healthy &= health.Value?.IsHealthy ?? false;
-        }
-
-        return healthy
-            ? HealthCheckResult.Healthy(data: data)
-            : HealthCheckResult.Degraded(data: data);
-    }
-}
+services.AddHealthChecks()
+    .AddRatatoskHealthChecks();
 ```
+
+This registers a single health check named `"ratatosk"` with the `"messaging"` tag. At check time it discovers all unnamed and named connectors via DI, probes each through `GetHealthAsync()`, and reports the worst status across all connectors.
 
 ### Health Check Endpoint
 
-Configure health check endpoint in `Program.cs`:
+Configure the health check endpoint in `Program.cs`:
 
 ```csharp
 var app = builder.Build();
 
-app.MapHealthChecks("/health");           // Basic health check
+app.MapHealthChecks("/health");
 app.MapHealthChecks("/health/ready", new HealthCheckOptions
 {
-    Predicate = check => check.Tags.Contains("ready")
+    Predicate = check => check.Tags.Contains("messaging")
 });
 
 app.Run();
 ```
+
+### Per-Connector Detail
+
+The health check result includes per-connector detail in the `Data` dictionary, keyed by connector type name (with the `Connector` suffix removed) or the named connector's registration name:
+
+```json
+{
+  "status": "Degraded",
+  "results": {
+    "TwilioSms": {
+      "status": "Healthy",
+      "state": "Ready",
+      "isHealthy": true,
+      "issues": [],
+      "uptime": "01:23:45",
+      "lastHealthCheck": "2026-06-21T10:00:00Z"
+    },
+    "SendGridEmail": {
+      "status": "Degraded",
+      "state": "Ready",
+      "isHealthy": true,
+      "issues": ["High latency detected"],
+      "uptime": "01:23:45",
+      "lastHealthCheck": "2026-06-21T10:00:00Z"
+    }
+  }
+}
+```
+
+### Health Status Mapping
+
+| `ConnectorHealth` | `HealthStatus` | Overall |
+|---|---|---|
+| `IsHealthy == true`, no `Issues` | `Healthy` | Worst across all connectors |
+| `IsHealthy == true`, has `Issues` | `Degraded` | |
+| `IsHealthy == false` | `Unhealthy` | |
+| Exception or failed `OperationResult` | `Unhealthy` | |
 
 ## Manual Health Verification
 
@@ -95,12 +108,10 @@ Test connector connectivity before sending messages:
 ```csharp
 public async Task<bool> VerifyConnectorAsync(IChannelConnector connector)
 {
-    // Test connection to provider
     var testResult = await connector.TestConnectionAsync(CancellationToken.None);
     if (testResult.IsFailure())
         return false;
 
-    // Check health status
     var health = await connector.GetHealthAsync(CancellationToken.None);
     return health.IsSuccess() && health.Value?.IsHealthy == true;
 }
@@ -148,7 +159,6 @@ protected override async Task<ConnectorHealth> GetConnectorHealthAsync(Cancellat
 
     try
     {
-        // Test actual API connectivity
         var response = await _httpClient.GetAsync("/health", ct);
         response.EnsureSuccessStatusCode();
         
@@ -171,45 +181,12 @@ Connector state affects health status:
 
 | State | IsHealthy | Description |
 |-------|-----------|-------------|
-| `Ready` | ✅ Yes | Operational, can send/receive |
-| `Initializing` | ❌ No | Still initializing |
-| `Uninitialized` | ❌ No | Not yet initialized |
-| `Error` | ❌ No | Error state, needs recovery |
-| `ShuttingDown` | ❌ No | Graceful shutdown in progress |
-| `Shutdown` | ❌ No | Connector is shut down |
-
-## Monitoring and Alerting
-
-### Prometheus Metrics
-
-Export health status as metrics:
-
-```csharp
-// In your monitoring service
-var connectors = serviceProvider.GetServices<IChannelConnector>();
-foreach (var connector in connectors)
-{
-    var health = await connector.GetHealthAsync(ct);
-    var isHealthy = health.Value?.IsHealthy == true ? 1 : 0;
-    
-    Metrics.RecordGauge("connector_health", isHealthy, 
-        new("connector", connector.Schema.ChannelType));
-}
-```
-
-### Application Insights
-
-Track health with telemetry:
-
-```csharp
-telemetryClient.GetMetric("Connector Health")
-    .TrackMetric(health.Value?.IsHealthy == true ? 1.0 : 0.0,
-        new Dictionary<string, string>
-        {
-            ["Connector"] = connector.Schema.ChannelType,
-            ["Provider"] = connector.Schema.ChannelProvider
-        });
-```
+| `Ready` | Yes | Operational, can send/receive |
+| `Initializing` | No | Still initializing |
+| `Uninitialized` | No | Not yet initialized |
+| `Error` | No | Error state, needs recovery |
+| `ShuttingDown` | No | Graceful shutdown in progress |
+| `Shutdown` | No | Connector is shut down |
 
 ## Troubleshooting
 
@@ -223,12 +200,9 @@ telemetryClient.GetMetric("Connector Health")
 
 **Recovery:**
 ```csharp
-// Attempt to reinitialize
 if (!health.IsHealthy)
 {
     await connector.InitializeAsync(ct);
-    
-    // Verify recovery
     health = await connector.GetHealthAsync(ct);
 }
 ```
@@ -247,36 +221,36 @@ if (!health.IsHealthy)
 
 ## Best Practices
 
-### ✅ DO: Implement Health Checks
+### DO: Implement Health Checks
 
 Always implement `GetConnectorHealthAsync()` in custom connectors - it's essential for monitoring.
 
-### ✅ DO: Test Provider Connectivity
+### DO: Test Provider Connectivity
 
 Don't just check internal state - verify you can actually reach the provider API.
 
-### ✅ DO: Include Diagnostic Information
+### DO: Include Diagnostic Information
 
 Provide useful diagnostic data in health check results:
 
 ```csharp
-health.AdditionalData["LastSuccessfulSend"] = _lastSuccessfulSend;
-health.AdditionalData["FailedSendCount"] = _failedSendCount;
+health.Metrics["LastSuccessfulSend"] = _lastSuccessfulSend;
+health.Metrics["FailedSendCount"] = _failedSendCount;
 ```
 
-### ❌ DON'T: Perform Expensive Operations
+### DON'T: Perform Expensive Operations
 
 Health checks should be lightweight and fast:
 
 ```csharp
-// ❌ Bad - sends actual message as health check
+// Bad - sends actual message as health check
 await SendMessageAsync(testMessage, ct);
 
-// ✅ Good - lightweight connectivity test
+// Good - lightweight connectivity test
 await _httpClient.GetAsync("/ping", ct);
 ```
 
-### ❌ DON'T: Cache Health Status
+### DON'T: Cache Health Status
 
 Always perform fresh health checks - cached status may be stale.
 

--- a/website/versioned_docs/version-1.1.3/roadmap.md
+++ b/website/versioned_docs/version-1.1.3/roadmap.md
@@ -17,7 +17,7 @@ Completes the receive-side model for bidirectional messaging.
 ### v1.0.0 — First Stable Release ✓
 Locks the public API and ships stable NuGet packages.
 
-### v1.1.0 — Resilience & Observability
+### v1.1.0 — Resilience & Observability ✓
 Retry/circuit-breaker policies, OpenTelemetry signals, health checks, timeout controls.
 
 ### v1.2.0 — New SaaS Connectors


### PR DESCRIPTION
This pull request introduces first-class health check support for Ratatosk connectors, enabling easy integration with ASP.NET Core's health check system. It adds a new `Ratatosk.Extensions.HealthChecks` package, which provides a unified health check for all registered connectors and exposes detailed per-connector health information through the standard health endpoint. The solution and roadmap documentation are updated accordingly.

**Key changes:**

**Health Check Feature Implementation:**
- Added `ConnectorHealthCheck`, an `IHealthCheck` implementation that probes all registered (unnamed and named) Ratatosk connectors, aggregates their health status, and provides detailed per-connector diagnostics in the health check result.
- Introduced `HealthChecksBuilderExtensions` with an `AddRatatoskHealthChecks` extension method for one-line registration of Ratatosk health checks in ASP.NET Core applications.

**Project and Solution Structure:**
- Added new projects: `Ratatosk.Extensions.HealthChecks` and its test project, and included them in the solution file with appropriate build configurations and solution folder assignments. [[1]](diffhunk://#diff-d6a200ee12a6723e2ff3d1a59ee2845d327baaa2e0ea325b31daf8bab06b8d74R70-R73) [[2]](diffhunk://#diff-d6a200ee12a6723e2ff3d1a59ee2845d327baaa2e0ea325b31daf8bab06b8d74R408-R431) [[3]](diffhunk://#diff-d6a200ee12a6723e2ff3d1a59ee2845d327baaa2e0ea325b31daf8bab06b8d74R464-R465)
- Created the initial project file for `Ratatosk.Extensions.HealthChecks` with dependencies and metadata.

**Documentation and Roadmap Updates:**
- Updated the roadmap to mark health checks as complete for the v1.1.0 "Resilience & Observability" milestone and clarified the implementation details, including usage and benefits. [[1]](diffhunk://#diff-683343bdf93f55ed3cada86151abb8051282e1936e58d4e0a04beca95dff6e51L18-R18) [[2]](diffhunk://#diff-683343bdf93f55ed3cada86151abb8051282e1936e58d4e0a04beca95dff6e51L275-R275) [[3]](diffhunk://#diff-683343bdf93f55ed3cada86151abb8051282e1936e58d4e0a04beca95dff6e51L328-R338)